### PR TITLE
disable cache for Docuseal fetch

### DIFF
--- a/src/components/services/Docuseal.vue
+++ b/src/components/services/Docuseal.vue
@@ -41,7 +41,10 @@ export default {
   },
   methods: {
     fetchStatus: async function () {
-      this.fetch("/version", null, false)
+      const params = {
+        cache: "no-cache",
+      };
+      this.fetch("/version", params, false)
         .then((response) => {
           this.status = "online";
           this.versionstring = response;


### PR DESCRIPTION
I noticed my Docuseal card was showing "online" after I'd shut it down.

Might be from one of these? https://github.com/search?q=repo%3Adocusealco%2Fdocuseal%20cache%20control&type=code

and/or because /version is just a file?

Either way, this fixes it from the Homer side.

## Description

This fixes invalid online/offline status for the Docusign card.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. **I did limited testing only**
- [x] I have made corresponding changes to the documentation (README.md). **n/a**
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
