### PR TITLE
Docker tweaks

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@ dockerfile
 *.md
 .git
 screenshot.png
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ENV UID 911
 ENV PORT 8080
 
 RUN addgroup -S ${GROUP} -g ${GID} && adduser -D -S -u ${UID} ${USER} ${GROUP} && \
-    apk add -U darkhttpd
+    apk add -U --no-cache darkhttpd
 
 COPY --from=build-stage --chown=${USER}:${GROUP} /app/dist /www/
 COPY --chown=${USER}:${GROUP} entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,5 +26,5 @@ COPY --chown=${USER}:${GROUP} entrypoint.sh /entrypoint.sh
 
 USER ${USER}
 EXPOSE ${PORT}
-VOLUME [ "/www/config.yml", "/www/assets" ]
+VOLUME /www/assets
 ENTRYPOINT ["/bin/sh", "/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN addgroup -S ${GROUP} -g ${GID} && adduser -D -S -u ${UID} ${USER} ${GROUP} &
 COPY --from=build-stage --chown=${USER}:${GROUP} /app/dist /www/
 COPY --chown=${USER}:${GROUP} entrypoint.sh /entrypoint.sh
 
+WORKDIR /www
 USER ${USER}
 EXPOSE ${PORT}
 VOLUME /www/assets

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -28,7 +28,7 @@ ENV UID 911
 ENV PORT 8080
 
 RUN addgroup -S ${GROUP} -g ${GID} && adduser -D -S -u ${UID} ${USER} ${GROUP} && \
-    apk add -U darkhttpd && \
+    apk add -U --no-cache darkhttpd && \
     rm /usr/bin/qemu-arm-static
 
 COPY --from=build-stage --chown=${USER}:${GROUP} /app/dist /www/

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -34,6 +34,7 @@ RUN addgroup -S ${GROUP} -g ${GID} && adduser -D -S -u ${UID} ${USER} ${GROUP} &
 COPY --from=build-stage --chown=${USER}:${GROUP} /app/dist /www/
 COPY --chown=${USER}:${GROUP} entrypoint.sh /entrypoint.sh
 
+WORKDIR /www
 USER ${USER}
 EXPOSE ${PORT}
 VOLUME /www/assets

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -36,5 +36,5 @@ COPY --chown=${USER}:${GROUP} entrypoint.sh /entrypoint.sh
 
 USER ${USER}
 EXPOSE ${PORT}
-VOLUME [ "/www/config.yml", "/www/assets" ]
+VOLUME /www/assets
 ENTRYPOINT ["/bin/sh", "/entrypoint.sh"]

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -34,6 +34,7 @@ RUN addgroup -S ${GROUP} -g ${GID} && adduser -D -S -u ${UID} ${USER} ${GROUP} &
 COPY --from=build-stage --chown=${USER}:${GROUP} /app/dist /www/
 COPY --chown=${USER}:${GROUP} entrypoint.sh /entrypoint.sh
 
+WORKDIR /www
 USER ${USER}
 EXPOSE ${PORT}
 VOLUME /www/assets

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -36,5 +36,5 @@ COPY --chown=${USER}:${GROUP} entrypoint.sh /entrypoint.sh
 
 USER ${USER}
 EXPOSE ${PORT}
-VOLUME [ "/www/config.yml", "/www/assets" ]
+VOLUME /www/assets
 ENTRYPOINT ["/bin/sh", "/entrypoint.sh"]

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -28,7 +28,7 @@ ENV UID 911
 ENV PORT 8080
 
 RUN addgroup -S ${GROUP} -g ${GID} && adduser -D -S -u ${UID} ${USER} ${GROUP} && \
-    apk add -U darkhttpd && \
+    apk add -U --no-cache darkhttpd && \
     rm /usr/bin/qemu-aarch64-static
 
 COPY --from=build-stage --chown=${USER}:${GROUP} /app/dist /www/

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
-yes n | cp -i /www/config.yml.dist /www/config.yml
-while true; do echo n; done | cp -Ri /app/dist/www/assets /www/assets 2>/dev/null
+if ! [ -f 'config.yml' ]; then
+    echo '/www/config.yml not found. Using default config.' 1>&2
+    cp config.yml.dist config.yml
+fi
 
-darkhttpd /www/ --no-listing --port $PORT
+exec darkhttpd /www/ --no-listing --port "$PORT"


### PR DESCRIPTION
## Description

No dependencies change with this PR. This just includes some small Docker changes to closer follow best practices.

- Adds `node_modules` to `.dockerignore`.
- Disables apk's cache while installing darkhttpd to shave ~1.5MB off of the final image.
- Removes `/www/config.yml` from the `VOLUME`s so that an empty directory isn't created when volume is not bound.
- Adds a workdir so that Docker always starts in `/www`
- Adds log output when the default config is copied over
- `exec` darkhttpd so that signals are passed to it

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/master/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes the documentation (README.md).
- [x] I've check my modifications for any breaking change, especially in the `config.yml` file
