### PR TITLE
Listen on IPv6

### DIFF
--- a/lighttpd.conf
+++ b/lighttpd.conf
@@ -1,6 +1,7 @@
 include "/etc/lighttpd/mime-types.conf"
 
 server.port            = env.PORT
+$SERVER["socket"] == "[::]:" + env.PORT {  }
 server.modules         = ( "mod_alias" )
 server.username        = "lighttpd"
 server.groupname       = "lighttpd"


### PR DESCRIPTION
## Description
This PR contains a small change that enables lighttpd to listen on IPv6 as well as the existing IPv4.  

While using host networking in docker Homer is unable to fulfill IPv6 requests and only listens to IPv4.  I've tested by making the change, building the docker container, and running the container in host and bridge mode. 

Doc showing how to listen to IPv6:
https://redmine.lighttpd.net/projects/lighttpd/wiki/IPv6-Config

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
