### PR TITLE
Feature/custom document title

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,6 +13,7 @@ Title, icons, links, colors, and services can be configured in the `config.yml` 
 
 title: "App dashboard"
 subtitle: "Homer"
+# documentTitle: "Welcome" # Customize the browser tab text
 logo: "assets/logo.png"
 # Alternatively a fa icon can be provided:
 # icon: "fas fa-skull-crossbones"

--- a/src/App.vue
+++ b/src/App.vue
@@ -159,7 +159,7 @@ export default {
     }
     this.config = merge(defaults, config);
     this.services = this.config.services;
-    document.title = `${this.config.title} | ${this.config.subtitle}`;
+    document.title = this.config.documentTitle || `${this.config.title} | ${this.config.subtitle}`;
     if (this.config.stylesheet) {
       let stylesheet = "";
       for (const file of this.config.stylesheet) {


### PR DESCRIPTION
## Description

This PR allows you to set a custom document title (the text displayed in the browser tab) via the `config.yml`. For backwards-compatibility, it falls back to the current format of `{title} | {subtitle}` if `documentTitle:` is not set.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/master/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes the documentation (README.md).
- [x] I've check my modifications for any breaking change, especially in the `config.yml` file
