### PR TITLE
Improve Pi-hole status

### DIFF
--- a/src/components/services/PiHole.vue
+++ b/src/components/services/PiHole.vue
@@ -230,6 +230,12 @@ export default {
   }
 
   &.disabled:before {
+    background-color: #f5a623;
+    border-color: #e59400;
+    box-shadow: 0 0 5px 1px #f5a623;
+  }
+
+  &.error:before {
     background-color: #c9404d;
     border-color: #c42c3b;
     box-shadow: 0 0 5px 1px #c9404d;

--- a/src/components/services/PiHole.vue
+++ b/src/components/services/PiHole.vue
@@ -170,13 +170,15 @@ export default {
           const authenticated = await this.authenticate();
           if (!authenticated) return;
         }
-        const summary_response = await this.fetch(
-          `api/stats/summary?sid=${encodeURIComponent(this.sessionId)}`,
-        );
 
-        const status_response = await this.fetch(
-          `api/dns/blocking?sid=${encodeURIComponent(this.sessionId)}`,
-        );
+        const [summary_response, status_response] = await Promise.all([
+          this.fetch(
+            `api/stats/summary?sid=${encodeURIComponent(this.sessionId)}`
+          ),
+          this.fetch(
+            `api/dns/blocking?sid=${encodeURIComponent(this.sessionId)}`
+          )
+        ]);
 
         if (
           summary_response?.queries?.percent_blocked === undefined ||


### PR DESCRIPTION
## Description
Currently, Pihole always shows a status of `enabled`, unless one of the HTTP calls involved fails. PiHole can however be temporarily disabled and the old v5 service used to reflect that.

I'm explicitly omitting also updating this, as https://github.com/bastienwirtz/homer/pull/927 removes it (to avoid merge conflicts):

https://github.com/bastienwirtz/homer/blob/30d0265d3922a1a56a60ded5def2d54577405cf2/src/components/services/PiHole.vue#L119-L123

If there's no intention of merging https://github.com/bastienwirtz/homer/pull/927, I can amend this!


Fixes # (issue)
Closes https://github.com/bastienwirtz/homer/issues/928

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [ ] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [ ] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
