### PR TITLE
Overrides/hides services based on detected domain

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,6 +24,26 @@ footer: '<p>Created with <span class="has-text-danger">❤️</span> with <a hre
 columns: "3" # "auto" or number (must be a factor of 12: 1, 2, 3, 4, 6, 12)
 connectivityCheck: true # whether you want to display a message when the apps are not accessible anymore (VPN disconnected for example)
 
+domainChecker: # optional domain checker
+  enabled: true
+  method: "url" # 'url' (matches browser URL) or 'ping' (pings specified URL)
+  url:
+    method: "hostname" # 'hostname' (matches hostname) or 'regex' (matches href via regex)
+    hostnames:
+      local:
+        - "localhost"
+        - "127.0.0.1"
+      remote:
+        - "github.io"
+    regex:
+      http: "^http"
+      https: "^https"
+  ping: # pings url(s) and matches domain
+    local:
+      - "http://localhost:8080"
+    remote:
+      - "github.io"
+
 # Optional theming
 theme: default # 'default' or one of the themes available in 'src/assets/themes'.
 
@@ -115,6 +135,10 @@ services:
         tag: "app"
         url: "https://www.reddit.com/r/selfhosted/"
         target: "_blank" # optional html tag target attribute
+        override: # override based on domain key
+          local: # override below properties if domain is 'local'
+            name: "Local app"
+            url: "http://localhost:8080"
       - name: "Another one"
         logo: "assets/tools/sample2.png"
         subtitle: "Another application"
@@ -127,6 +151,7 @@ services:
     items:
       - name: "Pi-hole"
         logo: "assets/tools/sample.png"
+        hidden: true # optional, hides entry by default
         # subtitle: "Network-wide Ad Blocking" # optional, if no subtitle is defined, PiHole statistics will be shown
         tag: "other"
         url: "http://192.168.0.151/admin"
@@ -134,6 +159,9 @@ services:
         target: "_blank" # optional html a tag target attribute
         # class: "green" # optional custom CSS class for card, useful with custom stylesheet
         # background: red # optional color for card to set color directly without custom stylesheet
+        override:
+          local: # shows entry if domain is "local"
+            hidden: false
 ```
 
 If you choose to fetch message information from an endpoint, the output format should be as follows (or you can [custom map fields as shown in tips-and-tricks](./tips-and-tricks.md#mapping-fields)):

--- a/src/App.vue
+++ b/src/App.vue
@@ -20,7 +20,15 @@
           </div>
           <div class="dashboard-title">
             <span class="headline">{{ config.subtitle }}</span>
+            <domain-checker 
+              v-if="config.domainChecker && config.domainChecker.enabled"
+              v-show="domain" 
+              class="domain" 
+              :config="config.domainChecker"
+              @domain-update="domain = $event"
+            /> 
             <h1>{{ config.title }}</h1>
+            
           </div>
         </div>
       </section>
@@ -134,6 +142,7 @@ import SearchInput from "./components/SearchInput.vue";
 import SettingToggle from "./components/SettingToggle.vue";
 import DarkMode from "./components/DarkMode.vue";
 import DynamicTheme from "./components/DynamicTheme.vue";
+import DomainChecker from './components/DomainChecker.vue';
 
 import defaultConfig from "./assets/defaults.yml";
 
@@ -148,11 +157,13 @@ export default {
     SettingToggle,
     DarkMode,
     DynamicTheme,
+    DomainChecker,
   },
   data: function () {
     return {
       config: null,
       services: null,
+      domain: null,
       offline: false,
       filter: "",
       vlayout: true,

--- a/src/assets/app.scss
+++ b/src/assets/app.scss
@@ -139,6 +139,18 @@ body {
           max-width: 70px;
         }
       }
+
+      .domain {
+        float: right;
+        margin-top: 5px;
+        margin-right: 15px;
+        border: none;
+        background-color: var(--highlight-hover);
+        border-radius: 5px;
+        padding: 5px;
+        color: #ffffff;
+        height: 30px;
+      }
     }
     .navbar,
     .navbar-menu {

--- a/src/components/DomainChecker.vue
+++ b/src/components/DomainChecker.vue
@@ -1,0 +1,84 @@
+<template>
+  <span>{{ domain }}</span>
+</template>
+
+<script>
+export default {
+  name: "DomainChecker",
+  props: {
+    config: Object,
+  },
+  data: function () {
+    return {
+      domain: null,
+    };
+  },
+  created() {
+    this.getDomain(this.config.method);
+  },
+  methods: {
+    checkUrl: function (config) {
+        const hostname = window.location.hostname;
+        const href = window.location.href;
+        switch (config.method) {
+          case "hostname":
+            for (const domain in config.hostnames) {
+              if (config.hostnames[domain] && config.hostnames[domain].includes(hostname)) {
+                return domain;
+              }
+            }
+            break;
+          case "regex":
+            for (const domain in config.regex) {
+              if (new RegExp(config.regex[domain]).test(href)) {
+                return domain;
+              }
+            }
+            break;
+        }
+
+        return null;
+    },
+
+    pingUrl: function (config) {
+      let that = this;
+
+      for (const domain in config) {
+        console.log(config[domain])
+        for (const url in config[domain]) {
+          return fetch(config[domain][url], {
+            method: "HEAD",
+            mode: "no-cors",
+            cache: "no-store",
+          })
+          .then(function () {
+            that.domain = domain;
+          })
+          .catch(function () {
+            that.domain = null;
+          })
+          .finally(function () {
+            that.$emit("domain-update", that.domain);
+          })
+        }
+      }
+    },
+
+    getDomain: function (method) {
+        switch (method) {
+            case "url":
+                this.domain = this.checkUrl(this.config.url);
+                this.$emit("domain-update", this.domain);
+                break;
+            case "ping":
+                this.domain = this.pingUrl(this.config.ping);
+                break;
+            default:
+                this.domain = null;
+                break;
+        }
+    },
+
+  },
+}
+</script>

--- a/src/components/Service.vue
+++ b/src/components/Service.vue
@@ -1,5 +1,5 @@
 <template>
-  <component v-bind:is="component" :item="item"></component>
+  <component v-bind:is="component" :item="domainOverride(item, domain)" v-show="!item.hidden"></component>
 </template>
 
 <script>
@@ -12,8 +12,21 @@ export default {
   },
   props: {
     item: Object,
+
+  },
+  methods: {
+    domainOverride(item, domain) {
+      if (item.override && item.override[domain]) {
+        return Object.assign(item, item.override[domain]);
+      } else {
+        return item
+      }
+    }
   },
   computed: {
+    domain() {
+      return this.$parent.domain
+    },
     component() {
       const type = this.item.type || "Generic";
       if (type == "Generic") {


### PR DESCRIPTION
## Description

This PR introduces an optional feature to detect what "domain" the user is on (e.g. local, remote, vps, etc.) based on user-configured rules, and allows overriding properties & hiding services based on this.

For example, the domain can be detected as "local" if browser address bar hostname matches either of "127.0.0.1", "localhost", or if "http://127.0.0.1:8080" pings successfully.

![Screenshot-20210620224930-479x185](https://user-images.githubusercontent.com/64436699/122678881-2c0e0b80-d21b-11eb-8a37-f6100c29e35b.png)

The following are implemented:
- Rules to detect domain based on:
  - Browser address bar URL (detects domain from user-defined hostname list, or full URL via regex)
  - URL pinging (matches domain group based on URL list ping success)
- Show the detected domain on top-right corner
- Flag to show/hide services
- Override service properties if domain matched

Configuration additions are described in [docs/configuration.md](docs/configuration.md).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
