### PR TITLE
Fix typos in `config-schema.json`

### DIFF
--- a/.schema/config-schema.json
+++ b/.schema/config-schema.json
@@ -70,10 +70,10 @@
       "properties": {
         "layout": {
           "enum": [
-            "colums",
+            "columns",
             "list"
           ],
-          "description": "Layout of the dashboard, either 'column' or 'list'"
+          "description": "Layout of the dashboard, either 'columns' or 'list'"
         },
         "colorTheme": {
           "enum": [


### PR DESCRIPTION
## Description

Fix 2 little typos in the json schema. `colums` was giving false validation error.

![image](https://github.com/user-attachments/assets/c3e49841-2543-4675-bdfc-3c6aa9b089c0)

Fixes #893

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
