### PR TITLE
Tag use --highlight-secondary background if not set bulma classes

### DIFF
--- a/src/assets/components/base.scss
+++ b/src/assets/components/base.scss
@@ -181,8 +181,6 @@
       }
   
       .tag {
-        color: var(--highlight-secondary);
-        background-color: var(--highlight-secondary);
         position: absolute;
         bottom: 1rem;
         right: -0.2rem;
@@ -190,6 +188,11 @@
         overflow: hidden;
         transition: all 0.2s ease-out;
         padding: 0;
+
+        &:not([class*="is-"]) {
+          color: #ffffff;
+          background-color: var(--highlight-secondary);
+        }
   
         .tag-text {
           display: none;
@@ -213,7 +216,6 @@
   
         .tag {
           width: auto;
-          color: #ffffff;
           padding: 0 0.75em;
   
           .tag-text {


### PR DESCRIPTION
## Description

Changed the selector to change the background color of .tag

Fixes #792

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
