### PR TITLE
Vue PWA Default Icon Paths are Incorrect

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -8,6 +8,13 @@ module.exports = {
       .end();
   },
   pwa: {
-    manifestPath: "assets/manifest.json"
+    manifestPath: "assets/manifest.json",
+    iconPaths: {
+      favicon32: 'assets/icons/favicon-32x32.png',
+      favicon16: 'assets/icons/favicon-16x16.png',
+      appleTouchIcon: 'assets/icons/apple-touch-icon-152x152.png',
+      maskIcon: 'assets/icons/safari-pinned-tab.svg',
+      msTileImage: 'assets/icons/msapplication-icon-144x144.png'
+    }
   }
 };


### PR DESCRIPTION
Corrected the icons due to the default iconPaths setting for Vue-PWA plugin is not where the icons actually are.  This corrects issue.

## Description

Corrected the icons due to the default iconPaths setting for Vue-PWA plugin is not where the icons actually are.  This corrects issue.

Fixes # None

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] I read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/master/CONTRIBUTING.md)
- [X] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [X] I have made corresponding changes the documentation (README.md).
- [X] I've check my modifications for any breaking change, especially in the `config.yml` file
