### PR TITLE
Fix quicklinks conditional icon rendering

### DIFF
--- a/src/components/services/Generic.vue
+++ b/src/components/services/Generic.vue
@@ -28,7 +28,7 @@
                     :target="link.target"
                     rel="noreferrer"
                   >
-                    <span v-if="item.icon"
+                    <span v-if="link.icon"
                       ><i
                         style="font-size: 12px"
                         :class="['fa-fw', link.icon]"


### PR DESCRIPTION
## Description
The quicklinks icon does not render unless the “parent” service also has an icon, which is not always the case.
Likely a copy-pasta.

Fixes # (issue)

https://github.com/bastienwirtz/homer/issues/874

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [ ] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [ ] I have made corresponding changes to the documentation (README.md).
- [ ] I've checked my modifications for any breaking changes, especially in the `config.yml` file
