### PR TITLE
Include credentials when calling Pi Hole API

### DIFF
--- a/src/components/services/PiHole.vue
+++ b/src/components/services/PiHole.vue
@@ -49,7 +49,7 @@ export default {
   },
   methods: {
     fetchStatus: async function () {
-      const result = await this.fetch("/api.php").catch((e) => console.log(e));
+      const result = await this.fetch("/api.php", {credentials: 'include'}).catch((e) => console.log(e));
 
       this.status = result.status;
       this.ads_percentage_today = result.ads_percentage_today;


### PR DESCRIPTION
## Description

When Pi Hole is protected with an authentication server like authelia, homer needs to include the credentials when calling the API.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
