### PR TITLE
force response to text if not json

### DIFF
--- a/src/mixins/service.js
+++ b/src/mixins/service.js
@@ -56,7 +56,7 @@ export default {
           throw new Error(`Ping: target not available (${response.status} error)`);
         }
 
-        return json ? response.json() : response;
+        return json ? response.json() : response.text();
       });
     },
   },


### PR DESCRIPTION
Without that I'm getting Version "[object Response]" on the smart card from an api that returns text/plain.

See #847 - add Docuseal (requires text/plain support or hack)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [ ] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. **not checking this off because I have done only minimal testing**
- [ ] I have made corresponding changes to the documentation (README.md). **n/a**
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
