### PR TITLE
disable directory listing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ RUN addgroup -S ${GROUP} -g ${GID} && adduser -D -S -u ${UID} ${USER} ${GROUP} &
 
 USER darkhttpd
 
-ENTRYPOINT ["darkhttpd","/www/"]
+ENTRYPOINT ["darkhttpd","/www/", "--no-listing"]


### PR DESCRIPTION
## Description

By default, directory listing is enabled for darkhttpd. This could be a security problem.

Fixes #55

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/master/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [ ] I have made corresponding changes the documentation (README.md). **Not needed**
- [x] I've check my modifications for any breaking change, especially in the `config.yml` file
