### PR TITLE
Add Collapsible Service Groups

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -124,6 +124,8 @@ services:
         url: "#"
   - name: "Other group"
     icon: "fas fa-heartbeat"
+    # Optionally make this group collapsable, and set default state to open
+    collapsed: false
     items:
       - name: "Pi-hole"
         logo: "assets/tools/sample.png"

--- a/public/assets/config.yml.dist
+++ b/public/assets/config.yml.dist
@@ -68,6 +68,7 @@ links:
 services:
   - name: "Applications"
     icon: "fas fa-cloud"
+    collapsed: false # optionally make group collapsable, default state is true/false for new connections
     items:
       - name: "Awesome app"
         logo: "assets/tools/sample.png"

--- a/src/App.vue
+++ b/src/App.vue
@@ -62,8 +62,8 @@
           <!-- Horizontal layout -->
           <div v-if="!vlayout || filter">
             <Accordion
-              v-for="(group, groupIndex) in services"
-              :key="group.name + groupIndex"
+              v-for="group in services"
+              :key="group.name"
               v-bind:group="group"
               v-bind:horizontal="true"
               v-bind:width="12 / config.columns"
@@ -76,8 +76,8 @@
             class="columns is-multiline layout-vertical"
           >
             <Accordion
-              v-for="(group, groupIndex) in services"
-              :key="group.name + groupIndex"
+              v-for="group in services"
+              :key="group.name"
               v-bind:group="group"
               v-bind:horizontal="false"
               v-bind:width="12 / config.columns"

--- a/src/App.vue
+++ b/src/App.vue
@@ -110,7 +110,6 @@ import SearchInput from "./components/SearchInput.vue";
 import SettingToggle from "./components/SettingToggle.vue";
 import DarkMode from "./components/DarkMode.vue";
 import DynamicTheme from "./components/DynamicTheme.vue";
-
 import Accordion from "./components/Accordion.vue";
 
 import defaultConfig from "./assets/defaults.yml";

--- a/src/App.vue
+++ b/src/App.vue
@@ -60,24 +60,14 @@
           <Message :item="config.message" />
 
           <!-- Horizontal layout -->
-          <div v-if="!vlayout || filter" class="columns is-multiline">
-            <template v-for="group in services">
-              <h2 v-if="group.name" class="column is-full group-title">
-                <i v-if="group.icon" :class="['fa-fw', group.icon]"></i>
-                <div v-else-if="group.logo" class="group-logo media-left">
-                  <figure class="image is-48x48">
-                    <img :src="group.logo" :alt="`${group.name} logo`" />
-                  </figure>
-                </div>
-                {{ group.name }}
-              </h2>
-              <Service
-                v-for="(item, index) in group.items"
-                :key="index"
-                v-bind:item="item"
-                :class="['column', `is-${12 / config.columns}`]"
-              />
-            </template>
+          <div v-if="!vlayout || filter">
+            <Accordion
+              v-for="(group, groupIndex) in services"
+              :key="group.name + groupIndex"
+              v-bind:group="group"
+              v-bind:horizontal="true"
+              v-bind:width="12 / config.columns"
+            />
           </div>
 
           <!-- Vertical layout -->
@@ -85,26 +75,13 @@
             v-if="!filter && vlayout"
             class="columns is-multiline layout-vertical"
           >
-            <div
-              :class="['column', `is-${12 / config.columns}`]"
-              v-for="group in services"
-              :key="group.name"
-            >
-              <h2 v-if="group.name" class="group-title">
-                <i v-if="group.icon" :class="['fa-fw', group.icon]"></i>
-                <div v-else-if="group.logo" class="group-logo media-left">
-                  <figure class="image is-48x48">
-                    <img :src="group.logo" :alt="`${group.name} logo`" />
-                  </figure>
-                </div>
-                {{ group.name }}
-              </h2>
-              <Service
-                v-for="(item, index) in group.items"
-                :key="index"
-                v-bind:item="item"
-              />
-            </div>
+            <Accordion
+              v-for="(group, groupIndex) in services"
+              :key="group.name + groupIndex"
+              v-bind:group="group"
+              v-bind:horizontal="false"
+              v-bind:width="12 / config.columns"
+            />
           </div>
         </div>
       </div>
@@ -128,12 +105,13 @@ const merge = require("lodash.merge");
 
 import Navbar from "./components/Navbar.vue";
 import ConnectivityChecker from "./components/ConnectivityChecker.vue";
-import Service from "./components/Service.vue";
 import Message from "./components/Message.vue";
 import SearchInput from "./components/SearchInput.vue";
 import SettingToggle from "./components/SettingToggle.vue";
 import DarkMode from "./components/DarkMode.vue";
 import DynamicTheme from "./components/DynamicTheme.vue";
+
+import Accordion from "./components/Accordion.vue";
 
 import defaultConfig from "./assets/defaults.yml";
 
@@ -142,12 +120,12 @@ export default {
   components: {
     Navbar,
     ConnectivityChecker,
-    Service,
     Message,
     SearchInput,
     SettingToggle,
     DarkMode,
     DynamicTheme,
+    Accordion,
   },
   data: function () {
     return {

--- a/src/assets/app.scss
+++ b/src/assets/app.scss
@@ -254,16 +254,16 @@ body {
     padding: 1.3rem;
   }
 
-  .layout-vertical {
+  .layout-vertical {    
     .card {
       border-radius: 0;
     }
 
-    .column div:first-of-type .card {
+    .column div div:first-of-type .card {
       border-radius: 5px 5px 0 0;
     }
 
-    .column div:last-child .card {
+    .column div div:last-child .card {
       border-radius: 0 0 5px 5px;
     }
   }
@@ -348,4 +348,27 @@ body {
 
 .group-logo {
   float: left;
+}
+
+
+
+
+
+// Accordion dropdown animation
+.dropdown-leave-active {
+  animation: growDown 150ms ease-in-out reverse;
+  transform-origin: top center;
+}
+.dropdown-enter-active {
+  animation: growDown 150ms ease-in-out forwards;
+  transform-origin: top center;
+}
+
+@keyframes growDown {
+  0% {
+    transform: scaleY(0)
+  }
+  100% {
+    transform: scaleY(1)
+  }
 }

--- a/src/assets/app.scss
+++ b/src/assets/app.scss
@@ -350,10 +350,6 @@ body {
   float: left;
 }
 
-
-
-
-
 // Accordion dropdown animation
 .dropdown-leave-active {
   animation: growDown 150ms ease-in-out reverse;

--- a/src/assets/app.scss
+++ b/src/assets/app.scss
@@ -350,6 +350,10 @@ body {
   float: left;
 }
 
+.pointer {
+  cursor: pointer;
+}
+
 // Accordion dropdown animation
 .dropdown-leave-active {
   animation: growDown 150ms ease-in-out reverse;

--- a/src/components/Accordion.vue
+++ b/src/components/Accordion.vue
@@ -30,15 +30,23 @@
           open ? 'fa-chevron-down' : 'fa-chevron-up',
           'media-right',
         ]"
+        style="float:right;"
       ></i>
     </h2>
-    <Service
-      :class="{ column: horizontal, [`is-${width}`]: horizontal }"
-      v-show="open"
-      v-for="(item, index) in group.items"
-      :key="index"
-      v-bind:item="item"
-    />
+    
+    <transition name="dropdown">
+      <div
+        v-if="open"
+        :class="{'column is-full columns is-multiline':horizontal}"
+      >
+        <Service
+          :class="{ column: horizontal, [`is-${width}`]: horizontal }"
+          v-for="(item, index) in group.items"
+          :key="index"
+          v-bind:item="item"
+        />
+      </div>
+    </transition>
   </div>
 </template>
 

--- a/src/components/Accordion.vue
+++ b/src/components/Accordion.vue
@@ -78,9 +78,15 @@ export default {
       vertical: !this.horizontal,
     };
   },
+  created: function() {
+    if (this.group.name + "_Open" in localStorage) {
+      this.open = this.value = JSON.parse(localStorage[this.group.name + "_Open"]);
+    }
+  },
   methods: {
     toggle() {
       this.open = !this.open;
+      localStorage[this.group.name + "_Open"] = this.open;
     },
   },
 };

--- a/src/components/Accordion.vue
+++ b/src/components/Accordion.vue
@@ -11,10 +11,10 @@
       :class="[
         {
           'column is-full': horizontal,
+          pointer: this.group.collapsed !== undefined,
         },
         'group-title',
       ]"
-      style="cursor: pointer"
       v-on:click="toggle"
     >
       <i v-if="group.icon" :class="['fa-fw', group.icon]"></i>
@@ -25,6 +25,7 @@
       </div>
       {{ group.name }}
       <i
+        v-if="this.group.collapsed !== undefined"
         :class="[
           'fas',
           open ? 'fa-chevron-down' : 'fa-chevron-up',
@@ -80,15 +81,17 @@ export default {
   },
   created: function () {
     if (this.group.name + "_Open" in localStorage) {
-      this.open = this.value = JSON.parse(
-        localStorage[this.group.name + "_Open"]
-      );
+      this.open = JSON.parse(localStorage[this.group.name + "_Open"]);
+    } else {
+      this.open = this.group.collapsed ? false : true;
     }
   },
   methods: {
     toggle() {
-      this.open = !this.open;
-      localStorage[this.group.name + "_Open"] = this.open;
+      if (this.group.collapsed !== undefined) {
+        this.open = !this.open;
+        localStorage[this.group.name + "_Open"] = this.open;
+      }
     },
   },
 };

--- a/src/components/Accordion.vue
+++ b/src/components/Accordion.vue
@@ -2,7 +2,7 @@
   <div
     :class="{
       'columns is-multiline': horizontal,
-      'column': vertical,
+      column: vertical,
       [`is-${width}`]: vertical,
     }"
   >
@@ -30,14 +30,14 @@
           open ? 'fa-chevron-down' : 'fa-chevron-up',
           'media-right',
         ]"
-        style="float:right;"
+        style="float: right"
       ></i>
     </h2>
-    
+
     <transition name="dropdown">
       <div
         v-if="open"
-        :class="{'column is-full columns is-multiline':horizontal}"
+        :class="{ 'column is-full columns is-multiline': horizontal }"
       >
         <Service
           :class="{ column: horizontal, [`is-${width}`]: horizontal }"
@@ -78,9 +78,11 @@ export default {
       vertical: !this.horizontal,
     };
   },
-  created: function() {
+  created: function () {
     if (this.group.name + "_Open" in localStorage) {
-      this.open = this.value = JSON.parse(localStorage[this.group.name + "_Open"]);
+      this.open = this.value = JSON.parse(
+        localStorage[this.group.name + "_Open"]
+      );
     }
   },
   methods: {

--- a/src/components/Accordion.vue
+++ b/src/components/Accordion.vue
@@ -1,0 +1,79 @@
+<template>
+  <div
+    :class="{
+      'columns is-multiline': horizontal,
+      'column': vertical,
+      [`is-${width}`]: vertical,
+    }"
+  >
+    <h2
+      v-if="group.name"
+      :class="[
+        {
+          'column is-full': horizontal,
+        },
+        'group-title',
+      ]"
+      style="cursor: pointer"
+      v-on:click="toggle"
+    >
+      <i v-if="group.icon" :class="['fa-fw', group.icon]"></i>
+      <div v-else-if="group.logo" class="group-logo media-left">
+        <figure class="image is-48x48">
+          <img :src="group.logo" :alt="`${group.name} logo`" />
+        </figure>
+      </div>
+      {{ group.name }}
+      <i
+        :class="[
+          'fas',
+          open ? 'fa-chevron-down' : 'fa-chevron-up',
+          'media-right',
+        ]"
+      ></i>
+    </h2>
+    <Service
+      :class="{ column: horizontal, [`is-${width}`]: horizontal }"
+      v-show="open"
+      v-for="(item, index) in group.items"
+      :key="index"
+      v-bind:item="item"
+    />
+  </div>
+</template>
+
+<script>
+import Service from "./Service.vue";
+
+export default {
+  name: "Accordion",
+  components: {
+    Service,
+  },
+  props: {
+    group: {
+      required: true,
+      type: Object,
+    },
+    horizontal: {
+      required: true,
+      type: Boolean,
+    },
+    width: {
+      required: true,
+      type: Number,
+    },
+  },
+  data: function () {
+    return {
+      open: true,
+      vertical: !this.horizontal,
+    };
+  },
+  methods: {
+    toggle() {
+      this.open = !this.open;
+    },
+  },
+};
+</script>


### PR DESCRIPTION
## Description

This change adds functionality to collapse service groups.
- Each group can have its own collapsible panel
- Clicking the group heading hides/shows the list of services for that group, and saves the state in localstorage
- Individual groups can be configured to become collapsible with the `collapsed` config attribute, and the default (open/closed) state can be specified

Fixes #161 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
