### PR TITLE
add service TruenasScale, view status and version

### DIFF
--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -48,6 +48,7 @@ within Homer:
 - [Tautulli](#tautulli)
 - [Tdarr](#tdarr)
 - [Traefik](#traefik)
+- [TrueNas Scale](#truenas-scale)
 - [Uptime Kuma](#uptime-kuma)
 - [Wallabag](#wallabag)
 - [What's Up Docker](#whats-up-docker)
@@ -638,6 +639,18 @@ This service displays a version string instead of a subtitle. Example configurat
   type: Traefik
   logo: assets/tools/sample.png
   url: http://traefik.example.com
+```
+
+## Truenas Scale
+
+This service displays a version string instead of a subtitle. Example configuration:
+
+```yaml
+- name: "Truenas"
+  type: "TruenasScale"
+  logo: "assets/tools/sample.png"
+  url: "http://truenas.example.com"
+  api_token: "your_api_token"
 ```
 
 ## Uptime Kuma

--- a/src/components/services/TruenasScale.vue
+++ b/src/components/services/TruenasScale.vue
@@ -1,0 +1,97 @@
+<template>
+  <Generic :item="item">
+    <template #content>
+      <p class="title is-4">{{ item.name }}</p>
+      <p class="subtitle is-6">
+        <template v-if="item.subtitle">
+          {{ item.subtitle }}
+        </template>
+        <template v-else-if="versionstring">
+          <span class="is-hidden-touch">Version {{ versionstring }}</span>
+          <span class="is-hidden-desktop">Version {{ versionstring.split('-').pop() }}</span>
+        </template>
+      </p>
+    </template>
+    <template #indicator>
+      <div v-if="status" class="status" :class="status">
+        {{ status }}
+      </div>
+    </template>
+  </Generic>
+</template>
+
+<script>
+import service from "@/mixins/service.js";
+import Generic from "./Generic.vue";
+
+export default {
+  name: "TruenasScale",
+  components: {
+    Generic,
+  },
+  mixins: [service],
+  props: {
+    item: Object,
+  },
+  data: () => ({
+    fetchOk: null,
+    versionstring: null,
+  }),
+  computed: {
+    status: function () {
+      return this.fetchOk ? "online" : "offline";
+    },
+  },
+  created() {
+    this.fetchStatus();
+  },
+  methods: {
+    fetchStatus: async function () {
+      let headers = {};
+      if (this.item.api_token) {
+        headers["Authorization"] = `Bearer ${this.item.api_token}`;
+      }
+      this.fetch("/api/v2.0/system/version", { headers })
+        .then((response) => {
+          this.fetchOk = true;
+          this.versionstring = response;
+        })
+        .catch((e) => {
+          this.fetchOk = false;
+          console.log(e);
+        });
+    },
+  },
+};
+</script>
+
+<style scoped lang="scss">
+.status {
+  font-size: 0.8rem;
+  color: var(--text-title);
+  white-space: nowrap;
+  margin-left: 0.25rem;
+
+  &.online:before {
+    background-color: #94e185;
+    border-color: #78d965;
+    box-shadow: 0 0 5px 1px #94e185;
+  }
+
+  &.offline:before {
+    background-color: #c9404d;
+    border-color: #c42c3b;
+    box-shadow: 0 0 5px 1px #c9404d;
+  }
+
+  &:before {
+    content: " ";
+    display: inline-block;
+    width: 7px;
+    height: 7px;
+    margin-right: 10px;
+    border: 1px solid #000;
+    border-radius: 7px;
+  }
+}
+</style>


### PR DESCRIPTION
## Description

Added a new service integration to monitor a Truenas Scale status.

📌 Issue :
There was no way to check if a TrueNas Scale was online or to display its version from the dashboard.

✅ Solution :

- Query the Truenas /api/v2.0/system/version endpoint to get the version string.
- Checks connectivity to determine whether the service is online or offline.
- Displays the version and status in the card.
- Updated the customservices.md documentation with usage instructions.

🔥 Motivation :
Allow users to monitor the availability and version of their TrueNas Scale directly in Homer.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
