### PR TITLE
Toggle dark mode when `prefers-color-scheme` changes

### DIFF
--- a/src/components/DarkMode.vue
+++ b/src/components/DarkMode.vue
@@ -47,6 +47,7 @@ export default {
     }
     this.isDark = this.getIsDark();
     this.$emit("updated", this.isDark);
+    this.watchIsDark();
   },
   methods: {
     toggleTheme: function () {
@@ -80,6 +81,13 @@ export default {
         true,
       ];
       return values[this.mode];
+    },
+
+    watchIsDark: function () {
+      matchMedia("(prefers-color-scheme: dark)").addEventListener("change", () => {
+        this.isDark = this.getIsDark();
+        this.$emit("updated", this.isDark);
+      });
     },
   },
 };


### PR DESCRIPTION
## Description

Currently, if the `prefers-color-scheme` media query changes (for example, due to scheduled dark mode), the theme does not update until Homer is refreshed. This PR adds an event listener that toggles the mode dynamically. The dynamic change will not occur if the current mode has been overridden via the navbar toggle.

### Examples
#### Current behavior

https://github.com/bastienwirtz/homer/assets/7717888/f91694a9-a929-4ab3-8196-db413cfac687

#### After this PR

https://github.com/bastienwirtz/homer/assets/7717888/261d4f6d-3ca7-435a-9908-b97d6f84d7b1

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
