### PR TITLE
Check if path has data before adding a trailing slash (/)

### DIFF
--- a/src/mixins/service.js
+++ b/src/mixins/service.js
@@ -31,7 +31,13 @@ export default {
         path = path.slice(1);
       }
 
-      return fetch(`${this.endpoint}/${path}`, options).then((response) => {
+      let url = this.endpoint;
+
+      if (path) {
+        url = `${this.endpoint}/${path}`;
+      }
+
+      return fetch(url, options).then((response) => {
         if (!response.ok) {
           throw new Error("Not 2xx response");
         }


### PR DESCRIPTION
## Description

This modifies the fetch method to check if the path variable has data before adding a trailing slash. Currently by not doing this services using the Ping type always have a trailing slash added to the end of the specified `endpoint` or `url` value. Depending on if the endpoint expects this, this can break the ping check.

The current return value is assuming that `${path}` is always present, this is not always the case or at least isn't with the Ping type, as demonstrated with reported issue/example from the linked GitHub issue.

This change will ensure the contents of `${path}` is added when it's present, otherwise it won't leave a trailing slash in the return value when it is not needed.

Fixes #374

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [X] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- ~~I have made corresponding changes to the documentation (README.md).~~
- [X] I've checked my modifications for any breaking changes, especially in the `config.yml` file
