### PR TITLE
fix(message): support API which returns plain text

### DIFF
--- a/src/components/Message.vue
+++ b/src/components/Message.vue
@@ -67,11 +67,22 @@ export default {
     },
 
     downloadMessage: function (url) {
-      return fetch(url).then(function (response) {
+      return fetch(url).then(async function (response) {
         if (response.status != 200) {
           return;
         }
-        return response.json();
+        const content_type = response.headers.get("Content-Type").split(";")[0];
+        switch (content_type) {
+          case "application/json": {
+            return response.json();
+          }
+          case "text/plain": {
+            return { content: await response.text() };
+          }
+          default: {
+            return response.json();
+          }
+        }
       });
     },
 


### PR DESCRIPTION
## Description

Add support for API returning plain text. Fetched text will be formatted as JSON and go to `content` field to keep the consistency with the original interface.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [ ] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
