### PR TITLE
Add crossorigin use-credentials attribute to manifest tag

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -12,6 +12,7 @@ module.exports = {
   publicPath: "",
   pwa: {
     manifestPath: "assets/manifest.json",
+    manifestCrossorigin: "use-credentials",
     appleMobileWebAppStatusBarStyle: "black",
     appleMobileWebAppCapable: "yes",
     name: manifestOptions.name,


### PR DESCRIPTION
## Description

When serving Homer behind an authentication proxy (ex. https://github.com/pusher/oauth2_proxy) the manifest request will fail because cookies are not sent with the manifest request.

See https://developer.mozilla.org/en-US/docs/Web/Manifest:
> Note: If the manifest requires credentials to fetch - the `crossorigin` attribute must be set to `"use-credentials"`, even if the manifest file is in the same origin as the current page.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [X] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [ ] I have made corresponding changes the documentation (README.md).
- [X] I've checked my modifications for any breaking changes, especially in the `config.yml` file
