### PR TITLE
feat: Add optional info icon to top right of cards

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -97,6 +97,8 @@ services:
         tag: "app"
         url: "https://www.reddit.com/r/selfhosted/"
         target: "_blank" # optional html tag target attribute
+        info: "https://github.com/bastienwirtz/homer/tree/main/docs" # optional link to documentation
+        infotarget: "_blank" # same as target, but for icon link
       - name: "Another one"
         logo: "assets/tools/sample2.png"
         subtitle: "Another application"

--- a/src/assets/app.scss
+++ b/src/assets/app.scss
@@ -206,7 +206,7 @@ body {
     color: var(--highlight-secondary);
     background-color: var(--highlight-secondary);
     position: absolute;
-    top: 1rem;
+    bottom: 1rem;
     right: -0.2rem;
     width: 3px;
     overflow: hidden;

--- a/src/assets/app.scss
+++ b/src/assets/app.scss
@@ -49,6 +49,14 @@ body {
       &:hover {
         background-color: var(--card-background);
       }
+     
+      .linkoverlay {
+        position:absolute;
+        left:0;
+        top:0;
+        bottom:0;
+        right:0;
+      }
     }
 
     .message {
@@ -196,10 +204,20 @@ body {
       }
     }
   }
-
+  .media-left {
+    pointer-events: none;
+    z-index: 1;
+  }
   .media-content {
     overflow: hidden;
     text-overflow: inherit;
+  }
+  .infolink {
+    font-family: "Font Awesome 5 Free";
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    padding: 0;
   }
 
   .tag {

--- a/src/assets/app.scss
+++ b/src/assets/app.scss
@@ -57,6 +57,9 @@ body {
         bottom:0;
         right:0;
       }
+      .thirty-five {
+        font-size: 35px;
+      }
     }
 
     .message {

--- a/src/components/services/Generic.vue
+++ b/src/components/services/Generic.vue
@@ -2,7 +2,8 @@
 export default {};
 </script>
 
-<style></style> */
+<style></style>
+*/
 
 <script>
 export default {};
@@ -13,29 +14,42 @@ export default {};
 <template>
   <div>
     <div class="card" :class="item.class">
-      <a :href="item.url" :target="item.target" rel="noreferrer">
-        <div class="card-content">
-          <div class="media">
-            <div v-if="item.logo" class="media-left">
-              <figure class="image is-48x48">
-                <img :src="item.logo" :alt="`${item.name} logo`" />
-              </figure>
-            </div>
-            <div v-if="item.icon" class="media-left">
-              <figure class="image is-48x48">
-                <i style="font-size: 35px;" :class="['fa-fw', item.icon]"></i>
-              </figure>
-            </div>
-            <div class="media-content">
-              <p class="title is-4">{{ item.name }}</p>
-              <p class="subtitle is-6">{{ item.subtitle }}</p>
-            </div>
+      <a
+        :href="item.url"
+        class="linkoverlay"
+        :target="item.target"
+        rel="noreferrer"
+      ></a>
+      <div class="card-content">
+        <div class="media">
+          <div v-if="item.logo" class="media-left">
+            <figure class="image is-48x48">
+              <img :src="item.logo" :alt="`${item.name} logo`" />
+            </figure>
           </div>
-          <div class="tag" :class="item.tagstyle" v-if="item.tag">
-            <strong class="tag-text">#{{ item.tag }}</strong>
+          <div v-if="item.icon" class="media-left">
+            <figure class="image is-48x48">
+              <i style="font-size: 35px;" :class="['fa-fw', item.icon]"></i>
+            </figure>
+          </div>
+          <div class="media-content">
+            <p class="title is-4">{{ item.name }}</p>
+            <p class="subtitle is-6">{{ item.subtitle }}</p>
           </div>
         </div>
-      </a>
+        <a v-if="item.info"
+          :href="item.info"
+          :target="item.infotarget"
+          rel="noreferrer"
+        >
+          <div class="infolink">
+            <i class="fas fa-info-circle"></i>
+          </div>
+        </a>
+        <div class="tag" :class="item.tagstyle" v-if="item.tag">
+          <strong class="tag-text">#{{ item.tag }}</strong>
+        </div>
+      </div>
     </div>
   </div>
 </template>

--- a/src/components/services/Generic.vue
+++ b/src/components/services/Generic.vue
@@ -3,7 +3,6 @@ export default {};
 </script>
 
 <style></style>
-*/
 
 <script>
 export default {};
@@ -29,7 +28,7 @@ export default {};
           </div>
           <div v-if="item.icon" class="media-left">
             <figure class="image is-48x48">
-              <i style="font-size: 35px;" :class="['fa-fw', item.icon]"></i>
+              <i class="thirty-five" :class="['fa-fw', item.icon]"></i>
             </figure>
           </div>
           <div class="media-content">
@@ -37,7 +36,8 @@ export default {};
             <p class="subtitle is-6">{{ item.subtitle }}</p>
           </div>
         </div>
-        <a v-if="item.info"
+        <a
+          v-if="item.info"
           :href="item.info"
           :target="item.infotarget"
           rel="noreferrer"


### PR DESCRIPTION
## Description

No new dependencies for this feature, screenshots attached below.
New options for services were bundled into the `Generic` card and allow an optional info link to be set with the `info` and `infotarget` properties.

Note this UI/UX change moves the tag element from the top to the bottom right of the card to make room for the new icon.

Fixes #125 
![image](https://user-images.githubusercontent.com/8261498/97166862-27a05a00-1743-11eb-8632-12ba2a2a3711.png)
![image](https://user-images.githubusercontent.com/8261498/97166836-20794c00-1743-11eb-919b-98ba095721e6.png)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/master/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes the documentation (README.md).
- [x] I've check my modifications for any breaking change, especially in the `config.yml` file
