### PR TITLE
Ping service timeout

### DIFF
--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -153,7 +153,7 @@ This card checks if the target link is available. All you need is to set the `ty
   logo: "assets/tools/sample.png"
   url: "https://www.wikipedia.org/"
   # method: "head"
-  # timeout: 500
+  # timeout: 500 # in ms. default 2000
   # subtitle: "Bookmark example" # By default, request round trip time is displayed when subtitle is not set.
 ```
 

--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -153,6 +153,7 @@ This card checks if the target link is available. All you need is to set the `ty
   logo: "assets/tools/sample.png"
   url: "https://www.wikipedia.org/"
   # method: "head"
+  # timeout: 500
   # subtitle: "Bookmark example" # By default, request round trip time is displayed when subtitle is not set.
 ```
 

--- a/src/components/services/Ping.vue
+++ b/src/components/services/Ping.vue
@@ -60,8 +60,14 @@ export default {
       }
 
       const startTime = performance.now();
+      const timeout = parseInt(this.item.timeout, 10) || 2000;
+      const params = { 
+        method, 
+        cache: "no-cache", 
+        signal: AbortSignal.timeout(timeout) 
+      };
 
-      this.fetch("/", { method, cache: "no-cache" }, false)
+      this.fetch("/", params, false)
         .then(() => {
           this.status = "online";
           const endTime = performance.now();


### PR DESCRIPTION
## Description

Added support for the timeout option for the Ping service. The default value is 2000 ms, which should be sufficient for most services.

Fixes #804

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
