### PR TITLE
fix(Dockerfile): ensure VERSION_TAG is correctly passed as a build ar…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN pnpm build
 # production stage
 FROM alpine:3.21
 
-ARG VERSION_TAG
+ARG VERSION_TAG=latest
 
 LABEL \
     org.label-schema.schema-version="1.0" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ RUN pnpm build
 # production stage
 FROM alpine:3.21
 
+ARG VERSION_TAG
+
 LABEL \
     org.label-schema.schema-version="1.0" \
     org.label-schema.version="$VERSION_TAG" \


### PR DESCRIPTION
## **Description**  

This PR fixes an issue where the `VERSION_TAG` label was not correctly set in the built Docker image due to a missing `ARG` definition in the `Dockerfile`.  

### **Issue Summary**  
The `VERSION_TAG` value was passed as a `build-arg` in GitHub Actions but was not recognized inside the `Dockerfile` because the `ARG VERSION_TAG` statement was missing. As a result, the image labels that referenced `$VERSION_TAG` were empty.  

### **Fix**  
- Added `ARG VERSION_TAG=latest` in the `Dockerfile`, ensuring that the build argument is recognized.
- This allows the `LABEL` section to properly use `${VERSION_TAG}`.

Fixes #881  

---

## **Type of change**  

- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  

---

## **Checklist**  

- [x] I've read & comply with the [[contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md).  
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.  
- [ ] I have made corresponding changes to the documentation (README.md) (N/A for this change).  
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file.  