### PR TITLE
Use SUBFOLDER as asset base to allow mounting homer at a different base path.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@ dockerfile
 .git
 screenshot.png
 node_modules
+dummy-data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # build stage
 FROM node:lts-alpine as build-stage
 
+ARG SUBFOLDER ""
+
 WORKDIR /app
 
 COPY package*.json ./

--- a/src/App.vue
+++ b/src/App.vue
@@ -208,7 +208,7 @@ export default {
 
         if (this.currentPage !== "default") {
           let pageConfig = await this.getConfig(
-            `assets/${this.currentPage}.yml`
+            `${import.meta.env.BASE_URL}/assets/${this.currentPage}.yml`
           );
           config = Object.assign(config, pageConfig);
         }
@@ -230,7 +230,7 @@ export default {
         this.createStylesheet(stylesheet);
       }
     },
-    getConfig: function (path = "assets/config.yml") {
+    getConfig: function (path = `${import.meta.env.BASE_URL}/assets/config.yml`) {
       return fetch(path).then((response) => {
         if (response.status == 404 || response.redirected) {
           this.configNotFound = true;

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,7 +6,7 @@ import vue from "@vitejs/plugin-vue";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: "",
+  base: process.env.SUBFOLDER ?? "",
   build: {
     assetsDir: "resources",
   },


### PR DESCRIPTION
To try run e.g.:

    $ docker build -t homer --build-arg SUBFOLDER=/bar . && docker run --rm -p 8080:8080 -e SUBFOLDER=/bar homer

before and after. Previously, the base path wasn't set. So when browsing to the lighthttp alias, you'd be instantly be sent back to the root path.

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #578 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [X] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [ ] I have made corresponding changes to the documentation (README.md).
- [ ] I've checked my modifications for any breaking changes, especially in the `config.yml` file
