### PR TITLE
Make Homer more "web app" friendly

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,8 +3,11 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0, viewport-fit=cover">
     <meta name="robots" content="noindex">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-title" content="<%= htmlWebpackPlugin.options.title %>">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black">
     <link rel="icon" href="<%= BASE_URL %>favicon.png">
     <title><%= htmlWebpackPlugin.options.title %></title>
   </head>

--- a/public/index.html
+++ b/public/index.html
@@ -5,9 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0, viewport-fit=cover">
     <meta name="robots" content="noindex">
-    <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="apple-mobile-web-app-title" content="<%= htmlWebpackPlugin.options.title %>">
-    <meta name="apple-mobile-web-app-status-bar-style" content="black">
     <link rel="icon" href="<%= BASE_URL %>favicon.png">
     <title><%= htmlWebpackPlugin.options.title %></title>
   </head>

--- a/vue.config.js
+++ b/vue.config.js
@@ -10,6 +10,8 @@ module.exports = {
   publicPath: "",
   pwa: {
     manifestPath: "assets/manifest.json",
+    appleMobileWebAppStatusBarStyle: "black",
+    appleMobileWebAppCapable: "yes",
     iconPaths: {
       favicon32: "assets/icons/favicon-32x32.png",
       favicon16: "assets/icons/favicon-16x16.png",


### PR DESCRIPTION
## Description

I have saved Homer to my homescreen, but it just opens in Safari. By setting a few new meta data fields we can make Homer look and feel like and app.


## Type of change

- [ ] The viewports update makes it work with the iPhone X* notch.
- [ ] Web app capable tells the iPhone it's a web app.
- [ ] Web app title presets the title for the app.
- [ ] Web app status bar style sets the colour of the status bar.

## Checklist:

- [-] I read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/master/CONTRIBUTING.md)
- [-] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [-] I have made corresponding changes the documentation (README.md).
- [-] I've check my modifications for any breaking change, especially in the `config.yml` file
