### PR TITLE
fixed Ping documentation yaml

### DIFF
--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -97,8 +97,9 @@ For Ping you need to set the type to Ping and provide a url.
 - name: "Awesome app"
   type: Ping
   logo: "assets/tools/sample.png"
-  subtitle: "Bookmark example" tag: "app" 
-  url: "https://www.reddit.com/r/selfhosted/" 
+  subtitle: "Bookmark example"
+  tag: "app"
+  url: "https://www.reddit.com/r/selfhosted/"
 ```
 
 ## Prometheus


### PR DESCRIPTION
## Description

Fixed yaml example of the Ping service. The `tag` was in the same line as `subtitle` which broke the `config.yml` for me. 

see also #249 (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
