### PR TITLE
Fix: don't stretch non-square logos

### DIFF
--- a/src/components/services/Generic.vue
+++ b/src/components/services/Generic.vue
@@ -62,6 +62,7 @@ export default {
 
   img {
     max-height: 100%;
+    object-fit: contain;
   }
 }
 </style>


### PR DESCRIPTION
## Description

This fixes the issue where non-square logos were being stretched. With this fix, the logos will maintain their original aspect ratio and will no longer appear distorted.

Before:
![image](https://user-images.githubusercontent.com/60856741/235355288-1459415f-54a5-49cd-b4f2-2a529fe4fed7.png)

After:
![image](https://user-images.githubusercontent.com/60856741/235355304-f98621f5-4958-422b-8125-87adc0c2be33.png)

Logos used from here:
https://github.com/walkxcode/Dashboard-Icons

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
