### PR TITLE
Allow using the same host with different port for urls

### DIFF
--- a/src/components/Service.vue
+++ b/src/components/Service.vue
@@ -14,6 +14,13 @@ export default {
   },
   computed: {
     component() {
+      if (this.item.url.startsWith('/') || this.item.url.startsWith(':')) {
+        let hostname = window.location.hostname;
+        if (hostname.endsWith('/')) {
+          hostname = hostname.slice(0, -1)
+        }
+        this.item.url = window.location.protocol + '//' + hostname + this.item.url
+      }
       const type = this.item.type || "Generic";
       if (type === "Generic") {
         return Generic;


### PR DESCRIPTION
## Description

Some places still not have this modification, for example the links section, as I don't know how to implement this url calculation in multiple places nicely in Vue/JS.
I've only had a problem with trailing slash on iOS, not on desktop.
I've also had a problem with having to recreate the "Add to Home" icon for changes to take effect on iOS. Maybe trailing slash wasn't even a problem and not even the first iteration of the code had any effect. (But then why did the config change had an effect?) -- Might be unrelated.

Partial fix for #726 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [ ] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
