### PR TITLE
Update walkxcode.scss

### DIFF
--- a/src/assets/themes/walkxcode.scss
+++ b/src/assets/themes/walkxcode.scss
@@ -12,7 +12,7 @@
   --card-shadow: rgba(0, 0, 0, 0.5);
   --link: #3273dc;
   --link-hover: #2e4053;
-  --background-image: url("assets/themes/walkxcode/wallpaper-light.webp");
+  --background-image: url("/assets/themes/walkxcode/wallpaper-light.webp");
 }
 
 .theme-walkxcode.dark {
@@ -28,7 +28,7 @@
   --card-shadow: rgba(0, 0, 0, 0.5);
   --link: #ffffff;
   --link-hover: #fafafa;
-  --background-image: url("assets/themes/walkxcode/wallpaper.webp");
+  --background-image: url("/assets/themes/walkxcode/wallpaper.webp");
 }
 
 // theme


### PR DESCRIPTION
Addresses issue #769 where background image url is referencing <ip_address>/resources/assets/themes/walkxcode (404) rather than <ip_address>/assets/themes/walkxcode where the images are stored

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [ ] I have made corresponding changes to the documentation (README.md).
- [ ] I've checked my modifications for any breaking changes, especially in the `config.yml` file
