### PR TITLE
Display round-trip time on the subtitle of the custom service ping

### DIFF
--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -137,16 +137,16 @@ API key can be generated in Settings > Administration > Auth Tokens
 
 ## Ping
 
-For Ping you need to set the type to Ping and provide a url. By default the HEAD method is used but it can be configured to use GET using the optional `method` property.
+For Ping you need to set the type to Ping and provide a url. By default the HEAD method is used but it can be configured to use GET using the optional `method` property. You can also choose to show the round trip time (RTT) by setting `showRtt` to true, default is false.
 
 ```yaml
 - name: "Awesome app"
   type: Ping
   logo: "assets/tools/sample.png"
-  subtitle: "Bookmark example"
   tag: "app"
   url: "https://www.reddit.com/r/selfhosted/"
   method: "head"
+  showRtt: false
 ```
 
 ## Prometheus

--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -137,7 +137,7 @@ API key can be generated in Settings > Administration > Auth Tokens
 
 ## Ping
 
-For Ping you need to set the type to Ping and provide a url. By default the HEAD method is used but it can be configured to use GET using the optional `method` property. You can also choose to show the round trip time (RTT) by setting `showRtt` to true, default is false.
+For Ping you need to set the type to Ping and provide a url. By default the HEAD method is used but it can be configured to use GET using the optional `method` property. You can also choose to show the round trip time (RTT) by setting `showRtt` to true, default is false. The RTT will be displayed in the subtitle section.
 
 ```yaml
 - name: "Awesome app"
@@ -146,7 +146,8 @@ For Ping you need to set the type to Ping and provide a url. By default the HEAD
   tag: "app"
   url: "https://www.reddit.com/r/selfhosted/"
   method: "head"
-  showRtt: false
+  subtitle: "Bookmark example"
+  # showRtt: true
 ```
 
 ## Prometheus

--- a/src/components/services/Ping.vue
+++ b/src/components/services/Ping.vue
@@ -5,6 +5,14 @@
         {{ status }}
       </div>
     </template>
+    <template #content>
+      <p class="title is-4">{{ item.name }}</p>
+      <p class="subtitle is-6">
+      <template v-if="status === 'online' && item.showRtt">
+        {{ rtt }} ms
+      </template>
+      </p>
+    </template>
   </Generic>
 </template>
 
@@ -23,6 +31,7 @@ export default {
   },
   data: () => ({
     status: null,
+    rtt: null,
   }),
   created() {
     this.fetchStatus();
@@ -39,12 +48,17 @@ export default {
         return;
       }
 
+      const startTime = performance.now();
+
       this.fetch("/", { method, cache: "no-cache" }, false)
         .then(() => {
           this.status = "online";
+          const endTime = performance.now();
+          this.rtt = Math.round(endTime - startTime);
         })
         .catch(() => {
           this.status = "offline";
+          this.rtt = null; // Reset rtt on failure
         });
     },
   },
@@ -81,3 +95,4 @@ export default {
   }
 }
 </style>
+

--- a/src/components/services/Ping.vue
+++ b/src/components/services/Ping.vue
@@ -11,6 +11,12 @@
       <template v-if="status === 'online' && item.showRtt">
         {{ rtt }} ms
       </template>
+      <template v-else-if="status === 'offline' && item.showRtt">
+        N/A
+      </template>
+      <template v-else-if="!item.showRtt && item.subtitle">
+          {{ item.subtitle }}
+      </template>
       </p>
     </template>
   </Generic>


### PR DESCRIPTION
## Description

Display round-trip time on the subtitle of the custom service ping. Toggled by showRtt, default set to false.

<img width="446" alt="Screenshot 2024-08-12 at 06 52 00" src="https://github.com/user-attachments/assets/5b24627d-4357-4d6e-b314-dceecd31ca8d">

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
