### PR TITLE
Run the project on a subpath

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # build stage
 FROM node:lts-alpine as build-stage
 
+ENV PUBLIC_PATH ""
+
 WORKDIR /app
 
 COPY package*.json ./

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -1,6 +1,8 @@
 # build stage
 FROM node:lts-alpine as build-stage
 
+ENV PUBLIC_PATH ""
+
 WORKDIR /app
 
 COPY package*.json ./

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -1,6 +1,8 @@
 # build stage
 FROM node:lts-alpine as build-stage
 
+ENV PUBLIC_PATH ""
+
 WORKDIR /app
 
 COPY package*.json ./

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ docker run -d \
   b4bz/homer:latest
 ```
 
-Default assets will be automatically installed in the `/www/assets` directory. Use `UID` and/or `GID` env var to change the assets owner (`docker run -e "UID=1000" -e "GID=1000" [...]`).
+Default assets will be automatically installed in the `/www/assets` directory. Use `UID` and/or `GID` env var to change the assets owner (`docker run -e "UID=1000" -e "GID=1000" [...]`). If you want to run the project under a sub-path rather than a domain or subdomain (e.g. `mydomain.com/homer/`) you can assign the `PUBLIC_PATH` env var with value of your path (note the sub-path must have a [trailing slash](https://cli.vuejs.org/config/#publicpath)).
 
 ### Using docker-compose
 
@@ -107,6 +107,20 @@ Default assets will be automatically installed in the `/www/assets` directory. U
 environment:
   - UID=1000
   - GID=1000
+```
+
+Use the `PUBLIC_PATH` env var to run the project under a specific path in the `docker-compose.yml`:
+
+```yaml
+environment:
+  - PUBLIC_PATH="/homer/"
+```
+
+To run an example of the project using a sub-path behind traefik, as a reverse-proxy, run the following:
+
+```sh
+cd /path/to/docker-compose.subpath.yml
+docker-compose -f docker-compose.subpath.yml up -d
 ```
 
 ### Using the release tarball (prebuilt, ready to use)

--- a/docker-compose.subpath.yml
+++ b/docker-compose.subpath.yml
@@ -1,0 +1,50 @@
+---
+version: "3"
+
+services:
+  homer:
+    image: b4bz/homer
+    #To build from source, comment previous line and uncomment below
+    # build: .
+    environment:
+      PUBLIC_PATH: "/homer/"
+      #  - UID=1000
+      #  - GID=1000
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.homer.entrypoints=web"
+      - "traefik.http.routers.homer.rule=Host(`localhost`) && PathPrefix(`/homer`)"
+      - "traefik.http.middlewares.homer-stripprefix.stripprefix.prefixes=/homer"
+      - "traefik.http.middlewares.homer-redirectregex.redirectregex.regex=^(.*)/homer$$"
+      - "traefik.http.middlewares.homer-redirectregex.redirectregex.replacement=$$1/homer/"
+      - "traefik.http.middlewares.homer-redirectregex.redirectregex.permanent=true"
+      - "traefik.http.routers.homer.middlewares=homer-redirectregex, homer-stripprefix"
+      - "traefik.http.routers.homer.service=homer"
+      - "traefik.http.services.homer.loadbalancer.server.port=8080"
+    networks:
+      - traefik
+    restart: unless-stopped
+    # volumes:
+    #   - /your/local/assets/:/www/assets
+
+  traefik:
+    image: traefik
+    command:
+      - "--accesslog=true"
+      - "--entrypoints.web.address=:80"
+      - "--providers.docker=true"
+      - "--providers.docker.endpoint=unix:///var/run/docker.sock"
+      - "--providers.docker.exposedbydefault=false"
+      - "--providers.docker.network=traefik"
+      - "--providers.docker.watch=true"
+    networks:
+      - traefik
+    ports:
+      - "80:80"
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
+networks:
+  traefik:
+    name: traefik

--- a/vue.config.js
+++ b/vue.config.js
@@ -9,7 +9,7 @@ module.exports = {
       .loader("raw-loader")
       .end();
   },
-  publicPath: "",
+  publicPath: process.env.PUBLIC_PATH,
   pwa: {
     manifestPath: "assets/manifest.json",
     manifestCrossorigin: "use-credentials",


### PR DESCRIPTION
## Description

This PR gives you the ability to run the project under a subpath (e.g. mydomain.com/homer/), such as behind a reverse-proxy like traefik or nginx. I noticed there was another PR (#238) attempting to solve the same issue, but that solution is only applicable for docker builds. Since this PR uses an env var for the value of `publicPath` it will be relevant for all deployments. I've included an example docker-compose file to show how to run the project with a subpath behind traefik.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
