### PR TITLE
Fix link for smart cards in demo app

### DIFF
--- a/public/assets/config-demo.yml.dist
+++ b/public/assets/config-demo.yml.dist
@@ -66,7 +66,7 @@ services:
         icon: "fa-solid fa-palette"
         subtitle: "Displays dynamic information or actions."
         tag: "setup"
-        url: "https://github.com/bastienwirtz/homer/blob/main/docs/theming.md"
+        url: "https://github.com/bastienwirtz/homer/blob/main/docs/customservices.md"
       - name: "Dashboard icons"
         icon: "fa-solid fa-icons"
         subtitle: "Dashboard icons"

--- a/public/assets/config.yml.dist
+++ b/public/assets/config.yml.dist
@@ -93,7 +93,7 @@ services:
         icon: "fa-solid fa-palette"
         subtitle: "Displays dynamic information or actions."
         tag: "setup"
-        url: "https://github.com/bastienwirtz/homer/blob/main/docs/theming.md"
+        url: "https://github.com/bastienwirtz/homer/blob/main/docs/customservices.md"
       - name: "Dashboard icons"
         icon: "fa-solid fa-icons"
         subtitle: "Dashboard icons"


### PR DESCRIPTION
## Description

Just a tiny fix for a wrong link in the demo app

Fixes # (issue)

Smart cards widget in the demo app was wrongly pointing to theming.md.