### PR TITLE
Pass accept header when fetching the message via url

### DIFF
--- a/src/components/Message.vue
+++ b/src/components/Message.vue
@@ -67,12 +67,14 @@ export default {
     },
 
     downloadMessage: function (url) {
-      return fetch(url).then(function (response) {
-        if (response.status != 200) {
-          return;
+      return fetch(url, { headers: { Accept: "application/json" } }).then(
+        function (response) {
+          if (response.status != 200) {
+            return;
+          }
+          return response.json();
         }
-        return response.json();
-      });
+      );
     },
 
     mapRemoteMessage: function (message) {


### PR DESCRIPTION
## Description

When pulling the message via the given URL some api's require the accept header to know that it must send json data.  

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
