### PR TITLE
Warn about exposed apikeys

### DIFF
--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -1,7 +1,11 @@
 # Custom Services
 
 Some service can use a specific a component that provides some extra features by adding a `type` key to the service yaml
-configuration. Available services are in `src/components/`. Here is an overview of all custom services that are available
+configuration and, where applicable, an apikey. Note that config.yml is exposed at /assets/config.yml via HTTP and any
+apikey included in the configuration file is exposed to anyone who can access the homer instance. Only include an apikey
+if your homer instance is secured behind some form of authentication or access restriction.
+
+Available services are in `src/components/`. Here is an overview of all custom services that are available
 within Homer.
 
 If you experiencing any issue, please have a look to the [troubleshooting](troubleshooting.md) page.


### PR DESCRIPTION
## Description

The config.yml is loaded by the client at /assets/config.yml and a request made to the "serverurl?apikey=..." for custom services.

All of this is fine, but is should be clearly pointed out that the homer dashboard when including your apikey should not be exposed to untrusted users.  This seems like a documentation issue which could easily be added.

Fixes # (issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [X] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [X] I have made corresponding changes to the documentation (README.md).
- [X] I've checked my modifications for any breaking changes, especially in the `config.yml` file
