### PR TITLE
Fix(entrypoint.sh): Skip chown & su-exec when running as non-root | Fixes: #325 & #261

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,5 +11,10 @@ fi
 # Install default config if no one is available.
 yes n | cp -i /www/default-assets/config.yml.dist /www/assets/config.yml &> /dev/null
 
-chown -R $UID:$GID /www/assets
-exec su-exec $UID:$GID darkhttpd /www/ --no-listing --port "$PORT"
+# Skip chown & su-exec if we are already non-root
+if [ "$(whoami)" == "root" ] ; then
+    chown -R $UID:$GID /www/assets
+    exec su-exec $UID:$GID darkhttpd /www/ --no-listing --port "$PORT"
+else
+    exec darkhttpd /www/ --no-listing --port "$PORT"
+fi


### PR DESCRIPTION
## Description

This is a simple workaround in the `entrypoint.sh` which makes homer fully working when running as non-root e.g. on kubernetes.

It makes homer compatible with the full set of [pod]securityContexts:

``` yaml
podSecurityContext:
  runAsNonRoot: true
  runAsUser: 911
  runAsGroup: 911
  fsGroup: 911

securityContext:
  privileged: false
  allowPrivilegeEscalation: false
  readOnlyRootFilesystem: true
  runAsUser: 911
  runAsGroup: 911
```

Fixes #325 & #261 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [ ] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
