### PR TITLE
Feature/local port custom service

### DIFF
--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -10,6 +10,7 @@ within Homer:
 
 - [Custom Services](#custom-services)
   - [Common options](#common-options)
+  - [GenericWithPort](#gemericwithport)
   - [PiHole](#pihole)
   - [OpenWeatherMap](#openweathermap)
   - [Medusa](#medusa)
@@ -49,6 +50,17 @@ If you experiencing any issue, please have a look to the [troubleshooting](troub
   endpoint: "http://my-service-endpoint" # Optional: alternative base URL used to fetch service data is necessary.
   useCredentials: false # Optional: Override global proxy.useCredentials configuration.
   type: "<type>"
+```
+
+## GenericWithPort
+Is shown as a generic service, but you can specify an additional port where the service is running, in case there is no DNS for the domain or reverse proxy for this service.
+A link to access this service via port is added to which the browser is redirected based on the base url where the user accessed homer.
+```yaml
+- name: "My Service"
+  logo: "assets/tools/sample.png"
+  url: "http://my-service.domain"
+  port: <my-port>
+  type: "GenericWithPort"
 ```
 
 ## PiHole

--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -10,7 +10,7 @@ within Homer:
 
 - [Custom Services](#custom-services)
   - [Common options](#common-options)
-  - [GenericWithPort](#gemericwithport)
+  - [GenericWithPort](#genericwithport)
   - [PiHole](#pihole)
   - [OpenWeatherMap](#openweathermap)
   - [Medusa](#medusa)

--- a/src/components/services/GenericWithPort.vue
+++ b/src/components/services/GenericWithPort.vue
@@ -1,0 +1,85 @@
+<template>
+  <div class="is-multiline layout-vertical">
+    <div
+      class="card"
+      :style="`background-color:${item.background};`"
+      :class="item.class"
+    >
+      <a :href="item.url" :target="item.target" rel="noreferrer">
+        <div class="card-content">
+          <div :class="mediaClass">
+            <slot name="icon">
+              <div v-if="item.logo" class="media-left">
+                <figure class="image is-48x48">
+                  <img :src="item.logo" :alt="`${item.name} logo`" />
+                </figure>
+              </div>
+              <div v-if="item.icon" class="media-left">
+                <figure class="image is-48x48">
+                  <i style="font-size: 35px" :class="['fa-fw', item.icon]"></i>
+                </figure>
+              </div>
+            </slot>
+            <div class="media-content">
+              <slot name="content">
+                <p class="title is-4">{{ item.name }}</p>
+                <p class="subtitle is-6" v-if="item.subtitle">
+                  {{ item.subtitle }}
+                </p>
+              </slot>
+            </div>
+            <slot name="indicator" class="indicator"></slot>
+          </div>
+          <div class="tag" :class="item.tagstyle" v-if="item.tag">
+            <strong class="tag-text">#{{ item.tag }}</strong>
+          </div>
+        </div>
+      </a>
+      <footer class="card-footer" v-if="item.port">
+        <a
+          href="/" :target="item.target"
+          @click="onClickPort"
+          @mouseover="onMouseoverPort"
+          rel="noreferrer"
+          class="card-footer-item"
+        >:{{ item.port }}</a>
+      </footer>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "GenericWithPort",
+  props: {
+    item: Object,
+  },
+  computed: {
+    mediaClass: function () {
+      return { media: true, "no-subtitle": !this.item.subtitle };
+    },
+  },
+  methods: {
+    onMouseoverPort: function(event){
+      event.target.port = this.item.port;
+    },
+    onClickPort: function(event){
+      event.target.port = this.item.port;
+    }
+  },
+};
+</script>
+
+<style scoped lang="scss">
+.media-left {
+  .image {
+    display: flex;
+    align-items: center;
+  }
+
+  img {
+    max-height: 100%;
+    object-fit: contain;
+  }
+}
+</style>


### PR DESCRIPTION
## Description
I often access my services not only via reverse proxy but also by port.
E.g. I access the service via URL  if I am at home and if I want to access it remotely via wireguard, the DNS does not properly work, so I access the service via port.  
Up until now, you could only specify one URL for a service in homer, so either the subdomain that is registered in the reverse proxy or the URL with the port.  

I added a `GenericWithPort` custom service, where you can specify the url and the port. This adds a small footer to the service card which contains a link to the service via port.
Depending on the current base url where you are accessing homer, the link leads to the service on that port.

You can see some example screenshots below (the mouse cursor is not visible, but is hovering over the corresponding link, so you can see the url that it leads to).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [X] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [X] I have made corresponding changes to the documentation (README.md).
- [X] I've checked my modifications for any breaking changes, especially in the `config.yml` file


# Examples
### Overview
![local Homer](https://github.com/bastienwirtz/homer/assets/15056932/f9ed425c-9fa4-4652-b0c7-e9c3746d9243)
### Mouse hovering over the usual link
![homer-url](https://github.com/bastienwirtz/homer/assets/15056932/49fdbb90-478a-41ec-8cd0-82639cbf4460)
## Mouse hovering over Port link
![homer-port](https://github.com/bastienwirtz/homer/assets/15056932/1d0cb0b8-de6c-4f86-b2db-8cb4b0fcaa70)

