### PR TITLE
Adds indicator logo or icon on the right side.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -126,6 +126,9 @@ services:
         logo: "assets/tools/sample.png"
         # Alternatively a fa icon can be provided:
         # icon: "fab fa-jenkins"
+        indicator_logo: "assets/tools/sample2.png"
+        # Alternatively a fa icon can be provided:
+        # indicator_icon: "fab fa-jenkins"
         subtitle: "Bookmark example"
         tag: "app"
         keywords: "self hosted reddit" # optional keyword used for searching purpose

--- a/src/components/services/Generic.vue
+++ b/src/components/services/Generic.vue
@@ -29,18 +29,16 @@
               </slot>
             </div>
             <slot name="indicator" class="indicator">
-              <slot name="indicator" class="indicator">
-                <div v-if="item.indicator_logo" class="media-right">
-                  <figure class="image is-48x48">
-                    <img :src="item.indicator_logo" :alt="`${item.name} logo`" />
-                  </figure>
-                </div>
-                <div v-if="item.indicator_icon" class="media-right">
-                  <figure class="image is-48x48">
-                    <i style="font-size: 35px" :class="['fa-fw', item.indicator_icon]"></i>
-                  </figure>
-                </div>
-              </slot>
+              <div v-if="item.indicator_logo" class="media-right">
+                <figure class="image is-48x48">
+                  <img :src="item.indicator_logo" :alt="`${item.name} logo`" />
+                </figure>
+              </div>
+              <div v-if="item.indicator_icon" class="media-right">
+                <figure class="image is-48x48">
+                  <i style="font-size: 35px" :class="['fa-fw', item.indicator_icon]"></i>
+                </figure>
+              </div>
             </slot>
           </div>
           <div class="tag" :class="item.tagstyle" v-if="item.tag">

--- a/src/components/services/Generic.vue
+++ b/src/components/services/Generic.vue
@@ -28,7 +28,20 @@
                 </p>
               </slot>
             </div>
-            <slot name="indicator" class="indicator"></slot>
+            <slot name="indicator" class="indicator">
+              <slot name="indicator" class="indicator">
+                <div v-if="item.indicator_logo" class="media-right">
+                  <figure class="image is-48x48">
+                    <img :src="item.indicator_logo" :alt="`${item.name} logo`" />
+                  </figure>
+                </div>
+                <div v-if="item.indicator_icon" class="media-right">
+                  <figure class="image is-48x48">
+                    <i style="font-size: 35px" :class="['fa-fw', item.indicator_icon]"></i>
+                  </figure>
+                </div>
+              </slot>
+            </slot>
           </div>
           <div class="tag" :class="item.tagstyle" v-if="item.tag">
             <strong class="tag-text">#{{ item.tag }}</strong>


### PR DESCRIPTION
## Description

Adds yaml configuration options for showing logo (`indicator_logo`) or icon (`indicator_icon`) on the indicator slot (right side) of a service.

Fixes #336 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
