### PR TITLE
Ignore paused Uptime Kuma monitors

### DIFF
--- a/src/components/services/UptimeKuma.vue
+++ b/src/components/services/UptimeKuma.vue
@@ -51,7 +51,9 @@ export default {
 
       for (let id in this.heartbeat.heartbeatList) {
         let index = this.heartbeat.heartbeatList[id].length - 1;
-        result[id] = this.heartbeat.heartbeatList[id][index];
+        if (index >= 0) {
+          result[id] = this.heartbeat.heartbeatList[id][index];
+        }
       }
 
       return result;
@@ -106,7 +108,10 @@ export default {
       if (!this.heartbeat) {
         return 0;
       }
-      const data = Object.values(this.heartbeat.uptimeList);
+      let data = [];
+      for (let id in this.lastHeartBeatList) {
+        data.push(this.heartbeat.uptimeList[id + "_24"]);
+      }
       const percent = data.reduce((a, b) => a + b, 0) / data.length || 0;
       return (percent * 100).toFixed(1);
     },


### PR DESCRIPTION
## Description

If the Uptime Kuma status page contains paused monitors, the dashboard component fails, because the monitor may has no latest heartbeat not older than 24h. This PR fixes this by ignoring paused monitors for the status message as well as for the uptime calculation.  

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
