### PR TITLE
Fixes mealie when meal plan is empty

### DIFF
--- a/src/components/services/Mealie.vue
+++ b/src/components/services/Mealie.vue
@@ -6,7 +6,9 @@
         <template v-if="item.subtitle">
           {{ item.subtitle }}
         </template>
-        <template v-else-if="meal"> Today: {{ meal[0].recipe.name }} </template>
+        <template v-else-if="meal">
+          Today: {{ (meal && meal.length > 0) ? meal[0].recipe.name : 'Nothing planned' }}
+        </template>
         <template v-else-if="stats">
           happily keeping {{ stats.totalRecipes }} recipes organized
         </template>

--- a/src/components/services/Mealie.vue
+++ b/src/components/services/Mealie.vue
@@ -7,7 +7,7 @@
           {{ item.subtitle }}
         </template>
         <template v-else-if="meal">
-          Today: {{ (meal && meal.length > 0) ? meal[0].recipe.name : 'Nothing planned' }}
+          Today: {{ meal.length > 0 ? meal[0].recipe.name : 'Nothing planned' }}
         </template>
         <template v-else-if="stats">
           happily keeping {{ stats.totalRecipes }} recipes organized

--- a/src/components/services/Mealie.vue
+++ b/src/components/services/Mealie.vue
@@ -6,11 +6,11 @@
         <template v-if="item.subtitle">
           {{ item.subtitle }}
         </template>
-        <template v-else-if="meal">
-          Today: {{ meal.length > 0 ? meal[0].recipe.name : 'Nothing planned' }}
+        <template v-else-if="mealtext">
+          {{ mealtext }}
         </template>
-        <template v-else-if="stats">
-          happily keeping {{ stats.totalRecipes }} recipes organized
+        <template v-else-if="statsText">
+          {{ statsText }}
         </template>
       </p>
     </template>
@@ -34,6 +34,20 @@ export default {
     stats: null,
     meal: null,
   }),
+  computed: {
+    mealtext: function () {
+      if (this.meal && this.meal.length > 0) {
+        return `Today: ${this.meal[0].recipe.name}`;
+      }
+      return null;
+    },
+    statsText: function () {
+      if (this.stats) {
+        return `Happily keeping ${this.stats.totalRecipes} recipes organized`;
+      }
+      return null;
+    }
+  },
   created() {
     this.fetchStatus();
   },


### PR DESCRIPTION
If there's nothing in the meal plan for the current day, the /api/groups/mealplans/today endpoint will simply return an `[]` response.

This case wasn't guarded for in the template before this fix.

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

Follow up to https://github.com/bastienwirtz/homer/issues/721.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [ ] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [ ] I have made corresponding changes to the documentation (README.md).
- [ ] I've checked my modifications for any breaking changes, especially in the `config.yml` file
