### PR TITLE
feat: Set Theme Variant and Layout defaults in config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,10 +22,12 @@ header: true # Set to false to hide the header
 footer: '<p>Created with <span class="has-text-danger">❤️</span> with <a href="https://bulma.io/">bulma</a>, <a href="https://vuejs.org/">vuejs</a> & <a href="https://fontawesome.com/">font awesome</a> // Fork me on <a href="https://github.com/bastienwirtz/homer"><i class="fab fa-github-alt"></i></a></p>' # set false if you want to hide it.
 
 columns: "3" # "auto" or number (must be a factor of 12: 1, 2, 3, 4, 6, 12)
+vlayout: true # default to the vertical layout
 connectivityCheck: true # whether you want to display a message when the apps are not accessible anymore (VPN disconnected for example)
 
 # Optional theming
 theme: default # 'default' or one of the theme available in 'src/assets/themes'.
+theme_use_dark: false # true or false, useful for overriding browser default in new sessions
 
 # Optional custom stylesheet
 # Will load custom CSS files. Especially useful for custom icon sets.

--- a/src/App.vue
+++ b/src/App.vue
@@ -28,7 +28,7 @@
         :links="config.links"
         @navbar-toggle="showMenu = !showMenu"
       >
-        <DarkMode @updated="isDark = $event" />
+        <DarkMode :isDark="this.isDark" @updated="isDark = $event" />
 
         <LayoutToggle
           @updated="vlayout = $event"
@@ -159,6 +159,8 @@ export default {
     }
     this.config = merge(defaults, config);
     this.services = this.config.services;
+    this.isDark = this.config.theme_use_dark;
+    this.vlayout = this.config.vlayout;
     document.title =
       this.config.documentTitle ||
       `${this.config.title} | ${this.config.subtitle}`;

--- a/src/App.vue
+++ b/src/App.vue
@@ -31,6 +31,7 @@
         <DarkMode :isDark="this.isDark" @updated="isDark = $event" />
 
         <LayoutToggle
+          :vlayout="this.vlayout"
           @updated="vlayout = $event"
           name="vlayout"
           icon="fa-list"
@@ -145,7 +146,7 @@ export default {
       offline: false,
       services: null,
       showMenu: false,
-      vlayout: true,
+      vlayout: null,
     };
   },
   created: async function () {

--- a/src/App.vue
+++ b/src/App.vue
@@ -30,7 +30,7 @@
       >
         <DarkMode @updated="isDark = $event" />
 
-        <SettingToggle
+        <LayoutToggle
           @updated="vlayout = $event"
           name="vlayout"
           icon="fa-list"
@@ -119,7 +119,7 @@ import ConnectivityChecker from "./components/ConnectivityChecker.vue";
 import Service from "./components/Service.vue";
 import Message from "./components/Message.vue";
 import SearchInput from "./components/SearchInput.vue";
-import SettingToggle from "./components/SettingToggle.vue";
+import LayoutToggle from "./components/LayoutToggle.vue";
 import DarkMode from "./components/DarkMode.vue";
 import DynamicTheme from "./components/DynamicTheme.vue";
 
@@ -128,24 +128,24 @@ import defaultConfig from "./assets/defaults.yml";
 export default {
   name: "App",
   components: {
-    Navbar,
     ConnectivityChecker,
-    Service,
-    Message,
-    SearchInput,
-    SettingToggle,
     DarkMode,
     DynamicTheme,
+    Message,
+    Navbar,
+    SearchInput,
+    Service,
+    LayoutToggle,
   },
   data: function () {
     return {
       config: null,
-      services: null,
-      offline: false,
       filter: "",
-      vlayout: true,
       isDark: null,
+      offline: false,
+      services: null,
       showMenu: false,
+      vlayout: true,
     };
   },
   created: async function () {

--- a/src/components/DarkMode.vue
+++ b/src/components/DarkMode.vue
@@ -11,23 +11,21 @@
 <script>
 export default {
   name: "Darkmode",
-  data: function () {
-    return {
-      isDark: null,
-    };
-  },
+  props: ["isDark"],
   created: function () {
-    this.isDark =
+    var isDark =
       "overrideDark" in localStorage
         ? JSON.parse(localStorage.overrideDark)
-        : matchMedia("(prefers-color-scheme: dark)").matches;
-    this.$emit("updated", this.isDark);
+        : this.isDark === null
+        ? matchMedia("(prefers-color-scheme: dark)").matches
+        : this.isDark;
+    this.$emit("updated", isDark);
   },
   methods: {
     toggleTheme: function () {
-      this.isDark = !this.isDark;
-      localStorage.overrideDark = this.isDark;
-      this.$emit("updated", this.isDark);
+      var isDark = !this.isDark;
+      localStorage.overrideDark = isDark;
+      this.$emit("updated", isDark);
     },
   },
 };

--- a/src/components/DarkMode.vue
+++ b/src/components/DarkMode.vue
@@ -13,7 +13,7 @@ export default {
   name: "Darkmode",
   props: ["isDark"],
   created: function () {
-    var isDark =
+    let isDark =
       "overrideDark" in localStorage
         ? JSON.parse(localStorage.overrideDark)
         : this.isDark === null
@@ -23,7 +23,7 @@ export default {
   },
   methods: {
     toggleTheme: function () {
-      var isDark = !this.isDark;
+      let isDark = !this.isDark;
       localStorage.overrideDark = isDark;
       this.$emit("updated", isDark);
     },

--- a/src/components/DarkMode.vue
+++ b/src/components/DarkMode.vue
@@ -11,7 +11,9 @@
 <script>
 export default {
   name: "Darkmode",
-  props: ["isDark"],
+  props: {
+    isDark: Boolean,
+  },
   created: function () {
     let isDark =
       "overrideDark" in localStorage

--- a/src/components/LayoutToggle.vue
+++ b/src/components/LayoutToggle.vue
@@ -1,6 +1,6 @@
 <template>
-  <a v-on:click="toggleSetting()" class="navbar-item is-inline-block-mobile">
-    <span><i :class="['fas', 'fa-fw', value ? icon : secondaryIcon]"></i></span>
+  <a v-on:click="toggleLayout()" class="navbar-item is-inline-block-mobile">
+    <span><i :class="['fas', 'fa-fw', vlayout ? icon : secondaryIcon]"></i></span>
     <slot></slot>
   </a>
 </template>
@@ -12,27 +12,31 @@ export default {
     name: String,
     icon: String,
     iconAlt: String,
+    vlayout: Boolean,
   },
   data: function () {
     return {
       secondaryIcon: null,
-      value: true,
     };
   },
   created: function () {
     this.secondaryIcon = this.iconAlt || this.icon;
-
+    let vlayout;
     if (this.name in localStorage) {
-      this.value = JSON.parse(localStorage[this.name]);
+      vlayout = JSON.parse(localStorage[this.name]);
+    } else {
+	vlayout = this.vlayout === null 
+        ? true 
+        : this.vlayout;
     }
 
-    this.$emit("updated", this.value);
+    this.$emit("updated", vlayout);
   },
   methods: {
-    toggleSetting: function () {
-      this.value = !this.value;
-      localStorage[this.name] = this.value;
-      this.$emit("updated", this.value);
+    toggleLayout: function () {
+      let vlayout = !this.vlayout;
+      localStorage[this.name] = vlayout;
+      this.$emit("updated", vlayout);
     },
   },
 };

--- a/src/components/LayoutToggle.vue
+++ b/src/components/LayoutToggle.vue
@@ -1,6 +1,8 @@
 <template>
   <a v-on:click="toggleLayout()" class="navbar-item is-inline-block-mobile">
-    <span><i :class="['fas', 'fa-fw', vlayout ? icon : secondaryIcon]"></i></span>
+    <span>
+      <i :class="['fas', 'fa-fw', vlayout ? icon : secondaryIcon]"></i>
+    </span>
     <slot></slot>
   </a>
 </template>
@@ -25,9 +27,7 @@ export default {
     if (this.name in localStorage) {
       vlayout = JSON.parse(localStorage[this.name]);
     } else {
-	vlayout = this.vlayout === null 
-        ? true 
-        : this.vlayout;
+      vlayout = this.vlayout === null ? true : this.vlayout;
     }
 
     this.$emit("updated", vlayout);

--- a/src/components/LayoutToggle.vue
+++ b/src/components/LayoutToggle.vue
@@ -7,7 +7,7 @@
 
 <script>
 export default {
-  name: "SettingToggle",
+  name: "LayoutToggle",
   props: {
     name: String,
     icon: String,


### PR DESCRIPTION
## Description

Allows default configuration of theme and layout as described in #121. 

Order of precedence is as follows:
- localstorage (user's preference)
- configuration file 
- browser preference (applies to theme only, as there's no media query for layout)
- light theme


Fixes #121 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/master/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes the documentation (README.md).
- [x] I've check my modifications for any breaking change, especially in the `config.yml` file
