### PR TITLE
Add GHCR Docker image mirror

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -27,6 +27,13 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
       - 
         name: Set tag name
         run: |
@@ -40,5 +47,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
-          tags: b4bz/homer:${{env.IMAGE_TAG}}
+          tags: |
+            b4bz/homer:${{env.IMAGE_TAG}}
+            ghcr.io/${{ github.repository }}:${{ env.IMAGE_TAG }}
           platforms: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64


### PR DESCRIPTION
## Description

This PR adds a container repository mirror at `ghcr.io/bastienwirtz/homer`.

I considered renaming the action from `Dockerhub` to `Build Docker Image` and renaming the workflow yaml file, but didn't want to mess with your Actions history. If you're fine with that then just let me know!

Fixes #618 

### After Merge

The package repository will be created automatically during the first run, but may default to `private` visibility. If so, you will need to:

1. Go to https://ghcr.io/bastienwirtz/homer
2. Package Settings
3. Change package visibility
4. Set to `Public`

After changing visibility, I'd also suggest that you go to this repo's homepage, click the settings cog on the right, then enable `Packages` on the homepage.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [ ] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [ ] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
