### PR TITLE
Display services notification badges directly on cards

### DIFF
--- a/app.css
+++ b/app.css
@@ -188,7 +188,7 @@ body {
     color: #4285f4;
     background-color: #4285f4;
     position: absolute;
-    top: 1rem;
+    top: 2.8rem;
     right: -0.2rem;
     width: 3px;
     overflow: hidden;
@@ -214,6 +214,44 @@ body {
   body .card-content {
     height: 85px;
     padding: 1.3rem; }
+  body .notif {
+    color: white;
+    font-size: .9em;
+    font-family: sans-serif;
+    position: absolute;
+    top: 2px;
+    right: 3px;
+}
+  body .info {
+    background-color: #4fb5d6;
+    padding-right: 0.4em;
+    padding-left: 0.4em;
+    padding-top: 0.2em;
+    padding-bottom: 0.3em;
+    border-radius: 0.25em;
+    position: relative;
+    display: none;
+}
+  body .warning {
+    background-color: #d08d2e;
+    padding-right: 0.4em;
+    padding-left: 0.4em;
+    padding-top: 0.2em;
+    padding-bottom: 0.3em;
+    border-radius: 0.25em;
+    position: relative;
+    display: none;
+}
+  body .error {
+    background-color: #e51111;
+    padding-right: 0.4em;
+    padding-left: 0.4em;
+    padding-top: 0.2em;
+    padding-bottom: 0.3em;
+    border-radius: 0.25em;
+    position: relative;
+    display: none;
+}
   body .layout-vertical .card {
     border-radius: 0; }
   body .layout-vertical .column div:first-of-type .card {

--- a/app.js
+++ b/app.js
@@ -42,6 +42,9 @@ const app = new Vue({
             }
         }, false);
     },
+    updated: async function () {
+        setTimeout(this.healthcheck,100);
+    },
     methods: {
         checkOffline: function () {
             let that = this;
@@ -80,6 +83,168 @@ const app = new Vue({
             this.vlayout = !this.vlayout;
             localStorage.vlayout = this.vlayout;
         },
+        healthcheck: function() {
+            
+            async function loop_cards() {
+                //loop cards and check if healthcheck is needed
+                console.log("healthcheck is running");
+                var links = document.getElementsByClassName('card');
+                console.log(links.length);
+                for(var i = 0; i < links.length; i++) {
+                    var thisLink = links[i];
+                    if (thisLink.getElementsByClassName('notif').length > 0) {
+                        var url     = thisLink.getElementsByTagName('a')[0].href;
+                        var name    = thisLink.getElementsByClassName('title')[0].innerHTML;
+                        var type    = thisLink.getElementsByClassName('type')[0].innerHTML;
+                        var rooturl = thisLink.getElementsByClassName('rooturl')[0].innerHTML;
+                        var apikey  = thisLink.getElementsByClassName('apikey')[0].innerHTML;
+                        if (type == 'medusa') {
+                            var val = await medusa_get_health(rooturl, apikey);
+                            //info has grey color in medusa
+                            thisLink.getElementsByClassName('info')[0].style.backgroundColor = "#777777";
+                            show_notif(val, thisLink);
+                        } else if (type == 'radarr') {
+                            var val = await radarr_get_health(rooturl, apikey);
+                            show_notif(val, thisLink);
+                        } else if (type == 'sonarr') {
+                            var val = await radarr_get_health(rooturl, apikey);
+                            show_notif(val, thisLink);
+                        } else {
+                            isSiteOnline(url,function(found){
+                                if(found == false) {
+                                    // site is offline (or favicon not found, or server is too slow)
+                                    show_notif([0, 0, 'offline'], thisLink);
+                                }
+                            })
+                        }
+                    }
+                }
+            }
+
+            async function api_load(api_url, api_key) {
+                var obj;
+                try {
+                    obj = await fetch(api_url, {
+                        headers: { 'X-Api-Key': api_key }
+                    });
+                }
+                catch(err) {
+                    console.log("api error! check url and apikey");
+                    return 1;
+                }
+                if (obj.ok != true) {
+                    return 1
+                } else {
+                    obj = obj.json();
+                    return(obj);
+                }
+            }
+
+            function isSiteOnline(url,callback) {
+                // try to load favicon
+                var timer = setTimeout(function(){
+                    // timeout after 5 seconds
+                    callback(false);
+                },5000)
+
+                var img = document.createElement("img");
+                img.onload = function() {
+                    clearTimeout(timer);
+                    callback(true);
+                }
+
+                img.onerror = function() {
+                    clearTimeout(timer);
+                    callback(false);
+                }
+
+                img.src = url+"/favicon.ico";
+            }
+
+
+            async function medusa_get_health(medusa_rooturl, medusa_apikey) {
+                //fetch medusa health
+
+                var medusa_apiurl = medusa_rooturl.replace(/\/$/, "") + '/api/v2/config';
+
+                config_json = await api_load(medusa_apiurl, medusa_apikey);
+                if (config_json != 1) {
+                    var m_news = config_json.system.news.unread;
+                    var m_warnings = config_json.main.logs.numWarnings;
+                    var m_errors = config_json.main.logs.numErrors;
+                } else {
+                    var m_news = 0;
+                    var m_warnings = 0;
+                    var m_errors = "api error";
+                }
+                return [m_news, m_warnings, m_errors]
+            }
+
+            async function radarr_get_health(radarr_rooturl, radarr_apikey) {
+                //fetch radarr health (maybe can work with sonarr)
+
+                var radarr_apiurl = radarr_rooturl.replace(/\/$/, "") + '/api/health';
+                var radarr_apiurl2 = radarr_rooturl.replace(/\/$/, "") + '/api/queue';
+                
+                health_json = await api_load(radarr_apiurl, radarr_apikey);
+                
+                if (health_json != 1) {
+                    //var nb = api_json.length;
+                    queue_json = await api_load(radarr_apiurl2, radarr_apikey);
+                    var r_activity = queue_json.length;
+                    var r_warnings = 0;
+                    var r_errors = 0;
+                    for (var i = 0; i < health_json.length; i++) {
+                        if (health_json[i].type == 'warning') {
+                            r_warnings++
+                            //api_json[i].message
+                        } else if (health_json[i].type == 'error') {
+                            r_errors++
+                            //api_json[i].message
+                        }
+                    }
+                } else {
+                    var r_activity = 0;
+                    var r_warnings = 0;
+                    var r_errors = "api error";
+                }
+                return [r_activity, r_warnings, r_errors]
+
+            }
+
+            function show_offline(card) {
+                //show offline notif
+                var off_notif = card.getElementsByClassName('error');
+                off_notif.style.display = "block";
+            }
+
+            function show_notif(notif_values, card) {
+                //show info/warning/error notifs
+                //by default are blue/orange/red
+                i = notif_values[0];
+                w = notif_values[1];
+                e = notif_values[2];
+
+                var i_notif = card.getElementsByClassName('info')[0];
+                var w_notif = card.getElementsByClassName('warning')[0];
+                var e_notif = card.getElementsByClassName('error')[0];
+                
+                if (i != 0) {
+                    i_notif.innerHTML = i;
+                    i_notif.style.display = "inline";
+                }
+                if (w != 0) {
+                    w_notif.innerHTML = w;
+                    w_notif.style.display = "inline";
+                }
+                if (e != 0) {  
+                    e_notif.innerHTML = e;
+                    e_notif.style.display = "inline";
+                }
+            }
+            
+            loop_cards();
+        },
     }
 });
 
@@ -107,6 +272,14 @@ Vue.component('service', {
                 </div>
                 <div class="tag" :class="item.tagstyle" v-if="item.tag">
                     <strong class="tag-text">#{{ item.tag }}</strong>
+                </div>
+                <div class="notif" :class="item.healthcheck.type" v-if="item.healthcheck">
+                    <span hidden class="type">{{ item.healthcheck.type }}</span>
+                    <span hidden class="rooturl">{{ item.healthcheck.rooturl }}</span>
+                    <span hidden class="apikey">{{ item.healthcheck.apikey }}</span>
+                    <strong class="notif info">0</strong>
+                    <strong class="notif warning">0</strong>
+                    <strong class="notif error">0</strong>
                 </div>
             </div>
         </a>

--- a/app.scss
+++ b/app.scss
@@ -234,7 +234,7 @@ body {
     color: $secondary-color;
     background-color: $secondary-color;
     position: absolute;
-    top: 1rem;
+    top: 2.8rem;
     right: -0.2rem;
     width: 3px;
     overflow: hidden;
@@ -274,6 +274,48 @@ body {
   .card-content {
     height: 85px;
     padding: 1.3rem;
+  }
+  
+  .notif {
+    color: white;
+    font-size: .9em;
+    font-family: sans-serif;
+    position: absolute;
+    top: 2px;
+    right: 3px;
+  }
+
+  .info {
+    background-color: #4fb5d6;
+    padding-right: 0.4em;
+    padding-left: 0.4em;
+    padding-top: 0.2em;
+    padding-bottom: 0.3em;
+    border-radius: 0.25em;
+    position: relative;
+    display: none;
+  }
+
+  .warning {
+    background-color: #d08d2e;
+    padding-right: 0.4em;
+    padding-left: 0.4em;
+    padding-top: 0.2em;
+    padding-bottom: 0.3em;
+    border-radius: 0.25em;
+    position: relative;
+    display: none;
+  }
+  
+  .error {
+    background-color: #e51111;
+    padding-right: 0.4em;
+    padding-left: 0.4em;
+    padding-top: 0.2em;
+    padding-bottom: 0.3em;
+    border-radius: 0.25em;
+    position: relative;
+    display: none;
   }
 
   .layout-vertical {

--- a/config.yml
+++ b/config.yml
@@ -46,6 +46,16 @@ services:
         # Same styling options as the optional message.
         tagstyle: "is-success"
         url: "https://www.rabbitmq.com/"
+      - name: "Radarr"
+        logo: "assets/tools/radarr.png"
+        subtitle: "Video library manager for movies"
+        url: "http://mydomain.com:7878/calendar"
+        target: '_blank'
+        # Optional healthcheck to fetch service notification badges through its api
+        healthcheck:
+            type: "radarr" # Can be 'radarr', 'sonarr' or 'medusa'
+            rooturl: "http://mydomain.com:7878"
+            apikey: "xxxxx"
   - name: "Monitoring"
     icon: "fas fa-heartbeat"
     items:


### PR DESCRIPTION
Using their API, it can fetch and display notification badges of those services :  radarr, sonarr and medusa.
Maybe more services could be added.

Example:
![image](https://user-images.githubusercontent.com/10365746/74105747-c73f9d00-4b60-11ea-84c3-3acf9054cb2f.png)

