### PR TITLE
Properly pass signals to lighttpd

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,4 +15,4 @@ if [[ "${INIT_ASSETS}" == "1" ]] && [[ ! -f "/www/assets/config.yml" ]]; then
 fi
 
 echo "Starting webserver"
-lighttpd -D -f /lighttpd.conf
+exec lighttpd -D -f /lighttpd.conf


### PR DESCRIPTION
## Description

With the current `entrypoint.sh` script, lighttpd is launched as a child of the shell.
As such it doesn't receive signals and `docker stop` ends up killing the process after 10 seconds.
The issue is explained here: https://madflojo.medium.com/shutdown-signals-with-docker-entry-point-scripts-5e560f4e2d45.

This PR `exec` lighttpd so that it replaces the shell and receive signals.
This is similar to what was done in https://github.com/bastienwirtz/homer/pull/96.

Before:
```
PID                 USER                TIME                COMMAND
4035                1000                0:00                /bin/sh /entrypoint.sh
4067                1000                0:00                lighttpd -D -f /lighttpd.conf
```

After:
```
PID                 USER                TIME                COMMAND
4911                1000                0:00                lighttpd -D -f /lighttpd.conf
```





## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
