### PR TITLE
feat: display version and update status for Wg-easy

### DIFF
--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -766,7 +766,7 @@ This service displays a version string instead of a subtitle. Example configurat
 ## Wg-easy
 
 This service displays a version string instead of a subtitle.  
-If a new version is available, it will also be shown alongside the current one.  
+If a new version is available, it will also be shown alongside the current one. Except on small screens.  
 The indicator shows if Wg-easy is online, offline. Example configuration:
 
 ```yaml

--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -56,6 +56,7 @@ within Homer:
 - [Uptime Kuma](#uptime-kuma)
 - [Vaultwarden](#vaultwarden)
 - [Wallabag](#wallabag)
+- [Wg-easy](#wg-easy)
 - [What's Up Docker](#whats-up-docker)
 
 > [!IMPORTANT]  
@@ -760,6 +761,20 @@ This service displays a version string instead of a subtitle. Example configurat
   type: Wallabag
   logo: assets/tools/sample.png
   url: https://wallabag.example.com
+```
+
+## Wg-easy
+
+This service displays a version string instead of a subtitle.  
+If a new version is available, it will also be shown alongside the current one.  
+The indicator shows if Wg-easy is online, offline. Example configuration:
+
+```yaml
+- name: "Wireguard"
+  type: Wg-easy
+  logo: assets/tools/sample.png
+  url:  http://wg-easy.example.com
+  basic_auth: "admin:password"
 ```
 
 ## What's up Docker

--- a/src/components/services/Wg-easy.vue
+++ b/src/components/services/Wg-easy.vue
@@ -63,7 +63,7 @@ export default {
       try {
         const response = await this.fetch("/api/information", { headers });
         this.fetchOk = true;
-        this.versionstring = response.currentRelease || "inconnue";
+        this.versionstring = response.currentRelease || "unknown";
         this.updateAvailable = response.updateAvailable;
         this.latestVersion = response.latestRelease?.version || null;
       } catch (e) {

--- a/src/components/services/Wg-easy.vue
+++ b/src/components/services/Wg-easy.vue
@@ -1,0 +1,101 @@
+<template>
+  <Generic :item="item">
+    <template #content>
+      <p class="title is-4">{{ item.name }}</p>
+      <p class="subtitle is-6">
+        <template v-if="item.subtitle">
+          {{ item.subtitle }}
+        </template>
+        <template v-else-if="versionstring">
+          Version {{ versionstring }}
+          <span v-if="updateAvailable"> –</span>
+          <span v-if="updateAvailable" style="color: orange; font-weight: 500;">
+            Update available {{ latestVersion }}
+          </span>
+        </template>
+
+      </p>
+    </template>
+    <template #indicator>
+      <div v-if="status" class="status" :class="status">
+        {{ status }}
+      </div>
+    </template>
+  </Generic>
+</template>
+
+<script>
+import service from "@/mixins/service.js";
+
+export default {
+  name: "Wg-easy",
+  mixins: [service],
+  props: {
+    item: Object,
+  },
+  data: () => ({
+    fetchOk: null,
+    versionstring: null,
+    latestVersion: null,
+    updateAvailable: false,
+  }),
+  computed: {
+    status: function () {
+      return this.fetchOk ? "online" : "offline";
+    },
+  },
+  created() {
+    this.fetchStatus();
+  },
+  methods: {
+    fetchStatus: async function () {
+      let headers = {};
+      if (this.item.basic_auth) {
+        const encodedCredentials = btoa(this.item.basic_auth);
+        headers["Authorization"] = `Basic ${encodedCredentials}`;
+      }
+      try {
+        const response = await this.fetch("/api/information", { headers });
+        this.fetchOk = true;
+        this.versionstring = response.currentRelease || "inconnue";
+        this.updateAvailable = response.updateAvailable;
+        this.latestVersion = response.latestRelease?.version || null;
+      } catch (e) {
+        this.fetchOk = false;
+        console.log(e);
+      }
+    },
+  },
+};
+</script>
+
+<style scoped lang="scss">
+.status {
+  font-size: 0.8rem;
+  color: var(--text-title);
+  white-space: nowrap;
+  margin-left: 0.25rem;
+
+  &.online:before {
+    background-color: #94e185;
+    border-color: #78d965;
+    box-shadow: 0 0 5px 1px #94e185;
+  }
+
+  &.offline:before {
+    background-color: #c9404d;
+    border-color: #c42c3b;
+    box-shadow: 0 0 5px 1px #c9404d;
+  }
+
+  &:before {
+    content: " ";
+    display: inline-block;
+    width: 7px;
+    height: 7px;
+    margin-right: 10px;
+    border: 1px solid #000;
+    border-radius: 7px;
+  }
+}
+</style>

--- a/src/components/services/Wg-easy.vue
+++ b/src/components/services/Wg-easy.vue
@@ -8,8 +8,8 @@
         </template>
         <template v-else-if="versionstring">
           Version {{ versionstring }}
-          <span v-if="updateAvailable"> –</span>
-          <span v-if="updateAvailable" style="color: orange; font-weight: 500;">
+          <span v-if="updateAvailable && !this.showUpdateAvailable"> –</span>
+          <span v-if="updateAvailable && !this.showUpdateAvailable" :class="{ 'is-active': showMenu }" style="color: orange; font-weight: 500;">
             Update available {{ latestVersion }}
           </span>
         </template>
@@ -43,11 +43,17 @@ export default {
     status: function () {
       return this.fetchOk ? "online" : "offline";
     },
+    showUpdateAvailable: function () {
+      return this.isSmallScreenMethod();
+    },
   },
   created() {
     this.fetchStatus();
   },
   methods: {
+    isSmallScreenMethod: function () {
+      return window.matchMedia("screen and (max-width: 1023px)").matches;
+    },
     fetchStatus: async function () {
       let headers = {};
       if (this.item.basic_auth) {


### PR DESCRIPTION
## Description

📌 Issue :

There was no native support to display the current version or detect updates for Wg-easy from Homer.

✅ Solution

- With the release of Wg-easy v15, an HTTP API was introduced, making it possible to:
  - Query the endpoint /api/information
  - Retrieve the current installed version
  - Detect if an update is available (via updateAvailable boolean and latestRelease.version)

- This PR introduces a new service type Wg-easy:
  - Shows the current version in the subtitle
  - If an update is available, displays a colored tag: Update available vX.X.X
  - Maintains Homer’s design philosophy: minimalist, clear, and non-intrusive

- Updated customservices.md documentation with configuration instructions

🔥 Motivation

Improve the user experience for WireGuard users using Wg-easy, by surfacing useful version and update info directly on the Homer dashboard — with no additional setup.

🧪 Tested on

- Wg-easy v15: correctly displays version and update info from the new /api/information endpoint

- ✅ Simulated update scenario using json-server to mock a newer version (v15.0.0) and test the updateAvailable flag behavior and rendering

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
