### PR TITLE
Use logo in groups

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,6 +99,8 @@ links:
 services:
   - name: "Application"
     icon: "fas fa-code-branch"
+    # A path to an image can also be provided. Note that icon take precedence if both icon and logo are set.
+    # logo: "path/to/logo"
     items:
       - name: "Awesome app"
         logo: "assets/tools/sample.png"

--- a/src/App.vue
+++ b/src/App.vue
@@ -62,6 +62,11 @@
             <template v-for="group in services">
               <h2 v-if="group.name" class="column is-full group-title">
                 <i v-if="group.icon" :class="['fa-fw', group.icon]"></i>
+                <div v-else-if="group.logo" class="group-logo media-left">
+                  <figure class="image is-48x48">
+                    <img :src="group.logo" :alt="`${group.name} logo`" />
+                  </figure>
+                </div>
                 {{ group.name }}
               </h2>
               <Service
@@ -85,6 +90,11 @@
             >
               <h2 v-if="group.name" class="group-title">
                 <i v-if="group.icon" :class="['fa-fw', group.icon]"></i>
+                <div v-else-if="group.logo" class="group-logo media-left">
+                  <figure class="image is-48x48">
+                    <img :src="group.logo" :alt="`${group.name} logo`" />
+                  </figure>
+                </div>
                 {{ group.name }}
               </h2>
               <Service

--- a/src/assets/app.scss
+++ b/src/assets/app.scss
@@ -345,3 +345,7 @@ body {
     }
   }
 }
+
+.group-logo {
+  float: left;
+}


### PR DESCRIPTION
## Description

I added on option to use logo instead of icons in groups.
I’m not sure if that how things should be done (I mostly copy-pasted things from `Generic.vue`), but it works.

Fixes  #195

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [ ] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
