### PR TITLE
Fix typo in customservices docs

### DIFF
--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -107,7 +107,7 @@ Configuration example:
   clipboard: "this text will be copied to your clipboard"
 ```
 
-## Docker Socker Proxy
+## Docker Socket Proxy
 
 This service display the number of running, stopped and containers that have errors.
 It calls the API of DOcker Socket Proxy


### PR DESCRIPTION
## Description

I was checking the newly added services and noticed that upon clicking the hyperlink it doesn't automatically scroll down to the corresponding section. Seems to be caused by a small typo.

Looking forward to the new release, these additions are great!

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [ ] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes to the documentation (README.md).
- [ ] I've checked my modifications for any breaking changes, especially in the `config.yml` file
