### PR TITLE
Handling empty groups in search function

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -283,9 +283,11 @@ export default {
 
       const searchResultItems = [];
       for (const group of this.config.services) {
-        for (const item of group.items) {
-          if (this.matchesFilter(item)) {
-            searchResultItems.push(item);
+        if (group.items !== null) {
+          for (const item of group.items) {
+            if (this.matchesFilter(item)) {
+              searchResultItems.push(item);
+            }
           }
         }
       }


### PR DESCRIPTION
## Description
Now the search function does not crash when an empty group is on the dashboard.

Fixes #691

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [ ] I have made corresponding changes to the documentation (README.md). -> not necesarry
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
