### PR TITLE
Add service vaultwarden, view status and version

### DIFF
--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -49,6 +49,7 @@ within Homer:
 - [Tdarr](#tdarr)
 - [Traefik](#traefik)
 - [Uptime Kuma](#uptime-kuma)
+- [Vaultwarden](#vaultwarden)
 - [Wallabag](#wallabag)
 - [What's Up Docker](#whats-up-docker)
 
@@ -653,6 +654,17 @@ The following configuration is available for the UptimeKuma service. Needs v1.13
   url: "http://192.168.0.151:3001"
   slug: "myCustomDashboard" # Defaults to "default" if not provided.
   type: "UptimeKuma"
+```
+## Vaultwarden
+
+This service displays a version string instead of a subtitle. The indicator
+shows if Vaultwarden is online, offline
+
+```yaml
+- name: "Vaultwarden - Server"
+  type: "Vaultwarden"
+  logo: "assets/tools/sample.png"
+  url: "http://vaultwarden.example.com"
 ```
 
 ## Wallabag

--- a/src/components/services/Vaultwarden.vue
+++ b/src/components/services/Vaultwarden.vue
@@ -1,0 +1,92 @@
+<template>
+  <Generic :item="item">
+    <template #content>
+      <p class="title is-4">{{ item.name }}</p>
+      <p class="subtitle is-6">
+        <template v-if="item.subtitle">
+          {{ item.subtitle }}
+        </template>
+        <template v-else-if="versionstring">
+          Version {{ versionstring }}
+        </template>
+      </p>
+    </template>
+    <template #indicator>
+      <div v-if="status" class="status" :class="status">
+        {{ status }}
+      </div>
+    </template>
+  </Generic>
+</template>
+
+<script>
+import service from "@/mixins/service.js";
+import Generic from "./Generic.vue";
+
+export default {
+  name: "Vaultwarden",
+  components: {
+    Generic,
+  },
+  mixins: [service],
+  props: {
+    item: Object,
+  },
+  data: () => ({
+    fetchOk: null,
+    versionstring: null,
+  }),
+  computed: {
+    status: function () {
+      return this.fetchOk ? "online" : "offline";
+    },
+  },
+  created() {
+    this.fetchStatus();
+  },
+  methods: {
+    fetchStatus: async function () {
+      this.fetch("api/version")
+        .then((response) => {
+          this.fetchOk = true;
+          this.versionstring = response;
+        })
+        .catch((e) => {
+          this.fetchOk = false;
+          console.log(e);
+        });
+    },
+  },
+};
+</script>
+
+<style scoped lang="scss">
+.status {
+  font-size: 0.8rem;
+  color: var(--text-title);
+  white-space: nowrap;
+  margin-left: 0.25rem;
+
+  &.online:before {
+    background-color: #94e185;
+    border-color: #78d965;
+    box-shadow: 0 0 5px 1px #94e185;
+  }
+
+  &.offline:before {
+    background-color: #c9404d;
+    border-color: #c42c3b;
+    box-shadow: 0 0 5px 1px #c9404d;
+  }
+
+  &:before {
+    content: " ";
+    display: inline-block;
+    width: 7px;
+    height: 7px;
+    margin-right: 10px;
+    border: 1px solid #000;
+    border-radius: 7px;
+  }
+}
+</style>


### PR DESCRIPTION
## Description

Added a new service integration to monitor a **Vaultwarden** status.

📌 Issue :
There was no way to check if a Vaultwarden server was online or to display its version from the dashboard.

✅ Solution :

- Queries the Vaultwarden`api/version` endpoint to get the version string.
- Checks connectivity to determine whether the service is online or offline.
- Displays the version and status in the card.
- Updated the `customservices.md` documentation with usage instructions.

🔥 Motivation :
Allow users to monitor the availability and version of their Vaultwarden server directly in Homer.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
