### PR TITLE
Explicitly define start_url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ yarn-error.log*
 
 # App configuration
 config.yml
+
+.drone.yml

--- a/vue.config.js
+++ b/vue.config.js
@@ -10,6 +10,9 @@ module.exports = {
   publicPath: "",
   pwa: {
     manifestPath: "assets/manifest.json",
+    manifestOptions: {
+      start_url: '../',
+    },
     appleMobileWebAppStatusBarStyle: "black",
     appleMobileWebAppCapable: "yes",
     name: "Homer Dashboard",


### PR DESCRIPTION
## Description

Currently the manifest json links to the assets directory for the starting url, this points to the actual install dir of Homer

Relates to #99 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/master/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes the documentation (README.md).
- [x] I've check my modifications for any breaking change, especially in the `config.yml` file
