### PR TITLE
Add support for a custom stylesheet

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,8 +27,9 @@ connectivityCheck: true # whether you want to display a message when the apps ar
 theme: default # 'default' or one of the theme available in 'src/assets/themes'.
 
 # Optional custom stylesheet
-# Will load a custom CSS file. Especially useful for custom icon sets.
-# stylesheet: "assets/custom.css"
+# Will load custom CSS files. Especially useful for custom icon sets.
+# stylesheet:
+#   - "assets/custom.css"
 
 # Here is the exaustive list of customization parameters
 # However all value are optional and will fallback to default if not set.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,6 +26,10 @@ connectivityCheck: true # whether you want to display a message when the apps ar
 # Optional theming
 theme: default # 'default' or one of the theme available in 'src/assets/themes'.
 
+# Optional custom stylesheet
+# Will load a custom CSS file. Especially useful for custom icon sets.
+# stylesheet: "assets/custom.css"
+
 # Here is the exaustive list of customization parameters
 # However all value are optional and will fallback to default if not set.
 # if you want to change only some of the colors, feel free to remove all unused key.

--- a/src/App.vue
+++ b/src/App.vue
@@ -161,7 +161,11 @@ export default {
     this.services = this.config.services;
     document.title = `${this.config.title} | ${this.config.subtitle}`;
     if (this.config.stylesheet) {
-      this.createStylesheet(`@import "${this.config.stylesheet}";`);
+      let stylesheet = '';
+      for (const file of this.config.stylesheet) {
+        stylesheet += `@import "${file}";`;
+      }
+      this.createStylesheet(stylesheet);
     }
   },
   methods: {

--- a/src/App.vue
+++ b/src/App.vue
@@ -160,6 +160,9 @@ export default {
     this.config = merge(defaults, config);
     this.services = this.config.services;
     document.title = `${this.config.title} | ${this.config.subtitle}`;
+    if (this.config.stylesheet) {
+      this.createStylesheet(`@import "${this.config.stylesheet}";`);
+    }
   },
   methods: {
     getConfig: function (path = "assets/config.yml") {
@@ -234,6 +237,11 @@ export default {
           content: content,
         },
       };
+    },
+    createStylesheet: function(css) {
+      let style = document.createElement('style');
+      style.appendChild(document.createTextNode(css));
+      document.head.appendChild(style);
     },
   },
 };


### PR DESCRIPTION
## Description

This adds support for a custom stylesheet in config.yml.

I have been using it for importing Font Awesome Pro's CSS, but it could be used for individual styles too as an easier way than creating a custom theme.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/master/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes the documentation (README.md).
- [x] I've check my modifications for any breaking change, especially in the `config.yml` file
