### PR TITLE
Fix #167: align item name when subtitle is empty

### DIFF
--- a/src/assets/app.scss
+++ b/src/assets/app.scss
@@ -197,6 +197,11 @@ body {
     }
   }
 
+  .media.no-subtitle {
+    display: flex;
+    align-items: center;
+  }
+
   .media-content {
     overflow: hidden;
     text-overflow: inherit;

--- a/src/components/services/Generic.vue
+++ b/src/components/services/Generic.vue
@@ -1,16 +1,3 @@
-<script>
-export default {};
-</script>
-
-<style></style>
-*/
-
-<script>
-export default {};
-</script>
-
-<style></style>
-
 <template>
   <div>
     <div
@@ -20,7 +7,7 @@ export default {};
     >
       <a :href="item.url" :target="item.target" rel="noreferrer">
         <div class="card-content">
-          <div class="media">
+          <div :class="mediaClass">
             <div v-if="item.logo" class="media-left">
               <figure class="image is-48x48">
                 <img :src="item.logo" :alt="`${item.name} logo`" />
@@ -33,7 +20,9 @@ export default {};
             </div>
             <div class="media-content">
               <p class="title is-4">{{ item.name }}</p>
-              <p class="subtitle is-6">{{ item.subtitle }}</p>
+              <p class="subtitle is-6" v-if="item.subtitle">
+                {{ item.subtitle }}
+              </p>
             </div>
           </div>
           <div class="tag" :class="item.tagstyle" v-if="item.tag">
@@ -51,11 +40,23 @@ export default {
   props: {
     item: Object,
   },
+  computed: {
+    mediaClass: function () {
+      return { media: true, "no-subtitle": !this.item.subtitle };
+    },
+  },
 };
 </script>
 
 <style scoped lang="scss">
-.media-left img {
-  max-height: 100%;
+.media-left {
+  .image {
+    display: flex;
+    align-items: center;
+  }
+
+  img {
+    max-height: 100%;
+  }
 }
 </style>


### PR DESCRIPTION
## Description

👋 Hi! Thanks for the great tool, I just discovered it and it's pretty cool :)

Here's some suggested changes in this PR:
- Align the item's name in a Generic Service when there is no subtitle defined.
- Align the item logo vertically when the image is not square

Fixes #167

### Screenshots
**Before:**
<img width="322" alt="image" src="https://user-images.githubusercontent.com/2514425/103003778-1c4a8e80-453a-11eb-855d-642ff00aaa84.png">

**After:**
<img width="320" alt="image" src="https://user-images.githubusercontent.com/2514425/103003676-df7e9780-4539-11eb-9f75-37247392dcb9.png">

Notice: Logo is centered vertically. "Router" name is centered vertically.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [ ] I have made corresponding changes the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
