### PR TITLE
docs: configure Pi-Hole v6 API with URL that ends with admin

### DIFF
--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -468,7 +468,8 @@ The following configuration is available for the PiHole service.
 - name: "Pi-hole"
   logo: "assets/tools/sample.png"
   # subtitle: "Network-wide Ad Blocking" # optional, if no subtitle is defined, PiHole statistics will be shown
-  url: "http://192.168.0.151/admin" # For v6 API, do not include /admin in the URL
+  url: "http://192.168.0.151/admin"
+  # endpoint: "http://192.168.0.151" # optional, For v6 API, this is the base URL used to fetch Pi-hole data overwriting the url
   apikey: "<---insert-api-key-here--->" # optional, needed if web interface is password protected
   type: "PiHole"
   apiVersion: 5 # optional, defaults to 5. Use 6 if your PiHole instance uses API v6


### PR DESCRIPTION
## Description

Illustrate a way to set up PiHole v6 smart card with a URL that still ends with `/admin` suffix

Fixes #924

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
