### PR TITLE
Create Radarr, Sonarr & Medusa services

### DIFF
--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -1,0 +1,41 @@
+# Custom Services
+
+Here is an overview of all custom services that are available within Homer.
+
+## PiHole
+
+Using the PiHole service you can display info about your local PiHole instance right on your Homer dashboard.
+
+The following configuration is available for the PiHole service.
+
+```
+ items:
+      - name: "Pi-hole"
+        logo: "assets/tools/sample.png"
+        # subtitle: "Network-wide Ad Blocking" # optional, if no subtitle is defined, PiHole statistics will be shown
+        url: "http://192.168.0.151/admin"
+        type: "PiHole"
+```
+
+## Medusa
+
+This service displays News (grey), Warning (orange) or Error (red) notifications bubbles from the Medusa application.
+Two lines are needed in the config.yml :
+```
+type: "Medusa"
+apikey: "01234deb70424befb1f4ef6a23456789"
+```
+The url must be the root url of Medusa application.
+The Medusa API key can be found in General configuration > Interface. It is needed to access Medusa API.
+
+
+## Sonarr/Radarr
+
+This service displays Activity (blue), Warning (orange) or Error (red) notifications bubbles from the Radarr/Sonarr application.
+Two lines are needed in the config.yml :
+```
+type: "Radarr" or "Sonarr"
+apikey: "01234deb70424befb1f4ef6a23456789"
+```
+The url must be the root url of Radarr/Sonarr application.
+The Radarr/Sonarr API key can be found in Settings > General. It is needed to access the API.

--- a/src/assets/app.scss
+++ b/src/assets/app.scss
@@ -211,7 +211,7 @@ body {
     color: var(--highlight-secondary);
     background-color: var(--highlight-secondary);
     position: absolute;
-    top: 1rem;
+    bottom: 1rem;
     right: -0.2rem;
     width: 3px;
     overflow: hidden;

--- a/src/components/services/Medusa.vue
+++ b/src/components/services/Medusa.vue
@@ -1,0 +1,128 @@
+<template>
+  <div>
+    <div class="card" :class="item.class">
+      <a :href="item.url" :target="item.target" rel="noreferrer">
+        <div class="card-content">
+          <div class="media">
+            <div v-if="item.logo" class="media-left">
+              <figure class="image is-48x48">
+                <img :src="item.logo" :alt="`${item.name} logo`" />
+              </figure>
+            </div>
+            <div v-if="item.icon" class="media-left">
+              <figure class="image is-48x48">
+                <i style="font-size: 35px" :class="['fa-fw', item.icon]"></i>
+              </figure>
+            </div>
+            <div class="media-content">
+              <p class="title is-4">{{ item.name }}</p>
+              <p class="subtitle is-6">{{ item.subtitle }}</p>
+            </div>
+            <div class="notifs">
+              <strong
+                v-if="config !== null && config.system.news.unread > 0"
+                class="notif news"
+                title="News"
+                >{{ config.system.news.unread }}</strong
+              >
+              <strong
+                v-if="config !== null && config.main.logs.numWarnings > 0"
+                class="notif warnings"
+                title="Warning"
+                >{{ config.main.logs.numWarnings }}</strong
+              >
+              <strong
+                v-if="config !== null && config.main.logs.numErrors > 0"
+                class="notif errors"
+                title="Error"
+                >{{ config.main.logs.numErrors }}</strong
+              >
+              <strong
+                v-if="serverError"
+                class="notif errors"
+                title="Connection error to Medusa API, check url and apikey in config.yml"
+                >?</strong
+              >
+            </div>
+          </div>
+          <div class="tag" :class="item.tagstyle" v-if="item.tag">
+            <strong class="tag-text">#{{ item.tag }}</strong>
+          </div>
+        </div>
+      </a>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "Medusa",
+  props: {
+    item: Object,
+  },
+  data: () => {
+    return {
+      config: null,
+      serverError: false,
+    };
+  },
+  created: function () {
+    this.fetchConfig();
+  },
+  methods: {
+    fetchConfig: function () {
+      fetch(`${this.item.url}/api/v2/config`, {
+        credentials: "include",
+        headers: { "X-Api-Key": `${this.item.apikey}` },
+      })
+        .then((response) => {
+          if (response.status != 200) {
+            throw new Error(response.statusText);
+          }
+          return response.json();
+        })
+        .then((conf) => {
+          this.config = conf;
+        })
+        .catch((e) => {
+          console.log(e);
+          this.serverError = true;
+        });
+    },
+  },
+};
+</script>
+
+<style scoped lang="scss">
+.media-left img {
+  max-height: 100%;
+}
+.notifs {
+  position: absolute;
+  color: white;
+  font-family: sans-serif;
+  top: 0.3em;
+  right: 0.5em;
+}
+.notif {
+  padding-right: 0.35em;
+  padding-left: 0.35em;
+  padding-top: 0.2em;
+  padding-bottom: 0.2em;
+  border-radius: 0.25em;
+  position: relative;
+  margin-left: 0.3em;
+  font-size: 0.8em;
+}
+.news {
+  background-color: #777777;
+}
+
+.warnings {
+  background-color: #d08d2e;
+}
+
+.errors {
+  background-color: #e51111;
+}
+</style>

--- a/src/components/services/Radarr.vue
+++ b/src/components/services/Radarr.vue
@@ -1,0 +1,157 @@
+<template>
+  <div>
+    <div class="card" :class="item.class">
+      <a :href="item.url" :target="item.target" rel="noreferrer">
+        <div class="card-content">
+          <div class="media">
+            <div v-if="item.logo" class="media-left">
+              <figure class="image is-48x48">
+                <img :src="item.logo" :alt="`${item.name} logo`" />
+              </figure>
+            </div>
+            <div v-if="item.icon" class="media-left">
+              <figure class="image is-48x48">
+                <i style="font-size: 35px" :class="['fa-fw', item.icon]"></i>
+              </figure>
+            </div>
+            <div class="media-content">
+              <p class="title is-4">{{ item.name }}</p>
+              <p class="subtitle is-6">{{ item.subtitle }}</p>
+            </div>
+            <div class="notifs">
+              <strong
+                v-if="activity > 0"
+                class="notif activity"
+                title="Activity"
+                >{{ activity }}</strong
+              >
+              <strong
+                v-if="warnings > 0"
+                class="notif warnings"
+                title="Warning"
+                >{{ warnings }}</strong
+              >
+              <strong v-if="errors > 0" class="notif errors" title="Error">{{
+                errors
+              }}</strong>
+              <strong
+                v-if="serverError"
+                class="notif errors"
+                title="Connection error to Radarr API, check url and apikey in config.yml"
+                >?</strong
+              >
+            </div>
+          </div>
+          <div class="tag" :class="item.tagstyle" v-if="item.tag">
+            <strong class="tag-text">#{{ item.tag }}</strong>
+          </div>
+        </div>
+      </a>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "Radarr",
+  props: {
+    item: Object,
+  },
+  data: () => {
+    return {
+      activity: null,
+      warnings: null,
+      errors: null,
+      serverError: false,
+    };
+  },
+  created: function () {
+    this.fetchConfig();
+  },
+  methods: {
+    fetchConfig: function () {
+      fetch(`${this.item.url}/api/health`, {
+        credentials: "include",
+        headers: { "X-Api-Key": `${this.item.apikey}` },
+      })
+        .then((response) => {
+          if (response.status != 200) {
+            throw new Error(response.statusText);
+          }
+          return response.json();
+        })
+        .then((health) => {
+          this.warnings = 0;
+          this.errors = 0;
+          for (var i = 0; i < health.length; i++) {
+            if (health[i].type == "warning") {
+              this.warnings++;
+            } else if (health[i].type == "error") {
+              this.errors++;
+            }
+          }
+        })
+        .catch((e) => {
+          console.error(e);
+          this.serverError = true;
+        });
+      fetch(`${this.item.url}/api/queue`, {
+        credentials: "include",
+        headers: { "X-Api-Key": `${this.item.apikey}` },
+      })
+        .then((response) => {
+          if (response.status != 200) {
+            throw new Error(response.statusText);
+          }
+          return response.json();
+        })
+        .then((queue) => {
+          this.activity = 0;
+          for (var i = 0; i < queue.length; i++) {
+            if (queue[i].movie) {
+              this.activity++;
+            }
+          }
+        })
+        .catch((e) => {
+          console.error(e);
+          this.serverError = true;
+        });
+    },
+  },
+};
+</script>
+
+<style scoped lang="scss">
+.media-left img {
+  max-height: 100%;
+}
+.notifs {
+  position: absolute;
+  color: white;
+  font-family: sans-serif;
+  top: 0.3em;
+  right: 0.5em;
+}
+.notif {
+  padding-right: 0.35em;
+  padding-left: 0.35em;
+  padding-top: 0.2em;
+  padding-bottom: 0.2em;
+  border-radius: 0.25em;
+  position: relative;
+  margin-left: 0.3em;
+  font-size: 0.8em;
+}
+.activity {
+  background-color: #4fb5d6;
+}
+
+.warnings {
+  background-color: #d08d2e;
+}
+
+.errors {
+  background-color: #e51111;
+}
+</style>

--- a/src/components/services/Sonarr.vue
+++ b/src/components/services/Sonarr.vue
@@ -1,0 +1,157 @@
+<template>
+  <div>
+    <div class="card" :class="item.class">
+      <a :href="item.url" :target="item.target" rel="noreferrer">
+        <div class="card-content">
+          <div class="media">
+            <div v-if="item.logo" class="media-left">
+              <figure class="image is-48x48">
+                <img :src="item.logo" :alt="`${item.name} logo`" />
+              </figure>
+            </div>
+            <div v-if="item.icon" class="media-left">
+              <figure class="image is-48x48">
+                <i style="font-size: 35px" :class="['fa-fw', item.icon]"></i>
+              </figure>
+            </div>
+            <div class="media-content">
+              <p class="title is-4">{{ item.name }}</p>
+              <p class="subtitle is-6">{{ item.subtitle }}</p>
+            </div>
+            <div class="notifs">
+              <strong
+                v-if="activity > 0"
+                class="notif activity"
+                title="Activity"
+                >{{ activity }}</strong
+              >
+              <strong
+                v-if="warnings > 0"
+                class="notif warnings"
+                title="Warning"
+                >{{ warnings }}</strong
+              >
+              <strong v-if="errors > 0" class="notif errors" title="Error">{{
+                errors
+              }}</strong>
+              <strong
+                v-if="serverError"
+                class="notif errors"
+                title="Connection error to Sonarr API, check url and apikey in config.yml"
+                >?</strong
+              >
+            </div>
+          </div>
+          <div class="tag" :class="item.tagstyle" v-if="item.tag">
+            <strong class="tag-text">#{{ item.tag }}</strong>
+          </div>
+        </div>
+      </a>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "Sonarr",
+  props: {
+    item: Object,
+  },
+  data: () => {
+    return {
+      activity: null,
+      warnings: null,
+      errors: null,
+      serverError: false,
+    };
+  },
+  created: function () {
+    this.fetchConfig();
+  },
+  methods: {
+    fetchConfig: function () {
+      fetch(`${this.item.url}/api/health`, {
+        credentials: "include",
+        headers: { "X-Api-Key": `${this.item.apikey}` },
+      })
+        .then((response) => {
+          if (response.status != 200) {
+            throw new Error(response.statusText);
+          }
+          return response.json();
+        })
+        .then((health) => {
+          this.warnings = 0;
+          this.errors = 0;
+          for (var i = 0; i < health.length; i++) {
+            if (health[i].type == "warning") {
+              this.warnings++;
+            } else if (health[i].type == "error") {
+              this.errors++;
+            }
+          }
+        })
+        .catch((e) => {
+          console.error(e);
+          this.serverError = true;
+        });
+      fetch(`${this.item.url}/api/queue`, {
+        credentials: "include",
+        headers: { "X-Api-Key": `${this.item.apikey}` },
+      })
+        .then((response) => {
+          if (response.status != 200) {
+            throw new Error(response.statusText);
+          }
+          return response.json();
+        })
+        .then((queue) => {
+          this.activity = 0;
+          for (var i = 0; i < queue.length; i++) {
+            if (queue[i].series) {
+              this.activity++;
+            }
+          }
+        })
+        .catch((e) => {
+          console.error(e);
+          this.serverError = true;
+        });
+    },
+  },
+};
+</script>
+
+<style scoped lang="scss">
+.media-left img {
+  max-height: 100%;
+}
+.notifs {
+  position: absolute;
+  color: white;
+  font-family: sans-serif;
+  top: 0.3em;
+  right: 0.5em;
+}
+.notif {
+  padding-right: 0.35em;
+  padding-left: 0.35em;
+  padding-top: 0.2em;
+  padding-bottom: 0.2em;
+  border-radius: 0.25em;
+  position: relative;
+  margin-left: 0.3em;
+  font-size: 0.8em;
+}
+.activity {
+  background-color: #4fb5d6;
+}
+
+.warnings {
+  background-color: #d08d2e;
+}
+
+.errors {
+  background-color: #e51111;
+}
+</style>


### PR DESCRIPTION
## Description

Creates Radarr, Sonarr and Medusa services based on the one done for Pi-Hole, which displays the notification bubbles from those applications.

Example:
![image](https://user-images.githubusercontent.com/10365746/74105747-c73f9d00-4b60-11ea-84c3-3acf9054cb2f.png)

Notifications bubbles display the number of notification of each type :

* News
* Activity
* Warning
* Error

So the user doesn't need to open those applications to know if a notification is pending.

## Type of change

* [ ]  Bug fix (non-breaking change which fixes an issue)
* [x]  New feature (non-breaking change which adds functionality)
* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

* [x]  I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/master/CONTRIBUTING.md)
* [x]  I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
* [ ]  I have made corresponding changes the documentation (README.md).
* [x]  I've checked my modifications for any breaking changes, especially in the `config.yml` file


## Comments on the code

It is a copy paste of PiHole service with some edits.

### Medusa
It requests /api/v2/config to fetch the current status of the application in json format. This path is append to the item url in config.yml so url must be the root url of Medusa application.
Then it displays News (grey), Warning (orange) or Error (red) bubble with number in it. Just like in the Medusa application itself.
Two lines are needed in the config.yml :
```
type: "Medusa"
apikey: "01234deb70424befb1f4ef6a23456789"
```
The Medusa API key can be found in General configuration > Interface. It is needed to access Medusa API.

### Radarr / Sonarr
It requests /api/health and /api/queue to fetch the current status of the application in json format. This path is append to the item url in config.yml so url must be the root url of Radarr/Sonarr application.
Then it displays Activity (blue), Warning (orange) or Error (red) bubble with number in it. Just like in the Radarr/Sonarr application itself.
Two lines are needed in the config.yml :
```
type: "Radarr" or "Sonarr"
apikey: "01234deb70424befb1f4ef6a23456789"
```
The Radarr/Sonarr API key can be found in Settings > General. It is needed to access the API.

Maybe a wiki or a documentation will be needed to explain how to setup all services that can be added to _homer_.
This PR is an update of the PR #16 from feb 2020.