### PR TITLE
Allow setting no-cors in ping service

### DIFF
--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -144,6 +144,8 @@ For Ping you need to set the type to Ping and provide a url. By default the HEAD
   method: "head"
 ```
 
+You can also specify an optional field `mode` as `no-cors` to allow cross-origin requests from the browser. Setting this field will show the status of the service as `online` if the request is successful, irrespective of the response status code. Check the official [documentation](https://developer.mozilla.org/en-US/docs/Web/API/Request/mode) for more information about this field.
+
 ## Prometheus
 
 For Prometheus you need to set the type to Prometheus and provide a url.

--- a/src/components/services/Ping.vue
+++ b/src/components/services/Ping.vue
@@ -39,7 +39,9 @@ export default {
         return;
       }
 
-      this.fetch("/", { method, cache: "no-cache" }, false)
+      const mode = typeof this.item.mode  === "string" ? this.item.mode : "cors";
+
+      this.fetch("/", { method, cache: "no-cache", mode }, false)
         .then(() => {
           this.status = "online";
         })

--- a/src/mixins/service.js
+++ b/src/mixins/service.js
@@ -38,6 +38,11 @@ export default {
       }
 
       return fetch(url, options).then((response) => {
+        if (response.type == "opaque") {
+          // For no-cors requests, return empty response
+          return ""
+        }
+
         if (!response.ok) {
           throw new Error("Not 2xx response");
         }


### PR DESCRIPTION
## Description

Currently Ping custom service does not work if the service is hosted under a different domain and no `Access-Control-Allow-Origin`  header is set on the api response. This PR fixes this issue by allowing to make requests with `mode: no-cors` in fetch api.

More info about the `mode` field can be found [here](https://developer.mozilla.org/en-US/docs/Web/API/Request/mode)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
