### PR TITLE
Add keyboard shortcuts for searching

### DIFF
--- a/app.js
+++ b/app.js
@@ -85,6 +85,35 @@ const app = new Vue({
         toggleMenu: function() {
             this.showMenu = !this.showMenu;
         }
+    },
+    mounted() {
+        function isSmallScreen() {
+            return window.matchMedia('screen and (max-width: 1023px)').matches;
+        }
+        this._keyListener = function(e) {
+            if (e.key === '/') {
+                if (isSmallScreen()) {
+                    this.showMenu = true;
+                }
+                Vue.nextTick(() => {
+                    this.$refs.search.focus();
+                });
+
+                e.preventDefault();
+            }
+            if (e.key === 'Escape') {
+                this.filter = '';
+                this.$refs.search.blur();
+                if (isSmallScreen()) {
+                    this.showMenu = false;
+                }
+            }
+        }
+
+        document.addEventListener('keydown', this._keyListener.bind(this));
+    },
+    beforeDestroy() {
+        document.removeEventListener('keydown', this._keyListener);
     }
 });
 

--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
                       :class="['fas', vlayout ? 'fa-list' : 'fa-columns']"></i></a>
                   <div class="search-bar">
                     <label for="search" class="search-label"></label>
-                    <input type="text" id="search" v-model="filter" />
+                    <input type="text" id="search" ref="search" v-model="filter" />
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Description

I'm using Homer to manage a large number of bookmarks and I found that it is much more efficient to navigate using the keyboard in this scenario. This pull request implements two shortcuts, `/` and `Escape` to start searching and clear the search, respectively. On smaller sized screens when the breadcrumb menu is visible, it will automatically open the menu.

I haven't updated the README yet as I'd like to solicit some feedback on the approach first as I don't have experience with this stack. I'm happy to make any changes necessary to get this merged.

If this gets merged, I'm also going to send a pull request separately that will add functionality to open the first search result in the current tab (`Enter`) or a new tab (`Alt`/`Option` + `Enter`).

This was also requested in #35.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/master/.github/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [ ] I have made corresponding changes the documentation (README.md).
- [x] I've check my modifications for any breaking change, especially in the `config.yml` file
