### PR TITLE
For Portainer Service : add status online/offline and version of the card

### DIFF
--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -448,8 +448,11 @@ This service displays info about the total number of containers managed by your 
 In order to use it, you must be using Portainer version 1.11 or later. Generate an access token from the UI and pass
 it to the apikey field.
 By default, every connected environments will be checked. To select specific ones, add an "environments" entry which can be a simple string or an array containing all the selected environments name.
+### New features:
+Displays the Portainer version from /api/status  
+Shows online/offline status depending on API reachability  
 
-See <https://docs.portainer.io/api/access#creating-an-access-token>
+See <https://docs.portainer.io/api/access#creating-an-access-token>  
 
 ```yaml
 - name: "Portainer"

--- a/src/components/services/Portainer.vue
+++ b/src/components/services/Portainer.vue
@@ -1,5 +1,16 @@
 <template>
   <Generic :item="item">
+    <template #content>
+      <p class="title is-4">{{ item.name }}</p>
+      <p class="subtitle is-6">
+        <template v-if="item.subtitle">
+          {{ item.subtitle }}
+        </template>
+        <template v-else-if="versionstring">
+          Version {{ versionstring }}
+        </template>
+      </p>
+    </template>
     <template #indicator>
       <div class="notifs">
         <strong v-if="running > 0" class="notif running" title="Running">
@@ -8,13 +19,12 @@
         <strong v-if="dead > 0" class="notif dead" title="Dead">
           {{ dead }}
         </strong>
-        <strong
-          v-if="misc > 0"
-          class="notif misc"
-          title="Other (creating, paused, exited, etc.)"
-        >
+        <strong v-if="misc > 0" class="notif misc" title="Other (creating, paused, exited, etc.)">
           {{ misc }}
         </strong>
+      </div>
+      <div v-if="status" class="status" :class="status">
+        {{ status }}
       </div>
     </template>
   </Generic>
@@ -36,6 +46,8 @@ export default {
   data: () => ({
     endpoints: null,
     containers: null,
+    fetchOk: null,
+    versionstring: null,
   }),
   computed: {
     running: function () {
@@ -65,9 +77,13 @@ export default {
         );
       }).length;
     },
+    status: function () {
+      return this.fetchOk ? "online" : "offline";
+    },
   },
   created() {
     this.fetchStatus();
+    this.fetchVersion();
   },
   methods: {
     fetchStatus: async function () {
@@ -103,11 +119,54 @@ export default {
 
       this.containers = containers;
     },
+    fetchVersion: async function () {
+      const headers = {
+        "X-Api-Key": this.item.apikey,
+      };
+      this.fetch("/api/status", { headers })
+        .then((response) => {
+          this.fetchOk = true;
+          this.versionstring = response.Version;
+        })
+        .catch((e) => {
+          this.fetchOk = false;
+          console.error(e);
+        });
+    },
   },
 };
 </script>
 
 <style scoped lang="scss">
+.status {
+  font-size: 0.8rem;
+  color: var(--text-title);
+  white-space: nowrap;
+  margin-left: 0.25rem;
+
+  &.online:before {
+    background-color: #94e185;
+    border-color: #78d965;
+    box-shadow: 0 0 5px 1px #94e185;
+  }
+
+  &.offline:before {
+    background-color: #c9404d;
+    border-color: #c42c3b;
+    box-shadow: 0 0 5px 1px #c9404d;
+  }
+
+  &:before {
+    content: " ";
+    display: inline-block;
+    width: 7px;
+    height: 7px;
+    margin-right: 10px;
+    border: 1px solid #000;
+    border-radius: 7px;
+  }
+}
+
 .notifs {
   position: absolute;
   color: white;


### PR DESCRIPTION
## Description

Added Portainer status and version display to the Portainer service card.

:pushpin: Issue:
Previously, the Portainer service card only displayed the container stats (Running, Dead, etc.) without showing whether Portainer itself was accessible, or which version was in use.

:white_check_mark: Solution:

- Adds a health check via /api/status to determine if Portainer is online.
- Displays the Portainer version number when available.
- Shows an "online" or "offline" status indicator on the card.
- :blue_book: Updated documentation in customservices.md to reflect the new behavior.

:fire: Motivation:
Gives a clearer overview of the actual state of the Portainer instance, not just the containers. Helps quickly detect if Portainer is unreachable or misconfigured.
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
