### PR TITLE
Emby service also supports Jellyfin

### DIFF
--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -16,7 +16,7 @@ within Homer:
 + [Prometheus](#prometheus)
 + [AdGuard Home](#adguard-home)
 + [Portainer](#portainer)
-+ [Emby](#emby)
++ [Emby / Jellyfin](#emby--jellyfin)
 + [Uptime Kuma](#uptime-kuma)
 + [Tautulli](#tautulli)
 
@@ -169,7 +169,7 @@ See https://docs.portainer.io/v/ce-2.11/user/account-settings#access-tokens
   #   - "local"
 ```
 
-## Emby
+## Emby / Jellyfin
 
 You need to set the type to Emby, provide an api key and choose which stats to show if the subtitle is disabled.
 


### PR DESCRIPTION
## Description

Since Jellyfin is a fork of Emby, the recently added Emby custom service (#410) also supports Jellyfin. Update the custom services to make this easy to find for users that may not know that Jellyfin is a fork of Emby.

- [X] Tested Emby service against Jellyfin 10.7.7
![Screenshot from 2022-05-21 22-27-41](https://user-images.githubusercontent.com/89676/169675698-81227256-927d-4cae-a381-196061a992ca.png)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [X] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [X] I have made corresponding changes to the documentation (README.md).
- [X] I've checked my modifications for any breaking changes, especially in the `config.yml` file
