### PR TITLE
feat(pwa): enhance connectivity checks

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,7 +25,8 @@ header: true # Set to false to hide the header
 footer: '<p>Created with <span class="has-text-danger">❤️</span> with <a href="https://bulma.io/">bulma</a>, <a href="https://vuejs.org/">vuejs</a> & <a href="https://fontawesome.com/">font awesome</a> // Fork me on <a href="https://github.com/bastienwirtz/homer"><i class="fab fa-github-alt"></i></a></p>' # set false if you want to hide it.
 
 columns: "3" # "auto" or number (must be a factor of 12: 1, 2, 3, 4, 6, 12)
-connectivityCheck: true # whether you want to display a message when the apps are not accessible anymore (VPN disconnected for example)
+connectivityCheck: true # whether you want to display a message when the apps are not accessible anymore (VPN disconnected for example).
+                        # You should set it to true when using an authentication proxy, it also reloads the page when a redirection is detected when checking connectivity.
 
 # Optional: Proxy / hosting option
 proxy:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -17,3 +17,9 @@ To resolve this, you can either:
 * Host all your target service under the same domain & port.
 * Modify the target server configuration so that the response of the server included following header- `Access-Control-Allow-Origin: *` (<https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests>). It might be an option in the targeted service, otherwise depending on how the service is hosted, the proxy or web server can seamlessly add it.
 * Use a cors proxy server like [`cors-container`](https://github.com/imjacobclark/cors-container), [`cors-anywhere`](https://github.com/Rob--W/cors-anywhere) or many others.
+
+## I am using an authentication proxy and homer says I am offline
+
+This should be a configuration issue.
+* Make sure the option `connectivityCheck` is set to `true` in configuration.
+* Check your proxy configuration, the expected behavior is to redirect user using a 302 to the login page when user is not authenticated.

--- a/src/App.vue
+++ b/src/App.vue
@@ -231,13 +231,7 @@ export default {
     },
     getConfig: function (path = "assets/config.yml") {
       return fetch(path).then((response) => {
-        if (response.redirected) {
-          // This allows to work with authentication proxies.
-          window.location.href = response.url;
-          return;
-        }
-
-        if (response.status == 404) {
+        if (response.status == 404 || response.redirected) {
           this.configNotFound = true;
           return {};
         }

--- a/src/components/ConnectivityChecker.vue
+++ b/src/components/ConnectivityChecker.vue
@@ -17,6 +17,9 @@ export default {
     };
   },
   created: function () {
+    if (/t=\d+/.test(window.location.href)) {
+      window.history.replaceState({}, document.title, window.location.pathname);
+    }
     let that = this;
     this.checkOffline();
 
@@ -61,7 +64,7 @@ export default {
         .then(function (response) {
           // opaqueredirect means request has been redirected, to auth provider probably
           if (response.type === "opaqueredirect" && !response.ok) {
-            window.location.reload(true);
+            window.location.href = window.location.href + "?t="+(new Date().valueOf());
           }
           that.offline = !response.ok;
         })

--- a/src/components/ConnectivityChecker.vue
+++ b/src/components/ConnectivityChecker.vue
@@ -56,7 +56,8 @@ export default {
 
       // extra check to make sure we're not offline
       let that = this;
-      return fetch(window.location.href + "?alive", {
+      const aliveCheckUrl = window.location.href + "?t="+(new Date().valueOf());
+      return fetch(aliveCheckUrl, {
         method: "HEAD",
         cache: "no-store",
         redirect: "manual"
@@ -64,7 +65,7 @@ export default {
         .then(function (response) {
           // opaqueredirect means request has been redirected, to auth provider probably
           if ((response.type === "opaqueredirect" && !response.ok) || [401, 403].indexOf(response.status) != -1) {
-            window.location.href = window.location.href + "?t="+(new Date().valueOf());
+            window.location.href = aliveCheckUrl;
           }
           that.offline = !response.ok;
         })

--- a/src/components/ConnectivityChecker.vue
+++ b/src/components/ConnectivityChecker.vue
@@ -29,15 +29,40 @@ export default {
       },
       false
     );
+    window.addEventListener(
+      "online",
+      function () {
+          that.checkOffline();
+      },
+      false
+    );
+    window.addEventListener(
+      "offline",
+      function () {
+        this.offline = true;
+      },
+      false
+    );
   },
   methods: {
     checkOffline: function () {
+      if (!navigator.onLine) {
+        this.offline = true;
+        return;
+      }
+
+      // extra check to make sure we're not offline
       let that = this;
       return fetch(window.location.href + "?alive", {
         method: "HEAD",
         cache: "no-store",
+        redirect: "manual"
       })
         .then(function (response) {
+          // opaqueredirect means request has been redirected, to auth provider probably
+          if (response.type === "opaqueredirect" && !response.ok) {
+            window.location.reload(true);
+          }
           that.offline = !response.ok;
         })
         .catch(function () {

--- a/src/components/ConnectivityChecker.vue
+++ b/src/components/ConnectivityChecker.vue
@@ -63,7 +63,7 @@ export default {
       })
         .then(function (response) {
           // opaqueredirect means request has been redirected, to auth provider probably
-          if (response.type === "opaqueredirect" && !response.ok) {
+          if ((response.type === "opaqueredirect" && !response.ok) || [401, 403].indexOf(response.status) != -1) {
             window.location.href = window.location.href + "?t="+(new Date().valueOf());
           }
           that.offline = !response.ok;

--- a/vue.config.js
+++ b/vue.config.js
@@ -26,4 +26,7 @@ module.exports = {
       msTileImage: "assets/icons/icon-any.png",
     },
   },
+  devServer: {
+    disableHostCheck: true
+  },
 };


### PR DESCRIPTION
## Description

To check if user is offline, some simple tests without fetch request can be done (on `navigator.onLine`). But `navigator.onLine` does not mean you're online, some extra checks can be done in the right case.

I also check what happen to the `?alive` request, basically, if it was redirected, that means your behind an auth proxy which requires a re-auth.

Tested on Chrome/Brave/Safari for mac, Safari for iOS 15.

Fixes #232

I pushed a docker image, [`bemble/homer:fix-auth`](https://hub.docker.com/repository/docker/bemble/homer), for testing purpose, it will be deleted as soon as possible.

![demo](https://user-images.githubusercontent.com/397503/167508036-60b590c0-045d-423d-8b5d-b5a5f9d1fb26.gif)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
