### PR TITLE
Prepping for a proxy API implementation

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -84,6 +84,7 @@
                 :key="index"
                 :item="item"
                 :proxy="config.proxy"
+                :forwarder="config.forwarder"
                 :class="['column', `is-${12 / config.columns}`]"
               />
             </template>
@@ -113,6 +114,7 @@
                 :key="index"
                 :item="item"
                 :proxy="config.proxy"
+                :forwarder="config.forwarder"
               />
             </div>
           </div>

--- a/src/assets/defaults.yml
+++ b/src/assets/defaults.yml
@@ -53,3 +53,4 @@ services: []
 
 
 proxy: ~
+forwarder: ~

--- a/src/mixins/service.js
+++ b/src/mixins/service.js
@@ -3,6 +3,7 @@ const merge = require("lodash.merge");
 export default {
   props: {
     proxy: Object,
+    forwarder: Object,
   },
   created: function () {
     // custom service often consume info from an API using the item link (url) as a base url,
@@ -27,9 +28,9 @@ export default {
           this.item.useCredentials === true ? "include" : "omit";
       }
 
-      if (this.proxy?.apikey) {
+      if (this.forwarder?.apikey) {
         options.headers = {
-          "X-Homer-Api-Key": this.proxy.apikey,
+          "X-Homer-Forwarder-Api-Key": this.forwarder.apikey,
         };
       }
 
@@ -39,12 +40,12 @@ export default {
 
       let url = path ? `${this.endpoint}/${path}` : this.endpoint;
 
-      if (this.proxy?.url) {
+      if (this.forwarder?.url) {
         options.headers = {
           ...(options.headers || {}),
-          "X-Homer-Api-Url": url,
+          "X-Homer-Forwarder-Url": url,
         };
-        url = this.proxy.url;
+        url = this.forwarder.url;
       }
 
       options = merge(options, init);

--- a/src/mixins/service.js
+++ b/src/mixins/service.js
@@ -1,3 +1,5 @@
+const merge = require("lodash.merge");
+
 export default {
   props: {
     proxy: Object,
@@ -25,17 +27,27 @@ export default {
           this.item.useCredentials === true ? "include" : "omit";
       }
 
-      options = Object.assign(options, init);
+      if (this.proxy?.apikey) {
+        options.headers = {
+          "X-Homer-Api-Key": this.proxy.apikey,
+        };
+      }
 
       if (path.startsWith("/")) {
         path = path.slice(1);
       }
 
-      let url = this.endpoint;
+      let url = path ? `${this.endpoint}/${path}` : this.endpoint;
 
-      if (path) {
-        url = `${this.endpoint}/${path}`;
+      if (this.proxy?.url) {
+        options.headers = {
+          ...(options.headers || {}),
+          "X-Homer-Api-Url": url,
+        };
+        url = this.proxy.url;
       }
+
+      options = merge(options, init);
 
       return fetch(url, options).then((response) => {
         if (!response.ok) {


### PR DESCRIPTION
As discussed in our (w/ @bastienwirtz) chat, we have a lot of people report issues pertaining to CORS. In order to remedy this, I'd like to offer a first-party solution, with proper Homer integration. This PR marks the first step in that venture, by adding new config property `forwarder` with `apiKey` and `url` sub-properties.

Providing `forwarder.apiKey` will pass the value along with any API calls under the header "X-Homer-Forwarder-Api-Key". This can be checked by the forwarder server component for a layer of security in the case where the Homer dashboard is exposed to the internet.

Providing `forwarder.url` will alter all API requests for all services across the dashboard by instead sending them to the provided URL. The service's API endpiont (endpoint or url, configured at the service level) will then be pushed instead to the "X-Homer-Forwarder-Url" header to be read by the forwarder server component so that it can forward the request.

I've also written up what could eventually become the server component here: https://git.roundaround.me/Roundaround/homer-api

Once we get the server component repo created (or integrate it directly in homer's main repo) we can add the appropriate documentation on how to use it all.