### PR TITLE
Fixed 'method' not defaulting to HEAD request in Ping functionality

### DIFF
--- a/src/components/services/Ping.vue
+++ b/src/components/services/Ping.vue
@@ -29,7 +29,7 @@ export default {
   },
   methods: {
     fetchStatus: async function () {
-      const method = typeof this.item.method === 'string' ? this.item.method.toUpperCase() : 'unknown';
+      const method = typeof this.item.method === 'string' ? this.item.method.toUpperCase() : 'HEAD';
 
       if (!['GET', 'HEAD', 'OPTION'].includes(method)) {
         console.error(`Ping: ${method} is not a supported HTTP method`);


### PR DESCRIPTION
## Description

In the documentation it is pointed out that method "HEAD" should be used as default method for PING, but it was defaulting to 'unknown'

Fixes # ([issue](https://github.com/bastienwirtz/homer/issues/530))

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [X] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [ ] I have made corresponding changes to the documentation (README.md).
- [ ] I've checked my modifications for any breaking changes, especially in the `config.yml` file

