### PR TITLE
Fix alignment when navbar link name is empty

### DIFF
--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -28,8 +28,7 @@
             >
               <i
                 v-if="link.icon"
-                style="margin-right: 6px;"
-                :class="['fa-fw', link.icon]"
+                :class="['fa-fw', link.icon, { 'mr-2': link.name }]"
               ></i>
               {{ link.name }}
             </a>


### PR DESCRIPTION
## Description

Navbar items currently have an uneven margin-right which looks weird if the name field is left blank. This change only adds this margin if the name is not blank. Also, use `mr-2` instead of an inline style.

Before:
<img width="90" alt="Screen Shot 2020-07-28 at 5 19 41 PM" src="https://user-images.githubusercontent.com/7717888/88728141-ad861800-d0f6-11ea-873e-46d27f848984.png"> 

After:
<img width="78" alt="Screen Shot 2020-07-28 at 5 20 05 PM" src="https://user-images.githubusercontent.com/7717888/88728145-b1b23580-d0f6-11ea-8b0d-0140bafd33f1.png">


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/master/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes the documentation (README.md).
- [x] I've check my modifications for any breaking change, especially in the `config.yml` file
