### PR TITLE
Adds copy to clipboard custom service.

### DIFF
--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -22,6 +22,7 @@ within Homer:
 + [Mealie](#mealie)
 + [Healthchecks](#healthchecks)
 + [Proxmox](#proxmox)
++ [CopyToClipboard](#copy-to-clipboard)
 
 If you experiencing any issue, please have a look to the [troubleshooting](troubleshooting.md) page.
 
@@ -261,4 +262,21 @@ Configuration example:
   warning_value: 50
   danger_value: 80
   api_token: "PVEAPIToken=root@pam!your-api-token-name=your-api-token-key"
+```
+
+## Copy to Clipboard
+
+This service displays the same information of a generic one, but shows an icon button on the indicator place (right side) you can click to get the content of the `clipboard` field copied to your clipboard.
+
+You can still provide an `url` that would be open when clicked anywhere but on the icon button.
+
+Configuration example:
+
+```yaml
+- name: "Copy me!"
+  logo: "assets/tools/sample.png"
+  subtitle: "Subtitle text goes here"
+  url: "#"
+  type: "CopyToClipboard"
+  clipboard: "this text will be copied to your clipboard"
 ```

--- a/src/components/services/CopyToClipboard.vue
+++ b/src/components/services/CopyToClipboard.vue
@@ -1,7 +1,7 @@
 <template>
   <Generic :item="item">
     <template #indicator>
-      <div class="status"><i class="fa-regular fa-copy fa-xl" :class="{'fa-beat': animate, 'copied-icon': animate}" @click="copy"></i></div>
+      <div class="status"><i ref="copyIcon" class="fa-regular fa-copy fa-xl" :class="{'scale': animate}" @click="copy($event)"></i></div>
     </template>
   </Generic>
 </template>
@@ -22,24 +22,62 @@ export default {
   data: () => ({
     animate: false
   }),
+  mounted: function() {
+    this.$refs.copyIcon.addEventListener(
+      'animationend',
+      (event) => { this.animate = false; });
+  },
   methods: {
-    copy() {
+    copy(event) {
       javascript:navigator.clipboard.writeText(this.item.clipboard)
       this.animate = true;
-      setTimeout(
-        () => { this.animate = false },
-        1000
-      );
     }
   },
 };
 </script>
 
 <style scoped lang="scss">
-.status {
+.scale {
+	-webkit-animation: scale-up 0.3s cubic-bezier(0.250, 0.460, 0.450, 0.940) both;
+	        animation: scale-up 0.3s cubic-bezier(0.250, 0.460, 0.450, 0.940) both;
+}
+.is-light i {
   color: black;
 }
-.copied-icon {
-  color: #5dbc9d;
+.is-dark i {
+  color: white;
+}
+  /**
+ * ----------------------------------------
+ * animation scale-down-center
+ * ----------------------------------------
+ */
+@-webkit-keyframes scale-up {
+  0% {
+    -webkit-transform: scale(1);
+            transform: scale(1);
+  }
+  50% {
+    -webkit-transform: scale(1.25);
+            transform: scale(1.25);
+  }
+  100% {
+    -webkit-transform: scale(1);
+            transform: scale(1);
+  }
+}
+@keyframes scale-up {
+  0% {
+    -webkit-transform: scale(1);
+            transform: scale(1);
+  }
+  50% {
+    -webkit-transform: scale(1.25);
+            transform: scale(1.25);
+  }
+  100% {
+    -webkit-transform: scale(1);
+            transform: scale(1);
+  }
 }
 </style>

--- a/src/components/services/CopyToClipboard.vue
+++ b/src/components/services/CopyToClipboard.vue
@@ -1,0 +1,45 @@
+<template>
+  <Generic :item="item">
+    <template #indicator>
+      <div class="status"><i class="fa-regular fa-copy fa-xl" :class="{'fa-beat': animate, 'copied-icon': animate}" @click="copy"></i></div>
+    </template>
+  </Generic>
+</template>
+
+<script>
+import service from "@/mixins/service.js";
+import Generic from "./Generic.vue";
+
+export default {
+  name: "CopyToClipboard",
+  mixins: [service],
+  props: {
+    item: Object,
+  },
+  components: {
+    Generic,
+  },
+  data: () => ({
+    animate: false
+  }),
+  methods: {
+    copy() {
+      javascript:navigator.clipboard.writeText(this.item.clipboard)
+      this.animate = true;
+      setTimeout(
+        () => { this.animate = false },
+        1000
+      );
+    }
+  },
+};
+</script>
+
+<style scoped lang="scss">
+.status {
+  color: black;
+}
+.copied-icon {
+  color: #5dbc9d;
+}
+</style>

--- a/src/components/services/CopyToClipboard.vue
+++ b/src/components/services/CopyToClipboard.vue
@@ -25,7 +25,7 @@ export default {
   mounted: function() {
     this.$refs.copyIcon.addEventListener(
       'animationend',
-      (event) => { this.animate = false; });
+      () => { this.animate = false; });
   },
   methods: {
     copy() {

--- a/src/components/services/CopyToClipboard.vue
+++ b/src/components/services/CopyToClipboard.vue
@@ -1,7 +1,7 @@
 <template>
   <Generic :item="item">
     <template #indicator>
-      <div class="status"><i ref="copyIcon" class="fa-regular fa-copy fa-xl" :class="{'scale': animate}" @click="copy($event)"></i></div>
+      <div class="status"><i ref="copyIcon" class="fa-regular fa-copy fa-xl" :class="{'scale': animate}" @click="copy()"></i></div>
     </template>
   </Generic>
 </template>
@@ -28,7 +28,7 @@ export default {
       (event) => { this.animate = false; });
   },
   methods: {
-    copy(event) {
+    copy() {
       javascript:navigator.clipboard.writeText(this.item.clipboard)
       this.animate = true;
     }

--- a/src/components/services/CopyToClipboard.vue
+++ b/src/components/services/CopyToClipboard.vue
@@ -1,7 +1,7 @@
 <template>
   <Generic :item="item">
     <template #indicator>
-      <div class="status"><i ref="copyIcon" class="fa-regular fa-copy fa-xl" :class="{'scale': animate}" @click="copy()"></i></div>
+      <div class="status"><i class="fa-regular fa-copy fa-xl" :class="{'scale': animate}" @click="copy()" @animationend="animate = false"></i></div>
     </template>
   </Generic>
 </template>
@@ -22,11 +22,6 @@ export default {
   data: () => ({
     animate: false
   }),
-  mounted: function() {
-    this.$refs.copyIcon.addEventListener(
-      'animationend',
-      () => { this.animate = false; });
-  },
   methods: {
     copy() {
       navigator.clipboard.writeText(this.item.clipboard)

--- a/src/components/services/CopyToClipboard.vue
+++ b/src/components/services/CopyToClipboard.vue
@@ -29,7 +29,7 @@ export default {
   },
   methods: {
     copy() {
-      javascript:navigator.clipboard.writeText(this.item.clipboard)
+      navigator.clipboard.writeText(this.item.clipboard)
       this.animate = true;
     }
   },


### PR DESCRIPTION
## Description

Adds a custom service that adds an icon button on the indicator to copy to the clipboard the text in the `clipboard` field.

Fixes #500 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
