### PR TITLE
Portainer service - Fix for down endpoints

### DIFF
--- a/src/components/services/Portainer.vue
+++ b/src/components/services/Portainer.vue
@@ -90,7 +90,7 @@ export default {
           }
         );
 
-        if(endpointContainers){
+        if (endpointContainers) {
           containers = containers.concat(endpointContainers);
         }
       }

--- a/src/components/services/Portainer.vue
+++ b/src/components/services/Portainer.vue
@@ -90,7 +90,9 @@ export default {
           }
         );
 
-        containers = containers.concat(endpointContainers);
+        if(endpointContainers){
+          containers = containers.concat(endpointContainers);
+        }
       }
 
       this.containers = containers;


### PR DESCRIPTION
## Description

When Portainer has multiples endpoints, if one was down then the service would crash (the variable endpointContainers being 'undefined'). This fix just add a condition to add the endpoint containers if they exist/are up.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
