### PR TITLE
Fix #312 Vue warning in dev mode when having multiple service groups in list mode

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -73,7 +73,7 @@
               </h2>
               <Service
                 v-for="(item, index) in group.items"
-                :key="index"
+                :key="group.name + '-' + index"
                 :item="item"
                 :proxy="config.proxy"
                 :class="['column', `is-${12 / config.columns}`]"


### PR DESCRIPTION
## Description

Something I've noticed while working on #311, if multiple service groups are declared, Vue will raise warnings when rendering them in list mode, as they are using they service group index as a key, while all being rendered in the same div (which is why it's only an issue in list mode, in column they are in separate divs). This fix changes the key to use the service group name, as the alternatives would be to isolate each group which would require way more changes to keep things displaying the same.


Before:
![Screenshot from 2021-10-12 11-59-50](https://user-images.githubusercontent.com/3518172/136873005-c89b3cc5-3e1b-47eb-a575-40e6676a23f5.png)

After:
![Screenshot from 2021-10-12 12-00-15](https://user-images.githubusercontent.com/3518172/136873019-53de52d4-2f3b-47f3-8840-8d967e2ecb15.png)


Fixes #312

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [X] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [X] I have made corresponding changes to the documentation (README.md).
- [X] I've checked my modifications for any breaking changes, especially in the `config.yml` file
