### PR TITLE
Add blazing speed badge reflecting the "speed" of homer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@
   <a href="https://github.com/bastienwirtz/homer/releases/latest/download/homer.zip"><img
   alt="Download homer static build"
   src="https://img.shields.io/badge/Download-homer.zip-orange"></a>
+ <a href="https://twitter.com/acdlite/status/974390255393505280"><img
+  alt="speed-blazing"
+  src="https://img.shields.io/badge/speed-blazing%20%F0%9F%94%A5-red"></a>
  <a href="https://github.com/awesome-selfhosted/awesome-selfhosted"><img
   alt="Awesome"
   src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg"></a>


### PR DESCRIPTION

## Description

Please consider this funny badge. I noticed such badge at [IlanCosman/tide](https://github.com/IlanCosman/tide) the same week I've installed homer. I was impressed not only by dead simplicity but the fact that this dashboard is blazing fast :)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
None of the above - readme improvement ;)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
