### PR TITLE
New feature: Info popup component

### DIFF
--- a/src/components/services/Generic.vue
+++ b/src/components/services/Generic.vue
@@ -5,6 +5,8 @@
       :style="`background-color:${item.background};`"
       :class="item.class"
     >
+    <Info v-if="item.info" :item="item.info"/>
+
       <a :href="item.url" :target="item.target" rel="noreferrer">
         <div class="card-content">
           <div :class="mediaClass">
@@ -40,8 +42,13 @@
 </template>
 
 <script>
+import Info from "./Info.vue";
+
 export default {
   name: "Generic",
+  components: {
+    Info,
+  },
   props: {
     item: Object,
   },

--- a/src/components/services/Info.vue
+++ b/src/components/services/Info.vue
@@ -1,0 +1,85 @@
+<template>
+  <div>
+    <!-- Open Icon -->
+    <i class="icon fas fa-info-circle" @click="popupVisible = true" />
+
+    <!-- Content -->
+    <div class="popup" v-show="popupVisible">
+      <div class="popup-content">
+        <span class="icon close fas fa-close" @click="popupVisible = false" />
+        <p class="header">{{ item.header }}</p>
+        <p class="content">{{ item.content }}</p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "Info",
+  props: {
+    item: Object,
+  },
+  components: {},
+  data: () => ({
+    popupVisible: false
+  }),
+};
+</script>
+
+<style scoped lang="scss">
+.popup {
+  position: fixed;
+  top: 0;
+  left: 0;
+  background-color: rgba(0, 0, 0, 0.358);
+  width: 100%;
+  height: 100%;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.popup-content {
+  background-color: #fefefe;
+  margin: 24px;
+  max-width: 500px;
+  max-height: 90vh;
+  min-height: 200px;
+  width: calc(100% - 48px); 
+  overflow-y: scroll;
+  height: fit-content;
+  padding: 50px 20px;
+  position: fixed;
+  border-radius: 0.25rem;
+}
+
+.icon {
+  cursor: pointer;
+  color: var(--link);
+}
+
+.icon:hover {
+  color: var(--link-hover);
+}
+
+/* Visible even with scrolling */
+.icon.close {
+  color: var(--text);
+  position: absolute;
+  right: 15px;
+  top: 15px;
+}
+
+.fa-info-circle {
+  text-align: right;
+  display: inline-block;
+  width: 100%;
+  padding: 5px;
+}
+
+.header {
+  font-weight: 900;
+}
+</style>


### PR DESCRIPTION
## Description

New feature that's allowing to add info button on cards with popup and description.
[Fixed #issue](https://github.com/bastienwirtz/homer/issues/570)
It extends Generic component.
Data format is:
```
item: {
  info: {
    header: "fancy header",
    content: "fancier content"
  }
}

```


I'm pretty new to all this forking stuff so if you don't like it that's fine. I just wanted to try it and maybe contribute with something useful :D  

Preview images:
<img width="236" alt="Screenshot 2023-06-02 at 15 37 03" src="https://github.com/bastienwirtz/homer/assets/35303961/ce9b3f04-f112-4c2b-8e2c-8a9b9076e3e1">
<img width="1440" alt="Screenshot 2023-06-02 at 15 40 18" src="https://github.com/bastienwirtz/homer/assets/35303961/1cfb6441-41e7-42a6-8b56-1f4928533255">


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [ ] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
