### PR TITLE
Do not mandate the usage of an API key for Pi-hole v6

### DIFF
--- a/src/components/services/PiHole.vue
+++ b/src/components/services/PiHole.vue
@@ -116,14 +116,6 @@ export default {
       this.sessionExpiry = null;
     },
     authenticate: async function () {
-      if (!this.item.apikey) {
-        this.handleError(
-          "API key is required for PiHole authentication",
-          "disabled",
-        );
-        return false;
-      }
-
       try {
         const authResponse = await this.fetch("/api/auth", {
           method: "POST",
@@ -166,7 +158,7 @@ export default {
     },
     fetchStatus: async function () {
       try {
-        if (!this.isAuthenticated) {
+        if (!this.isAuthenticated && this.item.apikey) {
           const authenticated = await this.authenticate();
           if (!authenticated) return;
         }
@@ -182,10 +174,8 @@ export default {
         this.percent_blocked = response.queries.percent_blocked;
         this.retryCount = 0;
       } catch (e) {
-        if (
-          e.message.includes("401 error") ||
-          e.message.includes("403 error")
-        ) {
+        const isAuthError = e.message.includes("401 error") || e.message.includes("403 error");
+        if (isAuthError && this.item.apikey) {
           this.removeCacheSession();
           return this.retryWithDelay();
         }


### PR DESCRIPTION
## Description
Pihole's built-in authentication can be entirely disabled, which can be desired if you use a reverse proxy + middleware for authentication.
In this case, Homer can simply send the proxy credentials and there's no need to authenticate / cache sessions / retry authentication.

Fixes # (issue)
Closes https://github.com/bastienwirtz/homer/issues/926
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [ ] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [ ] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
