### PR TITLE
Add `PORT` usage in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ Install example configuration file & assets (favicons, ...) to help you get star
 * **`SUBFOLDER`** (default: `null`)
 If you would like to host Homer in a subfolder, (ex: *http://my-domain/**homer***), set this to the subfolder path (ex `/homer`).
 
+* **`PORT`** (default: `8080`)
+If you would like to change internal port of Homer from default `8080` to your port choice.
+
+
 #### With docker-compose
 
 A [`docker-compose.yml`](docker-compose.yml) file is available as an example. It must be edited to match your needs. You probably want to adjust the port mapping and volume binding (equivalent to `-p` and `-v` arguments).


### PR DESCRIPTION
Add `PORT` usage in Readme for repointing internal port, as mentioned on https://github.com/bastienwirtz/homer/issues/489

## Description

This is an addition to `Readme.md` for instructions of repointing internal port from default `8080` of your choice - sample usage can be found on https://github.com/bastienwirtz/homer/issues/489#issuecomment-1197857927

If there is an additional file to be edited to match instruction, please let me know!

Not too sure which type of change since this change only consist of `Readme.md` changes, thus no options is checked yet

Fixes #489

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
