### PR TITLE
Add Linkding support

### DIFF
--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -25,6 +25,7 @@ within Homer:
 - [Immich](#immich)
 - [Jellystat](#jellystat)
 - [Lidarr, Prowlarr, Sonarr, Readarr and Radarr](#lidarr-prowlarr-sonarr-readarr-and-radarr)
+- [Linkding](#linkding)
 - [Mealie](#mealie)
 - [Medusa](#medusa)
 - [Nextcloud](#nextcloud)
@@ -274,6 +275,27 @@ If you are using an older version of Radarr or Sonarr which don't support the ne
   apikey: "<---insert-api-key-here--->"
   target: "_blank"
   legacyApi: true
+```
+
+## Linkding
+
+This integration makes it possible to query Linkding and list multiple results from Linkding.   
+Linkding has to be configured with CORS enabled. Linkding does not support that, but a reverse proxy in front can fix that.   
+For example if you use Traefik, documentation about that is here: https://doc.traefik.io/traefik/middlewares/http/headers/#cors-headers   
+Examples for various servers can be found at https://enable-cors.org/server.html.   
+
+This integration supports at max 15 results from Linkding. But you can add it multiple times to you dashboard with different queries to retrieve what you need.
+
+```yaml
+      - name: "Linkding"
+        # Url to Linkding instance
+        url: https://ld.ceesbos.nl
+        token: "<add your secret token here>"
+        type: "Linkding"
+        # Maximum number of items returned by Linkding, minimal 1 and max 15
+        limit: 10 
+        # query to do on Linkding. User #tagname to search for tags
+        query: "#ToDo #Homer" 
 ```
 
 ## Mealie

--- a/src/components/services/Linkding.vue
+++ b/src/components/services/Linkding.vue
@@ -1,0 +1,68 @@
+<template>
+  <template v-for="bookmark in bookmarks">
+      <Generic :item="bookmark">
+    </Generic>
+  </template>
+</template>
+
+<script>
+import service from "@/mixins/service.js";
+import Generic from "./Generic.vue";
+
+export default {
+  name: "Linkding",
+  components: {
+    Generic,
+  },
+  mixins: [service],
+  props: {
+    item: Object
+  },
+  data: () => ({
+    bookmarks: [],
+  }),
+  computed: {
+    calculatedLimit: function () {
+      let limit = this.item.hasOwnProperty('limit') ? this.item['limit'] : 5;
+      return Math.min(Math.max(limit,1),15);
+    }
+  },
+  created() {
+    this.fetchBookmarks();
+  },
+  methods: {
+    fetchBookmarks: async function () {
+      const headers = {
+        Authorization: `Token ${this.item.token}`,
+        Accept: "application/json",
+      };
+
+      let limit = this.calculatedLimit;
+
+      let query = ''
+      if (this.item.query) {
+        query = `&q=${encodeURIComponent(this.item.query)}`;
+      }
+
+      let url = `/api/bookmarks/?limit=${limit}${query}`;
+
+      this.fetch(url, {
+        headers,
+      })
+          .then((ld_response) => {
+            this.bookmarks = ld_response.results.map(bookmark => ({
+              name: `${bookmark.title}`,
+              subtitle: `${bookmark.description}`,
+              url: bookmark.url,
+              logo: `${bookmark.favicon_url}`,
+              tag: `${bookmark.tag_names.join(" #")}`
+            }));
+          })
+          .catch((e) => {
+            console.log(e);
+            this.error = true;
+          });
+    },
+  },
+};
+</script>


### PR DESCRIPTION
## Description

Linkding is a bookmark manager. 
With this integration it uses the REST API to fetch some (max 15) bookmarks based on a query.
For each of the returned bookmarks an items is created. 
So this is a more dynamic integration. 

<img width="396" alt="image" src="https://github.com/user-attachments/assets/929d9464-5694-471f-a5a6-d0e35fd6982a" />

Example use case:
For a project I am working on, I have a number website I often use. I can mark them with a tag in Linkding.
Then query for that tag from Homer, then I have that list at hand.
Once the project is done, I can remove the tag in Linkding and the list is cleaned Homer.
When I use a new website I can easily bookmark that page with the Linkding extension and add the same tag, then it directly appears on the Homer dashboard on new load.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
