### PR TITLE
Fix Pi-hole logo URL

### DIFF
--- a/public/assets/config-demo.yml.dist
+++ b/public/assets/config-demo.yml.dist
@@ -70,7 +70,7 @@ services:
     icon: "fas fa-cloud"
     items:
       - name: "Pi-hole"
-        logo: "https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/pihole.png"
+        logo: "https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/pi-hole.png"
         url: "https://pi-hole.net/"
         endpoint: "https://homer-demo-content.netlify.app/pihole"
         type: "PiHole"


### PR DESCRIPTION
## Description

- Updated Pi Hole logo URL in the default dashboard because the link is outdated
![image](https://github.com/bastienwirtz/homer/assets/93255373/99f65f81-b02c-4dcb-8a6d-dd3a4f6d3714)


Fixes #-

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
