### PR TITLE
add Gitea subtitle fallback and dummy data

### DIFF
--- a/dummy-data/gitea/swagger.v1.json
+++ b/dummy-data/gitea/swagger.v1.json
@@ -1,0 +1,11 @@
+{
+  "info": {
+    "description": "This documentation describes the Forgejo API.",
+    "title": "Forgejo API",
+    "license": {
+      "name": "MIT",
+      "url": "http://opensource.org/licenses/MIT"
+    },
+    "version": "8.0.3+gitea-1.22.0"
+  }
+}

--- a/src/components/services/Gitea.vue
+++ b/src/components/services/Gitea.vue
@@ -3,7 +3,10 @@
     <template #content>
       <p class="title is-4">{{ item.name }}</p>
       <p class="subtitle is-6">
-        <template v-if="versionstring">
+        <template v-if="item.subtitle">
+          {{ item.subtitle }}
+        </template>
+        <template v-else-if="versionstring">
           Version {{ versionstring }}
         </template>
       </p>


### PR DESCRIPTION
I omitted most of the 0.5MiB Gitea/Foregejo API reponse from `dummy-data/gitea/swagger.v1.json` for brevity.

Omitted full PR description boilerplate since this is just a followup of #833 