### PR TITLE
Bundle dashboard-icons into the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,11 @@ RUN yarn install --frozen-lockfile
 COPY . .
 RUN yarn build
 
+# dashboard icons stage
+FROM bitnami/git as icons-stage
+WORKDIR /root
+RUN git clone https://github.com/walkxcode/dashboard-icons.git
+
 # production stage
 FROM alpine:3.16
 
@@ -27,6 +32,8 @@ COPY lighttpd.conf /lighttpd.conf
 COPY entrypoint.sh /entrypoint.sh
 COPY --from=build-stage --chown=${UID}:${GID} /app/dist /www/
 COPY --from=build-stage --chown=${UID}:${GID} /app/dist/assets /www/default-assets
+COPY --from=icons-stage --chown=${UID}:${GID} /root/dashboard-icons/png /www/assets/dashboard-icons/png
+COPY --from=icons-stage --chown=${UID}:${GID} /root/dashboard-icons/svg /www/assets/dashboard-icons/svg
 
 USER ${UID}:${GID}
 


### PR DESCRIPTION
## Description
This change bundles the https://github.com/walkxcode/dashboard-icons into the container image so that out of the box it provides icon images to most of the common services one would host in a home lab environment. The downside of this change is added image size and an extra dependency.

If bundling into the main image is not desirable, we can also introduce an alternative set of tags that incorporate the icons. There are already precedents of dashboards integrating with the dashboard-icons project, as described in the dashboard-icons README.

Discussion issue #597 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [ ] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [ ] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
