### PR TITLE
Slim down Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@ dockerfile
 *.md
 .git
 screenshot.png
+docker-compose.override.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,8 @@
-FROM alpine:3.11
+FROM halverneus/static-file-server:v1.8.0
+
+ENV \
+	DEBUG=true \
+	FOLDER=/www \
+	PORT=8080
 
 COPY ./ /www/
-
-ENV USER darkhttpd
-ENV GROUP darkhttpd
-ENV GID 911
-ENV UID 911
-
-RUN addgroup -S ${GROUP} -g ${GID} && adduser -D -S -u ${UID} ${USER} ${GROUP} && \
-    apk add -U darkhttpd
-
-USER darkhttpd
-
-ENTRYPOINT ["darkhttpd","/www/"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '2.1'
+services:
+  homer:
+    image: b4bz/homer:latest
+    build: .
+    volumes:
+      - './config.yml:/www/config.yml'
+      - './assets/:/www/assets'
+    ports:
+    - '8080:8080'


### PR DESCRIPTION
## Description

This PR slims down the Dockerfile by using https://github.com/halverneus/static-file-server instead of Alpine with an added webserver. static-file-server is built in go and can run in a scratch image.

To be backwards compatible the Dockerfile uses the same directory to serve assets from as the previous container.

Additionally this includes a docker-compose.yml to simplify local building and running.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [*] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [*] I read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/master/CONTRIBUTING.md)
- [*] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [ ] I have made corresponding changes the documentation (README.md).
- [*] I've check my modifications for any breaking change, especially in the `config.yml` file
