### PR TITLE
feat: Import secretes from secrets.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,6 @@ yarn-error.log*
 
 # App configuration
 config.yml
+secrets.yml
 
 .drone.yml

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -194,3 +194,29 @@ The `/assets/manifest.json` can also be edited to change the app (pwa) name, des
 ## PWA Icons
 
 See icons documentation [here](https://github.com/bastienwirtz/homer/blob/main/public/assets/icons/README.md).
+
+
+## Importing Secrets
+
+You can import sensitive information such as API keys or passwords into your `config.yml` file securely using the `!secret` keyword. The corresponding tokens are stored in the `secrets.yml` file. This approach allows you to keep confidential information separate, eliminating the need to expose sensitive information directly in your configuration.
+
+
+### Example:
+
+In your `secrets.yml` file:
+
+```yaml
+api_key: your_super_secret_api_key
+db_password: your_secure_database_password
+```
+
+In your `config.yml` file:
+
+```yaml
+services:
+  - name: "Example Service"
+    api_key: !secret api_key
+    database:
+      password: !secret db_password
+# ...
+```

--- a/public/assets/config-demo.yml.dist
+++ b/public/assets/config-demo.yml.dist
@@ -83,7 +83,7 @@ services:
         node: "node1"
         warning_value: 50
         danger_value: 80
-        api_token: "xxxxxxxxxxxx"
+        api_token: !secret proxmox_api
       - name: "An awesome app"
         logo: "assets/tools/sample.png"
         subtitle: "Bookmark example"
@@ -95,7 +95,7 @@ services:
     items:
       - name: "Octoprint"
         logo: "https://cdn-icons-png.flaticon.com/512/3112/3112529.png"
-        apikey: "xxxxxxxxxxxx"
+        apikey: !secret octoprint_api
         endpoint: "https://homer-demo-content.netlify.app/octoprint"
         type: "OctoPrint"
       - name: "Example item"
@@ -107,7 +107,7 @@ services:
         target: "_blank" 
       - name: "Weather"
         location: "Lyon"
-        apikey: "xxxxxxxxxxxx" # insert your own API key here. Request one from https://openweathermap.org/api.
+        apikey: !secret weather_api # insert your own API key here. Request one from https://openweathermap.org/api.
         units: "metric"
         endpoint: "https://homer-demo-content.netlify.app/openweather/weather"
         type: "OpenWeather"

--- a/public/assets/secrets.yml
+++ b/public/assets/secrets.yml
@@ -1,1 +1,4 @@
 some_password: welcome # include it in your config.yml by using !secret some_password
+proxmox_api: xxxxxxxxxxxx
+octoprint_api: xxxxxxxxxxxx
+weather_api: xxxxxxxxxxxx

--- a/public/assets/secrets.yml
+++ b/public/assets/secrets.yml
@@ -1,0 +1,1 @@
+some_password: welcome # include it in your config.yml by using !secret some_password


### PR DESCRIPTION
## Description

I have implemented a new function so that it is now possible to import secrets from a `secrets.yml` file using the keyword `!secret`.

When loading the config, the corresponding key is loaded with the token from the secrets.yml file and replaced everywhere in the `config.yml` file

Fixes #609

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [ ] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
