### PR TITLE
feat: add custom service Healthchecks

### DIFF
--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -19,6 +19,7 @@ within Homer:
 + [Emby / Jellyfin](#emby--jellyfin)
 + [Uptime Kuma](#uptime-kuma)
 + [Tautulli](#tautulli)
++ [Healthchecks](#healthchecks)
 
 If you experiencing any issue, please have a look to the [troubleshooting](troubleshooting.md) page.
 
@@ -223,3 +224,16 @@ endpoint pointing to Tautulli!
   type: "Tautulli"
   apikey: "MY-SUPER-SECRET-API-KEY"
 ```
+
+## Healthchecks
+
+This service displays information about the configured status checks from the Healthchecks application.
+Two lines are needed in the config.yml :
+
+```yaml
+  type: "Healthchecks"
+  apikey: "01234deb70424befb1f4ef6a23456789"
+```
+
+The url must be the root url of the Healthchecks application.
+The Healthchecks API key can be found in Settings > API Access > API key (read-only). The key is needed to access Healthchecks API.

--- a/src/components/services/Healhchecks.vue
+++ b/src/components/services/Healhchecks.vue
@@ -1,0 +1,115 @@
+<template>
+  <Generic :item="item">
+    <template #indicator>
+      <div class="notifs">
+        <strong v-if="up > 0" class="notif up" title="Up">
+          {{ up }}
+        </strong>
+        <strong v-if="down > 0" class="notif down" title="Down">
+          {{ down }}
+        </strong>
+        <strong v-if="grace > 0" class="notif grace" title="Grace">
+          {{ grace }}
+        </strong>
+      </div>
+    </template>
+  </Generic>
+</template>
+
+<script>
+import service from "@/mixins/service.js";
+import Generic from "./Generic.vue";
+
+export default {
+  name: "Healthchecks",
+  mixins: [service],
+  props: {
+    item: Object,
+  },
+  components: {
+    Generic,
+  },
+  data: () => ({
+    api: null,
+  }),
+  computed: {
+    up: function () {
+      if (!this.api) {
+        return "";
+      }
+      return this.api.checks?.filter((check) => {
+        return check.status.toLowerCase() === "up";
+      }).length;
+    },
+    down: function () {
+      if (!this.api) {
+        return "";
+      }
+      return this.api.checks?.filter((check) => {
+        return check.status.toLowerCase() === "down";
+      }).length;
+    },
+    grace: function () {
+      if (!this.api) {
+        return "";
+      }
+      return this.api.checks?.filter((check) => {
+        return check.status.toLowerCase() === "grace";
+      }).length;
+    },
+  },
+  created() {
+    this.fetchStatus();
+  },
+  methods: {
+    fetchStatus: async function () {
+      const apikey = this.item.apikey;
+      if (!apikey) {
+        console.error(
+          "apikey is not present in config.yml for the Healthchecks entry!"
+        );
+        return;
+      }
+
+      const headers = {
+        "X-Api-Key": this.item.apikey,
+      };
+
+      this.api = await this.fetch("/api/v1/checks/", { headers }).catch((e) => {
+        console.error(e);
+      });
+    },
+  },
+};
+</script>
+
+<style scoped lang="scss">
+.notifs {
+  position: absolute;
+  color: white;
+  font-family: sans-serif;
+  top: 0.3em;
+  right: 0.5em;
+
+  .notif {
+    display: inline-block;
+    padding: 0.2em 0.35em;
+    border-radius: 0.25em;
+    position: relative;
+    margin-left: 0.3em;
+    font-size: 0.8em;
+
+    &.up {
+      background-color: #4fd671;
+    }
+
+    &.down {
+      background-color: #e51111;
+    }
+
+    &.grace {
+      background-color: #cdd02e;
+    }
+  }
+}
+</style>


### PR DESCRIPTION
## Description

This pull request adds [Healthchecks](https://healthchecks.io/) as a custom service to Homer. I based the style on the Portainer service for consistency. It will look like the following:

![homer_healthchecks](https://user-images.githubusercontent.com/5375334/175356399-d6da9009-fd59-4596-b2f2-3c1533c9f5c8.png)


Fixes #474

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [X] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [X] I have made corresponding changes to the documentation (README.md).
- [X] I've checked my modifications for any breaking changes, especially in the `config.yml` file
