### PR TITLE
add health_url

### DIFF
--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -47,7 +47,80 @@ The Radarr/Sonarr API key can be found in Settings > General. It is needed to ac
 
 For Paperless you need an API-Key which you have to store at the item in the field `apikey`.
 
-
 ## Ping
 
-For Paperless you need an API-Key which you have to store at the item in the field `apikey`.
+The ping service to "ping" a service by sending a http request to the them. If the request is successful then service will be marked as `online` otherwise `offline`.
+
+### CORS Issues
+
+If try you to "ping" services, which have a differ domain as the homer service then may you get a `Cross-Origin Request Blocked` messages (https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors).
+
+Possible solutions:
+
+* Modify the target sever configuration so that the response of the server included following header- `Access-Control-Allow-Origin: *` (https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests)
+* Find a url, where the server add the `Access-Control-Allow-Origin: *` header (e.g. a api url).
+* Use a cors proxy sever  like `cors-container` (https://github.com/imjacobclark/cors-container)
+
+### Example confiq.yml file
+
+```yml
+---
+title: "Demo dashboard"
+subtitle: "Homer"
+logo: "logo.png"
+
+header: true
+footer: false
+
+services:
+  - name: "Applications"
+    icon: "fas fa-cloud"
+    items:
+      - name: "Awesome app"
+        type: Ping
+        logo: "assets/tools/sample.png"
+        subtitle: "Bookmark example"
+        tag: "app"
+        url: "https://www.reddit.com/r/selfhosted/"
+        # domain name and protocol (http/https) have to be the same of the homer server
+        health_url: "http://localhost:3000/https://www.reddit.com/r/selfhosted/"
+      - name: "Github repo"
+        type: Ping
+        icon: "fab fa-github"
+        tag: "app"
+        url: "https://github.com/bastienwirtz/homer"
+        health_url: "https://api.github.com/repos/bastienwirtz/homer"
+      - name: "Another one"
+        type: Ping
+        logo: "assets/tools/sample2.png"
+        subtitle: "Another application"
+        tag: "app"
+        url: "#"
+```
+### Example docker compose file
+
+```yml
+---
+version: "2"
+services:
+  homer:
+    image: b4bz/homer
+    #To build from source, comment previous line and uncomment below
+    #build: .
+    container_name: homer
+    volumes:
+      - /your/local/assets/:/www/assets
+    ports:
+      - 8080:8080
+    #environment:
+    #  - UID=1000
+    #  - GID=1000
+    restart: unless-stopped
+  #The cors-container service which avoid "allow" cross-domain requests, can use with the CorsPing type
+  cors-container:
+    image: imjacobclark/cors-container:latest
+    container_name: cors-container
+    ports:
+      - 3000:3000
+    restart: unless-stopped
+```

--- a/src/components/services/Ping.vue
+++ b/src/components/services/Ping.vue
@@ -49,7 +49,7 @@ export default {
   },
   methods: {
     fetchStatus: async function () {
-      const url = `${this.item.url}`;
+      const url = typeof this.item.health_url === 'undefined' ? `${this.item.url}` : `${this.item.health_url}`;
       fetch(url, { method: "HEAD", cache: "no-cache" })
         .then((response) => {
           if (!response.ok) {


### PR DESCRIPTION
## Description

@zanna-37 mention in pr  #255 to extend the ping service by a `health_url` instead of add a new  service type `CorsPing`.

Now the ping will check if the `health_url` is set. If it is, then it use  the value  of field `health_url` for the fetch call. Otherwise  the `url` field will still be used.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
