### PR TITLE
Fix item key for horizontal layout

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -65,8 +65,8 @@
                 {{ group.name }}
               </h2>
               <Service
-                v-for="item in group.items"
-                :key="item.url"
+                v-for="(item, index) in group.items"
+                :key="index"
                 v-bind:item="item"
                 :class="['column', `is-${12 / config.columns}`]"
               />
@@ -88,9 +88,9 @@
                 {{ group.name }}
               </h2>
               <Service
-                v-for="item in group.items"
+                v-for="(item, index) in group.items"
+                :key="index"
                 v-bind:item="item"
-                :key="item.url"
               />
             </div>
           </div>

--- a/src/App.vue
+++ b/src/App.vue
@@ -66,7 +66,7 @@
               </h2>
               <Service
                 v-for="item in group.items"
-                :key="item.name"
+                :key="item.url"
                 v-bind:item="item"
                 :class="['column', `is-${12 / config.columns}`]"
               />


### PR DESCRIPTION
## Description

App crashes if search results yield items with same name (in horizontal layout).
See issue for details.

Fixes  https://github.com/bastienwirtz/homer/issues/163

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/master/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [ ] I have made corresponding changes the documentation (README.md).
- [ ] I've checked my modifications for any breaking changes, especially in the `config.yml` file
