### PR TITLE
Add "Style Options" section for bulma CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,3 +127,14 @@ If you choose to fetch message information from an endpoint, the output format s
 
 `null` value or missing keys will be ignored and value from the `config.yml` will be used if available.
 Empty values (either in `config.yml` or the endpoint data) will hide the element (ex: set `"title": ""` to hide the title bar).
+
+### Style Options
+
+Homer uses [bulma CSS](https://bulma.io/), which provides a [modifiers syntax](https://bulma.io/documentation/modifiers/syntax/). You'll notice in the config there is a `tagstyle` option. It can be set to any of the bulma modifiers. You'll probably want to use one of these 4 main colors:
+
+- `is-info` (blue)
+- `is-success` (green)
+- `is-warning` (yellow)
+- `is-danger` (red)
+
+You can read the [bulma modifiers page](https://bulma.io/documentation/modifiers/syntax/) for other options regarding size, style, or state.


### PR DESCRIPTION
## Description

This project uses bulma CSS, but this fact is not obvious without reading the code. This commit adds explicit pointers on how to use the `tagstyle` field.

## Type of change

- [X] New feature (non-breaking change which adds functionality): extending documentation

## Checklist:

- [X] I read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/master/CONTRIBUTING.md)
- [X] I have tested my code: Yes, see markdown preview.
- [X] I have made corresponding changes the documentation (README.md).
- [X] I've check my modifications for any breaking change: I have tested this in the config file.
