### PR TITLE
Add scope and start_url to PWA manifest

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -21,6 +21,8 @@ export default defineConfig({
         short_name: "Homer",
         description: "Home Server Dashboard",
         theme_color: "#3367D6",
+        start_url: "../",
+        scope: "../",
         icons: [
           {
             src: "./icons/pwa-192x192.png",


### PR DESCRIPTION
## Description

Without explicitly defining `start_url` and `scope` URLs in the PWA manifest, Vite defaults them to `./` when it generates the manifest. Because the manifest path is within the `assets` folder, this essentially results in the installed desktop app on mobile devices pointing to `https://homer.yourdomain/assets/`.

The `start_url` and `scope` URLs in the PWA manifest are relative, so given that manifest.json lives in assets/, these should point to the root of the site. Alternatively they could be set to `/` instead of `../`, but I felt that pointing to the parent directory would cover more possible implementations.

Fixes #544 and #536 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
