### PR TITLE
Add the option to set custom headers in the custom service client 

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,6 +31,10 @@ connectivityCheck: true # whether you want to display a message when the apps ar
 # Optional: Proxy / hosting option
 proxy:
   useCredentials: false # send cookies & authorization headers when fetching service specific data. Set to `true` if you use an authentication proxy. Can be overrided on service level. 
+  headers: # send custom headers when fetching service specific data. Can also be set on a service level.
+    Test: "Example"
+    Test1: "Example1"
+
 
 # Set the default layout and color scheme
 defaults:

--- a/src/mixins/service.js
+++ b/src/mixins/service.js
@@ -19,10 +19,19 @@ export default {
         options.credentials = "include";
       }
 
+      if (this.proxy?.headers) {
+        options.headers = this.proxy.headers;
+      }
+
       // Each item can override the credential settings
       if (this.item.useCredentials !== undefined) {
         options.credentials =
           this.item.useCredentials === true ? "include" : "omit";
+      }
+
+      // Each item can have their own headers
+      if (this.item.headers !== undefined) {
+        options.headers = this.item.headers;
       }
 
       options = Object.assign(options, init);


### PR DESCRIPTION
## Description

Add the possibility to add custom headers to the requests perform by the service client. Full motivation in the following issue: https://github.com/bastienwirtz/homer/issues/646

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [X] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [X] I have made corresponding changes to the documentation (README.md).
- [X] I've checked my modifications for any breaking changes, especially in the `config.yml` file