### PR TITLE
Update Message.vue

### DIFF
--- a/src/components/Message.vue
+++ b/src/components/Message.vue
@@ -79,6 +79,10 @@ export default {
 
     mapRemoteMessage: function (message) {
       let mapped = {};
+
+      // If the msg is an array, take the frist value
+      if (Array.isArray(message)) message = message[0];
+      
       // map property from message into mapped according to mapping config (only if field has a value):
       for (const prop in this.item.mapping)
         if (message[this.item.mapping[prop]])


### PR DESCRIPTION
## Description

This PR adds support for array responses from the `message.url` endpoint in the `Message.vue` component. It ensures that if the response is an array (as is the case with some public APIs like `zenquotes.io`), the component will correctly use the first item in the array as the message.

### Changes

- Updated `mapRemoteMessage()` to check if the response is an array and use the first item.

Fixes # (issue)
Optional message #750

### How to test

1. Use a message config that fetches from an endpoint returning an array.
2. Confirm that the message is now correctly displayed using the first object in the array.

```yaml
message:
  #url: ./assets/quote.json
  #url: https://zenquotes.io/api/random CORS error
  url: https://corsproxy.io/?url=https://zenquotes.io/api/random
  mapping:
    title: 'a'
    content: 'h'
  refreshInterval: 600000
  style: "is-primary"
  title: "Quote every 10m"
  icon: "fa fa-quote-left"
  content: "Loading quote..."
```

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [X] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes to the documentation (README.md).
- [X] I've checked my modifications for any breaking changes, especially in the `config.yml` file
