### PR TITLE
Fix ConnectivityChecker to evaluate the response status codes

### DIFF
--- a/src/components/ConnectivityChecker.vue
+++ b/src/components/ConnectivityChecker.vue
@@ -37,8 +37,12 @@ export default {
         method: "HEAD",
         cache: "no-store",
       })
-        .then(function () {
-          that.offline = false;
+        .then(function (response) {
+          if (response.status >= 200 && response.status < 300) {
+            that.offline = false;
+          } else {
+            that.offline = true;
+          }
         })
         .catch(function () {
           that.offline = true;


### PR DESCRIPTION
## Description
`ConnectivityChecker` does not evaluate the status code of the response it receives and won't set `offline` to `true` if an error code (e.g. `502`) is received. 

**Steps to reproduce:**
1. Run `Homer` behind a reverse proxy
2. Open the `Homer` website (to load it into the cache)
3. Stop the server hosting `Homer`
4. Open the `Homer` website again (may take a minute for the proxy to timeout the upstream gateway)

**Expected Result:**
Website displays the `offline-message`.

**Actual Result:**
Console will show a `502` on the `HEAD` request but, the `offline-message` is not shown

**Suggested Fix in this PR:** a5fe53beb2d871ec475611c4b3034871e52a190b _(Fix ConnectivityChecker to evaluate the response status codes.)_
Simply check if the response has a `2XX` code and set `offline = false` only if it does.

**Discussion:**
This probably mostly only affects users with a reverse proxy or authentication. Another possibility would be to inverse the check and look if the response is neither `4XX` nor `5XX` and allow for `3XX`. A change like this may make the project more prone to regression like the initial suggestion of #177 in combination with #8 (this was how I stumbled upon this, as the _breaking change_ I mention [here](https://github.com/bastienwirtz/homer/pull/177#discussion_r567119138) only really shows up in the console at the moment, if e.g. the page is hosted on `/homer` and `/` returns a `404`).

**Checklist:**
I've currently only tested the fix with Firefox (Linux/iOS), got an Android Device and other major browsers, just haven't had the time yet. If this is added it may also be worth it to add to the documentation when exactly the `offline-message` is shown (e.g. a `2XX` response is expected when requesting the root directory). Maybe a link under `Feature -> Offline heathcheck`?

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [ ] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [ ] I have made corresponding changes the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
