### PR TITLE
Custom span size in service group

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -121,6 +121,8 @@ services:
     icon: "fas fa-code-branch"
     # A path to an image can also be provided. Note that icon take precedence if both icon and logo are set.
     # logo: "path/to/logo"
+    # Use custom span size instead of 12/columns
+    # span: 6
     items:
       - name: "Awesome app"
         logo: "assets/tools/sample.png"

--- a/src/App.vue
+++ b/src/App.vue
@@ -92,7 +92,7 @@
                 :key="`service-${groupIndex}-${index}`"
                 :item="item"
                 :proxy="config.proxy"
-                :class="['column', `is-${12 / config.columns}`]"
+                :class="['column', `is-${getSpan(group)}`]"
               />
             </template>
           </div>
@@ -103,7 +103,7 @@
             class="columns is-multiline layout-vertical"
           >
             <div
-              :class="['column', `is-${12 / config.columns}`]"
+              :class="['column', `is-${getSpan(group)}`]"
               v-for="(group, groupIndex) in services"
               :key="groupIndex"
             >
@@ -311,6 +311,9 @@ export default {
       let style = document.createElement("style");
       style.appendChild(document.createTextNode(css));
       document.head.appendChild(style);
+    },
+    getSpan: function (item) {
+      return item.span || 12 / this.config.columns;
     },
   },
 };


### PR DESCRIPTION
## Description

Some service group require larger span size. Add optional span option under services section
Hope it's useful 😉 

config looks like this
```yaml
services:
  - name: "Applications"
    icon: "fas fa-cloud"
    items: ...
  - name: "Surveillance"
    icon: "fas fa-cloud"
    span: 6
    items: ...
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
