### PR TITLE
Added feature for subfolder hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ docker run -d \
 
 Default assets will be automatically installed in the `/www/assets` directory. Use `UID` and/or `GID` env var to change the assets owner (`docker run -e "UID=1000" -e "GID=1000" [...]`).
 
+## Host in subfolder
+
+If you would like to host Homer in a subfolder, for e.g. behind a reverse proxy, supply the name of subfolder by using the `SUBFOLDER` env var.
+
 ### Using docker-compose
 
 The `docker-compose.yml` file must be edited to match your needs.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,5 +11,11 @@ fi
 # Install default config if no one is available.
 yes n | cp -i /www/default-assets/config.yml.dist /www/assets/config.yml &> /dev/null
 
+# Create symbolic link for hosting in subfolder.
+if [[ -n "${SUBFOLDER}" ]]; then
+  ln -s /www "/www/$SUBFOLDER"
+  chown -h $USER:$GROUP "/www/$SUBFOLDER"
+fi
+
 chown -R $UID:$GID /www/assets
 exec su-exec $UID:$GID darkhttpd /www/ --no-listing --port "$PORT"


### PR DESCRIPTION
By setting the SUBFOLDER env var, you can host Homer in a subfolder behind a reverse proxy.

## Description

I would like to host Homer behind a reverse proxy (traefik) in a subfolder. With using the StripPrefix middleware, the index page is loading but couldnt load any assets, because they had still absolute urls. To get this working, I have added a little modification to the entrypoint.sh script, which adds a symbolic link to the /www directory. This symbolic link has the name of the subfolder and points to the /www directory itself. So the application is available under yourdomain.com/ and yourdomain.com/<nameofyoursubfolder>/.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
