### PR TITLE
typo in Adguard Home logo path

### DIFF
--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -161,7 +161,7 @@ For AdGuard Home you need to set the type to AdGuard, if you have somes issues a
 
 ```yaml
 - name: "Adguard"
-  logo: "assets/tools/adguardhome.png"
+  logo: "assets/tools/adguard-home.png"
   url: "https://adguard.exemple.com"
   target: "_blank"
   type: "AdGuardHome"


### PR DESCRIPTION
## Description


The example in [homer/customservices.md at main · bastienwirtz/homer](https://github.com/bastienwirtz/homer/blob/main/docs/customservices.md#adguard-home) have a wrong Adguard Home logo path

Fixes # (issue)

I just put the right file name.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [ ] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [ ] I have made corresponding changes to the documentation (README.md).
- [ ] I've checked my modifications for any breaking changes, especially in the `config.yml` file
