### PR TITLE
Add fa-fw to icons by default to fix variable width icons

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -14,7 +14,7 @@
         <div v-cloak class="container">
           <div class="logo">
             <img v-if="config.logo" :src="config.logo" alt="dashboard logo" />
-            <i v-if="config.icon" :class="config.icon"></i>
+            <i v-if="config.icon" :class="['fa-fw', config.icon]"></i>
           </div>
           <div class="dashboard-title">
             <span class="headline">{{ config.subtitle }}</span>
@@ -61,7 +61,7 @@
           <div v-if="!vlayout || filter" class="columns is-multiline">
             <template v-for="group in services">
               <h2 v-if="group.name" class="column is-full group-title">
-                <i v-if="group.icon" :class="group.icon"></i>
+                <i v-if="group.icon" :class="['fa-fw', group.icon]"></i>
                 {{ group.name }}
               </h2>
               <Service
@@ -84,7 +84,7 @@
               :key="group.name"
             >
               <h2 v-if="group.name" class="group-title">
-                <i v-if="group.icon" :class="group.icon"></i>
+                <i v-if="group.icon" :class="['fa-fw', group.icon]"></i>
                 {{ group.name }}
               </h2>
               <Service

--- a/src/components/DarkMode.vue
+++ b/src/components/DarkMode.vue
@@ -4,7 +4,7 @@
     aria-label="Toggle dark mode"
     class="navbar-item is-inline-block-mobile"
   >
-    <i class="fas fa-adjust"></i>
+    <i class="fas fa-fw fa-adjust"></i>
   </a>
 </template>
 

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -29,7 +29,7 @@
               <i
                 v-if="link.icon"
                 style="margin-right: 6px;"
-                :class="link.icon"
+                :class="['fa-fw', link.icon]"
               ></i>
               {{ link.name }}
             </a>

--- a/src/components/Service.vue
+++ b/src/components/Service.vue
@@ -11,7 +11,7 @@
             </div>
             <div v-if="item.icon" class="media-left">
               <figure class="image is-48x48">
-                <i style="font-size: 35px;" :class="item.icon"></i>
+                <i style="font-size: 35px;" :class="['fa-fw', item.icon]"></i>
               </figure>
             </div>
             <div class="media-content">

--- a/src/components/SettingToggle.vue
+++ b/src/components/SettingToggle.vue
@@ -1,6 +1,6 @@
 <template>
   <a v-on:click="toggleSetting()" class="navbar-item is-inline-block-mobile">
-    <span><i :class="['fas', value ? icon : iconAlt]"></i></span>
+    <span><i :class="['fas', 'fa-fw', value ? icon : iconAlt]"></i></span>
     <slot></slot>
   </a>
 </template>


### PR DESCRIPTION
## Description

Font Awesome icons currently don't get the `fa-fw` class so they are not fixed width. This adds `fa-fw` to icons that should line up, which helps the overall page look more aligned.

Fixes #93 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/master/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes the documentation (README.md).
- [x] I've check my modifications for any breaking change, especially in the `config.yml` file
