### PR TITLE
fix card border radius when it's the only child

### DIFF
--- a/src/assets/app.scss
+++ b/src/assets/app.scss
@@ -224,7 +224,6 @@ body {
   }
 
   .card {
-    border-radius: 5px;
     border: none;
     box-shadow: 0 2px 15px 0 rgba(0, 0, 0, 0.1);
     transition: cubic-bezier(0.165, 0.84, 0.44, 1) 300ms;
@@ -260,11 +259,13 @@ body {
     }
 
     .column div:first-of-type .card {
-      border-radius: 5px 5px 0 0;
+      border-top-left-radius: 0.25rem;
+      border-top-right-radius: 0.25rem;
     }
 
     .column div:last-child .card {
-      border-radius: 0 0 5px 5px;
+      border-bottom-left-radius: 0.25rem;
+      border-bottom-right-radius: 0.25rem;
     }
   }
 


### PR DESCRIPTION
## Description

### Context
When there's only one card, the css rule `body .layout-vertical .column div:last-child .card` (line 266 of `src/assets/app.scss`) kicks in as it is indeed the "last-child" in this scenario. However, the css property `border-radius: 0 0 5px 5px;` caused the `top-left` and `top-right` border radius to reset to 0, which shouldn't be the case for a single child card should have all rounded corners.

Screenshot of issue & devtools to show the css selector involved:
![chrome_Q6OnL6lO7T](https://user-images.githubusercontent.com/42867097/123187223-4d495300-d4cc-11eb-9b37-bf60967078eb.png)

Just to ensure this is not caused by my custom css in the screenshot (which just changes the color variables provided & font), we can also see the same behavior over at the demo page here: https://homer-demo.netlify.app/#additionnal-page

### Summary of change
When I was checking the stylesheet, I noticed there's an approach using `border-top-left-radius` etc to make sure we don't reset other corners to 0, and apparently it came from the bulma css as seen here: 
![chrome_oV1wHgyW9N](https://user-images.githubusercontent.com/42867097/123187367-9c8f8380-d4cc-11eb-9871-809276fa19c2.png)

By mimicking the same approach, I then changed `body .layout-vertical .column div:last-child .card` and `body .layout-vertical .column div:first-of-type .card` to fix the issue, and here's an after screenshot (with list 2 being unaffected at all):
![chrome_MZzl1bkS9G](https://user-images.githubusercontent.com/42867097/123187602-10319080-d4cd-11eb-99b9-dfeaaceacb6d.png)

Lastly since Bulma also has `border-radius: 0.25rem` by default for the `.card` class, I removed it at line 227 so that it will be uniformly 0.25rem.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [ ] I have made corresponding changes the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
