### PR TITLE
Change Radarr/Sonarr v3 to use totalRecords

### DIFF
--- a/src/components/services/Radarr.vue
+++ b/src/components/services/Radarr.vue
@@ -83,11 +83,7 @@ export default {
               }
             }
           } else {
-            for (const record of queue.records) {
-              if (record.movieId) {
-                this.activity++;
-              }
-            }
+            this.activity = queue.totalRecords;
           }
         })
         .catch((e) => {

--- a/src/components/services/Sonarr.vue
+++ b/src/components/services/Sonarr.vue
@@ -83,11 +83,7 @@ export default {
               }
             }
           } else {
-            for (const record of queue.records) {
-              if (record.seriesId) {
-                this.activity++;
-              }
-            }
+            this.activity = queue.totalRecords;
           }
         })
         .catch((e) => {


### PR DESCRIPTION
Finally got CORS problems solved, and radarr/sonarr are returning 10 as the activity count (10 being the record count per page). Looks like the v3 api has a "totalRecords" field with the correct value, though. Should be faster to parse too.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] (N/A) I have made corresponding changes to the documentation (README.md).
- [x] (N/A) I've checked my modifications for any breaking changes, especially in the `config.yml` file
