### PR TITLE
Build multi-arch container with manifest

### DIFF
--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -1,0 +1,15 @@
+FROM arm32v7/alpine:3.11
+
+COPY ./ /www/
+
+ENV USER darkhttpd
+ENV GROUP darkhttpd
+ENV GID 911
+ENV UID 911
+
+RUN addgroup -S ${GROUP} -g ${GID} && adduser -D -S -u ${UID} ${USER} ${GROUP} && \
+    apk add -U darkhttpd
+
+USER darkhttpd
+
+ENTRYPOINT ["darkhttpd","/www/"]

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -1,0 +1,15 @@
+FROM arm64v8/alpine:3.11
+
+COPY ./ /www/
+
+ENV USER darkhttpd
+ENV GROUP darkhttpd
+ENV GID 911
+ENV UID 911
+
+RUN addgroup -S ${GROUP} -g ${GID} && adduser -D -S -u ${UID} ${USER} ${GROUP} && \
+    apk add -U darkhttpd
+
+USER darkhttpd
+
+ENTRYPOINT ["darkhttpd","/www/"]

--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+docker manifest push --purge b4bz/homer:latest
+docker manifest create b4bz/homer:latest b4bz/homer:latest-amd64 b4bz/homer:latest-arm32v7 b4bz/homer:latest-arm64v8
+docker manifest annotate b4bz/homer:latest b4bz/homer:latest-arm32v7 --os linux --arch arm
+docker manifest annotate b4bz/homer:latest b4bz/homer:latest-arm64v8 --os linux --arch arm64 --variant v8
+docker manifest push --purge b4bz/homer:latest

--- a/hooks/pre_build
+++ b/hooks/pre_build
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Update to docker-ee 18.x for manifests
+apt-get -y update
+apt-get -y --only-upgrade install docker-ee
+# Register qemu-*-static for all supported processors except the
+# current one, but also remove all registered binfmt_misc before
+docker run --rm --privileged multiarch/qemu-user-static:register --reset


### PR DESCRIPTION
## Description

This change will publish containers for the following Architectures:
- amd64 (x86_64)
- arm32v7 (armhf)
- arm64v8 (aarch64)

The `latest` manifest will be published on DockerHub which when pulled by a user, will distribute the respective container for the appropriate architecture.

This will require changes in the auto-build section of DockerHub per the below image:

![dockerhub](https://upload.nerv.com.au/HUgE0/hEVidAfI24.png/raw)

Build caching can be turned off.

Fixes #40 and fixes #43.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] I read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/master/CONTRIBUTING.md)
- [ ] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [ ] I have made corresponding changes the documentation (README.md).
- [ ] I've check my modifications for any breaking change, especially in the `config.yml` file
