### PR TITLE
Text color for is-warning tag

### DIFF
--- a/src/assets/app.scss
+++ b/src/assets/app.scss
@@ -13,7 +13,10 @@
   text-overflow: ellipsis;
 }
 
-html, body, body #app-mount, body #app {
+html,
+body,
+body #app-mount,
+body #app {
   height: 100%;
   background-color: var(--background);
 }
@@ -32,6 +35,7 @@ body {
 
     a {
       color: var(--link);
+
       &:hover {
         color: var(--link-hover);
       }
@@ -40,6 +44,7 @@ body {
     .title {
       color: var(--text-title);
     }
+
     .subtitle {
       color: var(--text-subtitle);
     }
@@ -47,6 +52,7 @@ body {
     .card {
       background-color: var(--card-background);
       box-shadow: 0 2px 15px 0 var(--card-shadow);
+
       &:hover {
         background-color: var(--card-background);
       }
@@ -54,6 +60,7 @@ body {
 
     .message {
       background-color: var(--card-background);
+
       .message-body {
         color: var(--text);
       }
@@ -132,6 +139,7 @@ body {
 
       .logo {
         float: left;
+
         i {
           vertical-align: top;
           padding: 8px 15px;
@@ -145,22 +153,26 @@ body {
         }
       }
     }
+
     .navbar {
       background-color: var(--highlight-secondary);
 
       a {
         color: var(--text-header);
         padding: 8px 12px;
+
         &:hover,
         &:focus {
           color: var(--text-header);
           background-color: var(--highlight-hover);
         }
       }
-	.navbar-menu {
-      background-color: inherit;
+
+      .navbar-menu {
+        background-color: inherit;
       }
     }
+
     .navbar-end {
       text-align: right;
     }
@@ -251,6 +263,10 @@ body {
       .tag-text {
         display: block;
       }
+
+      &.is-warning {
+        color: var(--link-hover);
+      }
     }
   }
 
@@ -300,6 +316,7 @@ body {
   .search-bar {
     position: relative;
     display: inline-block;
+
     input {
       border: none;
       background-color: var(--highlight-hover);


### PR DESCRIPTION
## Description

is-warning tag now have black color with --link-hover variable, also ran yarn lint.

```
.tag {
  width: auto;
  color: #ffffff;
  padding: 0 0.75em;

    .tag-text {
      display: block;
    }

    &.is-warning {
      color: var(--link-hover);
    }
}
```
Fixes [# (issue)](https://github.com/bastienwirtz/homer/issues/626)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [ ] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
