### PR TITLE
Remove fa-fw from main logo to fix Font Awesome duotone issues

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -14,7 +14,7 @@
         <div v-cloak class="container">
           <div class="logo">
             <img v-if="config.logo" :src="config.logo" alt="dashboard logo" />
-            <i v-if="config.icon" :class="['fa-fw', config.icon]"></i>
+            <i v-if="config.icon" :class="config.icon"></i>
           </div>
           <div class="dashboard-title">
             <span class="headline">{{ config.subtitle }}</span>


### PR DESCRIPTION
## Description

This removes `fa-fw` from the main logo icon since it does not need to align with any other icons, and this fixes the padding issues that can happen with Font Awesome duotone icons.

After the fix:

<img width="82" alt="Screen Shot 2020-07-22 at 3 10 49 PM" src="https://user-images.githubusercontent.com/7717888/88223798-a742f800-cc2d-11ea-88b9-36a9dbe4efe3.png">

Fixes #111 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/master/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes the documentation (README.md).
- [x] I've check my modifications for any breaking change, especially in the `config.yml` file
