### PR TITLE
ConnectivityChecker: Remove double // in aliveCheckUrl causing Invalid Redirect URL with CloudFlare Access.

### DIFF
--- a/src/components/ConnectivityChecker.vue
+++ b/src/components/ConnectivityChecker.vue
@@ -56,9 +56,8 @@ export default {
 
       // extra check to make sure we're not offline
       let that = this;
-      const aliveCheckUrl = `${window.location.origin}${
-        window.location.pathname
-      }/index.html?t=${new Date().valueOf()}`;
+      const urlPath = window.location.pathname.replace(/\/+$/, "");
+      const aliveCheckUrl = `${window.location.origin}${urlPath}/index.html?t=${new Date().valueOf()}`;
       return fetch(aliveCheckUrl, {
         method: "HEAD",
         cache: "no-store",


### PR DESCRIPTION
## Description

### Bug Fix
When Homer is protected behind **CloudFlare Access**, the `ConnectivityChecker` builds an `aliveCheckUrl` with something like:

```
https://homer.domain.net//index.html?t=1666582254399
```
and makes an HTTP `HEAD` to the `homer.domain.net` to verify connectedness.

The problem arises when the cookie protecting `homer.domain.net` is expired; and results in an `HTTP 302` redirect to a login page.

The browser follows the `HTTP 302` redirect and the user lands on a site like:

```
https://__team__.cloudflareaccess.com/cdn-cgi/access/login/....redirect_url=%2F%2Findex.html%3Ft%3D1666582258096....
```

Notice the URL encode `redirect_url=%2F%2Findex.html`. Decoded, the `redirect_url` looks something like `//index.html`. The double `//` in the `redirect_url` causes **CloudFlare Access** to display the following error page (instead of a proper Login Page or Redirect):

![image](https://user-images.githubusercontent.com/478118/197446330-b5f05903-779b-47cc-8baa-c4469c007e4e.png)

If we remove the leading `%2F` from the `redirect_url` so that we have: `redirect_url=%2Findex.html...`; we get the expected login page and/or a proper redirect with the necessary authorization cookies.

Feel free to push modifications or changes to this PR.

Thanks,
Brian

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
