### PR TITLE
fix: improve grammar of offline message

### DIFF
--- a/src/components/ConnectivityChecker.vue
+++ b/src/components/ConnectivityChecker.vue
@@ -2,7 +2,7 @@
   <div v-if="offline" class="offline-message">
     <i class="far fa-dizzy"></i>
     <h1>
-      You're offline friend.
+      You're offline, friend.
       <span @click="checkOffline"> <i class="fas fa-redo-alt"></i></span>
     </h1>
   </div>


### PR DESCRIPTION
## Description

The message that appears when Homer is offline implies that the developers of Homer consider me to be their offline friend. I believe the intent of the message is to communicate that I am simultaneously offline and considered by Homer's developers to be a friend.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
