### PR TITLE
Fetch status (online/offline) from uptime-kuma

### DIFF
--- a/src/components/services/Ping.vue
+++ b/src/components/services/Ping.vue
@@ -9,75 +9,98 @@
 </template>
 
 <script>
-import service from "@/mixins/service.js";
-import Generic from "./Generic.vue";
+  import service from "@/mixins/service.js";
+  import Generic from "./Generic.vue";
 
-export default {
-  name: "Ping",
-  mixins: [service],
-  props: {
-    item: Object,
-  },
-  components: {
-    Generic,
-  },
-  data: () => ({
-    status: null,
-  }),
-  created() {
-    this.fetchStatus();
-  },
-  methods: {
-    fetchStatus: async function () {
-      const method =
-        typeof this.item.method === "string"
-          ? this.item.method.toUpperCase()
-          : "HEAD";
-
-      if (!["GET", "HEAD", "OPTION"].includes(method)) {
-        console.error(`Ping: ${method} is not a supported HTTP method`);
-        return;
-      }
-
-      this.fetch("/", { method, cache: "no-cache" }, false)
-        .then(() => {
-          this.status = "online";
-        })
-        .catch(() => {
-          this.status = "offline";
-        });
+  export default {
+    name: "Ping",
+    mixins: [service],
+    props: {
+      item: Object,
     },
-  },
-};
+    components: {
+      Generic,
+    },
+    data: () => ({
+      status: null,
+    }),
+    created() {
+      switch (this.item.ping_src) {
+        case 'uptime-kuma':
+          this.fetchUptimeKumaStatus();
+          break;
+        case null || undefined:
+          this.fetchStatus();
+          break;
+
+        default:
+          console.error(`Ping: ${this.item.ping_src} is not a supported source`);
+          break;
+      }
+    },
+    methods: {
+      getMethod: function () {
+        const method = typeof this.item.method === "string"
+            ? this.item.method.toUpperCase()
+            : "HEAD";
+
+        if (!["GET", "HEAD", "OPTION"].includes(method)) {
+          console.error(`Ping: ${method} is not a supported HTTP method`);
+          return;
+        }
+
+        return method;
+      },
+      fetchStatus: async function () {
+        const method = this.getMethod();
+        this.fetch("/", { method, cache: "no-cache" }, false)
+          .then(() => {
+            this.status = "online";
+          })
+          .catch(() => {
+            this.status = "offline";
+          });
+      },
+      fetchUptimeKumaStatus: async function () {
+        console.log('Uptime-kuma URL', this.item.endpoint);
+        console.log('Uptime-kuma monitor ID', this.item.monitorID);
+
+        this.fetch(`/api/badge/${this.item.monitorID}/status?upLabel=online&downLabel=offline`, { method: 'GET', cache: "no-cache" }, false)
+          .then(async res => await res.text())
+          .then(badgeSvg => this.status = badgeSvg.includes('online') ? 'online' : 'offline')
+          .catch(() => this.status = "offline");
+      }
+    },
+  };
 </script>
 
 <style scoped lang="scss">
-.status {
-  font-size: 0.8rem;
-  color: var(--text-title);
-  white-space: nowrap;
-  margin-left: 0.25rem;
+  .status {
+    font-size: 0.8rem;
+    color: var(--text-title);
+    white-space: nowrap;
+    margin-left: 0.25rem;
 
-  &.online:before {
-    background-color: #94e185;
-    border-color: #78d965;
-    box-shadow: 0 0 5px 1px #94e185;
-  }
+    &.online:before {
+      background-color: #94e185;
+      border-color: #78d965;
+      box-shadow: 0 0 5px 1px #94e185;
+    }
 
-  &.offline:before {
-    background-color: #c9404d;
-    border-color: #c42c3b;
-    box-shadow: 0 0 5px 1px #c9404d;
-  }
+    &.offline:before {
+      background-color: #c9404d;
+      border-color: #c42c3b;
+      box-shadow: 0 0 5px 1px #c9404d;
+    }
 
-  &:before {
-    content: " ";
-    display: inline-block;
-    width: 7px;
-    height: 7px;
-    margin-right: 10px;
-    border: 1px solid #000;
-    border-radius: 7px;
+    &:before {
+      content: " ";
+      display: inline-block;
+      width: 7px;
+      height: 7px;
+      margin-right: 10px;
+      border: 1px solid #000;
+      border-radius: 7px;
+    }
   }
-}
 </style>

--- a/src/components/services/Ping.vue
+++ b/src/components/services/Ping.vue
@@ -54,17 +54,10 @@
       fetchStatus: async function () {
         const method = this.getMethod();
         this.fetch("/", { method, cache: "no-cache" }, false)
-          .then(() => {
-            this.status = "online";
-          })
-          .catch(() => {
-            this.status = "offline";
-          });
+          .then(() => this.status = "online")
+          .catch(() => this.status = "offline");
       },
       fetchUptimeKumaStatus: async function () {
-        console.log('Uptime-kuma URL', this.item.endpoint);
-        console.log('Uptime-kuma monitor ID', this.item.monitorID);
-
         this.fetch(`/api/badge/${this.item.monitorID}/status?upLabel=online&downLabel=offline`, { method: 'GET', cache: "no-cache" }, false)
           .then(async res => await res.text())
           .then(badgeSvg => this.status = badgeSvg.includes('online') ? 'online' : 'offline')


### PR DESCRIPTION
## Description

As far as I am aware, the ping component is not the most versatile as it requires the end service to have a sort of health check api integrated into it.

I would like to fetch the status of a service from uptime-kuma when I am displaying an online/offline indicator.

Fixes # (issue)
https://github.com/bastienwirtz/homer/issues/632
