### PR TITLE
Add docker build-arg to disable PWA / serviceworker (Fixes #232)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-
 # build stage
 FROM node:lts-alpine as build-stage
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+
 # build stage
 FROM node:lts-alpine as build-stage
 
@@ -7,6 +8,7 @@ COPY package*.json ./
 RUN yarn install --frozen-lockfile
 
 COPY . .
+ARG VUE_APP_DISABLE_PWA=false
 RUN yarn build
 
 # production stage

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -1,3 +1,4 @@
+
 # build stage
 FROM node:lts-alpine as build-stage
 
@@ -7,6 +8,7 @@ COPY package*.json ./
 RUN yarn install --frozen-lockfile
 
 COPY . .
+ARG VUE_APP_DISABLE_PWA=false
 RUN yarn build
 
 # Multi arch build support

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -1,4 +1,3 @@
-
 # build stage
 FROM node:lts-alpine as build-stage
 

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -1,3 +1,4 @@
+
 # build stage
 FROM node:lts-alpine as build-stage
 
@@ -7,6 +8,7 @@ COPY package*.json ./
 RUN yarn install --frozen-lockfile
 
 COPY . .
+ARG VUE_APP_DISABLE_PWA=false
 RUN yarn build
 
 # Multi arch build support

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -1,4 +1,3 @@
-
 # build stage
 FROM node:lts-alpine as build-stage
 

--- a/src/registerServiceWorker.js
+++ b/src/registerServiceWorker.js
@@ -2,7 +2,7 @@
 
 import { register } from "register-service-worker";
 
-if (process.env.NODE_ENV === "production") {
+if (process.env.NODE_ENV === "production" && process.env.VUE_APP_DISABLE_PWA !== "true") {
   register(`${process.env.BASE_URL}service-worker.js`, {
     ready() {
       console.log(


### PR DESCRIPTION
## Description

This PR introduces a build argument to disable the registration of the service worker. Therefore, homer is no longer installed as a progressive web app (PWA) when the build argument was provided during build. That fixes problems when using homer behind an authenticating proxy such as Authalia or oauth2-proxy.

The build argument can be added to the Docker build using `docker build --build-arg VUE_APP_DISABLE_PWA=true .`.
When the build argument is not provided, Homer is build like normal, inlcuding the PWA.

I propose releasesing two versions of the Docker image: one with PWA & one without PWA. Example: latest & latest-no-pwa.

Fixes #232 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [X] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [X] I have made corresponding changes to the documentation (README.md).
- [X] I've checked my modifications for any breaking changes, especially in the `config.yml` file
