### PR TITLE
Fix Immich fetch stats 

### DIFF
--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -437,7 +437,8 @@ The PiAlert service displays stats from your PiAlert server.
 
 ## Immich
 
-The Immich service displays stats from your Immich server.
+The Immich service displays stats from your Immich server. 
+The Immich server must be running at least version 1.85.0 for the correct api endpoint to work.
 
 ```yaml
 - name: "Immich"

--- a/src/components/services/Immich.vue
+++ b/src/components/services/Immich.vue
@@ -78,7 +78,7 @@ export default {
         "x-api-key": this.item.apikey,
       };
 
-      this.fetch(`/api/server-info/stats`, { headers })
+      this.fetch(`/api/server-info/statistics`, { headers })
         .then((stats) => {
           this.photos = stats.photos;
           this.videos = stats.videos;


### PR DESCRIPTION
api changes in immich v1.85.0

## Description

In Immich v1.85.0 the "/server-info/stats" endpoint was changed to "/server-info/statistics" per the release notes https://github.com/immich-app/immich/releases/tag/v1.85.0 

Fixes #719 

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x ] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [ x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [ x] I have made corresponding changes to the documentation (README.md).
- [x ] I've checked my modifications for any breaking changes, especially in the `config.yml` file
