### PR TITLE
Add GET Support to Ping service

### DIFF
--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -92,7 +92,7 @@ Two lines are needed in the config.yml :
 
 The url must be the root url of Lidarr, Prowlarr, Radarr or Sonarr application.
 The Lidarr, Prowlarr, Radarr or Sonarr API key can be found in Settings > General. It is needed to access the API.
-If you are using an older version of Radarr or Sonarr which don't support the new V3 api endpoints, add the following line to your service config "legacyApi: true", example: 
+If you are using an older version of Radarr or Sonarr which don't support the new V3 api endpoints, add the following line to your service config "legacyApi: true", example:
 
 ```yaml
 - name: "Radarr"
@@ -116,7 +116,7 @@ API key can be generated in Settings > Administration > Auth Tokens
 
 ## Ping
 
-For Ping you need to set the type to Ping and provide a url.
+For Ping you need to set the type to Ping and provide a url. By default the HEAD method is used but it can be configured to use GET using the optional `method` property.
 
 ```yaml
 - name: "Awesome app"
@@ -125,6 +125,7 @@ For Ping you need to set the type to Ping and provide a url.
   subtitle: "Bookmark example"
   tag: "app"
   url: "https://www.reddit.com/r/selfhosted/"
+  method: "head"
 ```
 
 ## Prometheus

--- a/src/components/services/Ping.vue
+++ b/src/components/services/Ping.vue
@@ -29,7 +29,8 @@ export default {
   },
   methods: {
     fetchStatus: async function () {
-      this.fetch("/", { method: "HEAD", cache: "no-cache" }, false)
+      const method = typeof this.item.method === 'string' && this.item.method.toLowerCase() === "get" ? "GET" : "HEAD"
+      this.fetch("/", { method, cache: "no-cache" }, false)
         .then(() => {
           this.status = "online";
         })
@@ -45,6 +46,8 @@ export default {
 .status {
   font-size: 0.8rem;
   color: var(--text-title);
+  white-space: nowrap;
+  margin-left: 0.25rem;
 
   &.online:before {
     background-color: #94e185;

--- a/src/components/services/Ping.vue
+++ b/src/components/services/Ping.vue
@@ -29,7 +29,13 @@ export default {
   },
   methods: {
     fetchStatus: async function () {
-      const method = typeof this.item.method === 'string' && this.item.method.toLowerCase() === "get" ? "GET" : "HEAD"
+      const method = typeof this.item.method === 'string' ? this.item.method.toUpperCase() : 'unknown';
+
+      if (!['GET', 'HEAD', 'OPTION'].includes(method)) {
+        console.error(`Ping: ${method} is not a supported HTTP method`);
+        return;
+      }
+
       this.fetch("/", { method, cache: "no-cache" }, false)
         .then(() => {
           this.status = "online";


### PR DESCRIPTION
## Description

Adds an optional new property to the Ping custom service that lets the user leverage the GET method rather than the HEAD method. The HEAD method is not universally implemented which limits what the Ping service can actually monitor. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ X] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [ X] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [ X] I have made corresponding changes to the documentation (README.md).
- [ X] I've checked my modifications for any breaking changes, especially in the `config.yml` file
