### PR TITLE
Added comment and example on how to set PUID and PGID.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM node:lts-alpine3.19 as build-stage
 WORKDIR /app
 
 COPY package.json ./
-RUN yarn install --frozen-lockfile --non-interactive
+RUN yarn install --verbose --frozen-lockfile --non-interactive
 
 COPY . .
 RUN yarn build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,10 @@ services:
       - /your/local/assets/:/www/assets
     ports:
       - 8080:8080
+    # homer doesn't accept PUID and PGID set in environment.
+    # to use global environment variables (e.g. like in omv-compose) 
+    # declare user like this:
+    # user: ${PUID}:${PGID}
     user: 1000:1000 # default
     environment:
       - INIT_ASSETS=1 # default


### PR DESCRIPTION
## Description

Users ran into issues with "Error: Assets directory not writable."
By placing a comment as a hint in docker-compose.yml users don't need to search for a solution.
As homer doesn't seem to support PUID and PGID assignment in "environment:", users should
be told to set user via the "user: xxx:xxx" option.

Fixes #459 

## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x ] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x ] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [ ] I have made corresponding changes to the documentation (README.md).
- [ ] I've checked my modifications for any breaking changes, especially in the `config.yml` file
