### PR TITLE
Improve dashboard title alignment

### DIFF
--- a/src/assets/components/base.scss
+++ b/src/assets/components/base.scss
@@ -104,6 +104,7 @@
 
       .dashboard-title {
         padding-top: 6px;
+        padding-left: 12px;
       }
 
       .first-line {
@@ -113,6 +114,7 @@
 
         h1 {
           margin-top: -12px;
+          margin-left: -2px;
           font-size: 2rem;
         }
 


### PR DESCRIPTION
## Description

This pull request improves the visual consistency of the Homer dashboard by aligning the dashboard name and headline elements with each other, while also adding appropriate left padding to ensure proper alignment with the main container for a more polished user interface.

P.S. Issues that were fixed here are noticeable when you open the dashboard on a mobile device.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
