### PR TITLE
Feat version status sftpgo

### DIFF
--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -48,6 +48,7 @@ within Homer:
 - [rTorrent](#rtorrent)
 - [SABnzbd](#sabnzbd)
 - [Scrutiny](#scrutiny)
+- [SFTPGo](#sftpgo)
 - [Speedtest Tracker](#speedtesttracker)
 - [Tautulli](#tautulli)
 - [Tdarr](#tdarr)
@@ -644,6 +645,20 @@ This service displays info about the total number of disk passed and failed S.M.
   url: "http://192.168.0.151:8080"
   type: "Scrutiny"
   updateInterval: 5000 # (Optional) Interval (in ms) for updating the status
+```
+
+## SFTPGo
+
+This service displays a version string instead of a subtitle.  
+And this service display the number of active connections    
+The indicator shows SFTPGo is online, offline. Example configuration:
+
+```yaml
+- name: "SFTPGO container"
+  type: "SFTPGo"
+  logo: assets/tools/sample.png
+  url:  http://sftp-go.example.com
+  sftpgo_api_key: 'hYdn26pTteWZNzbAXoiqgR.jG7TKwtoMRAMrJAGgdr3Ha'
 ```
 
 ## SpeedtestTracker

--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -650,7 +650,7 @@ This service displays info about the total number of disk passed and failed S.M.
 ## SFTPGo
 
 This service displays a version string instead of a subtitle.  
-And this service display the number of active connections    
+And this service display the number of active connections is hidden on small screen.  
 The indicator shows SFTPGo is online, offline. Example configuration:
 
 ```yaml

--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -658,7 +658,7 @@ The indicator shows SFTPGo is online, offline. Example configuration:
   type: "SFTPGo"
   logo: assets/tools/sample.png
   url:  http://sftp-go.example.com
-  sftpgo_api_key: 'hYdn26pTteWZNzbAXoiqgR.jG7TKwtoMRAMrJAGgdr3Ha'
+  sftpgoApiKey: 'hYdn26pTteWZNzbAXoiqgR.jG7TKwtoMRAMrJAGgdr3Ha'
 ```
 
 ## SpeedtestTracker

--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -658,7 +658,7 @@ The indicator shows SFTPGo is online, offline. Example configuration:
   type: "SFTPGo"
   logo: assets/tools/sample.png
   url:  http://sftp-go.example.com
-  sftpgoApiKey: 'hYdn26pTteWZNzbAXoiqgR.jG7TKwtoMRAMrJAGgdr3Ha'
+  sftpgo_api_key: "hYdn26pTteWZNzbAXoiqgR.jG7TKwtoMRAMrJAGgdr3Ha"
 ```
 
 ## SpeedtestTracker

--- a/dummy-data/sftpgo/api/v2/connections
+++ b/dummy-data/sftpgo/api/v2/connections
@@ -1,0 +1,22 @@
+[
+	{
+		"username": "test",
+		"connection_id": "SFTP_94f5b2b9f379173fa9cd0b8a836a7f40d860e4299e167793722d1e957a94e4d2_1",
+		"client_version": "SSH-2.0-OpenSSH_8.9p1 Ubuntu-3ubuntu0.13",
+		"remote_address": "192.168.1.15:37616",
+		"connection_time": 1751462552179,
+		"last_activity": 1751462552179,
+		"current_time": 1751462680531,
+		"protocol": "SFTP"
+	},
+	{
+		"username": "test",
+		"connection_id": "SFTP_f50a640bded5f2dda3f9861b0f73c1d9220fe65da1de1bbb5c549618221a6455_1",
+		"client_version": "SSH-2.0-OpenSSH_8.9p1 Ubuntu-3ubuntu0.13",
+		"remote_address": "192.168.1.15:37680",
+		"connection_time": 1751462590652,
+		"last_activity": 1751462590652,
+		"current_time": 1751462680531,
+		"protocol": "SFTP"
+	}
+]

--- a/dummy-data/sftpgo/api/v2/version
+++ b/dummy-data/sftpgo/api/v2/version
@@ -1,0 +1,17 @@
+{
+	"version": "2.6.6",
+	"build_date": "2025-02-24T18:47:26Z",
+	"commit_hash": "6825db76",
+	"features": [
+		"+metrics",
+		"+azblob",
+		"+gcs",
+		"+s3",
+		"+bolt",
+		"+mysql",
+		"+pgsql",
+		"+sqlite",
+		"+unixcrypt",
+		"+portable"
+	]
+}

--- a/src/components/services/Sftpgo.vue
+++ b/src/components/services/Sftpgo.vue
@@ -67,6 +67,7 @@ export default {
 
         this.fetchOk = true;
       } catch (e) {
+        console.error(e);
         this.fetchOk = false;
       }
     },

--- a/src/components/services/Sftpgo.vue
+++ b/src/components/services/Sftpgo.vue
@@ -1,0 +1,91 @@
+<template>
+  <Generic :item="item">
+    <template #content>
+      <p class="title is-4">{{ item.name }}</p>
+      <p class="subtitle is-6">
+        <template v-if="item.subtitle">
+          {{ item.subtitle }}
+        </template>
+        <template v-else-if="versionstring">
+          Version {{ versionstring }}
+        </template>
+      </p>
+    </template>
+    <template #indicator>
+      <div v-if="status" class="status" :class="status">
+        {{ status }}
+      </div>
+    </template>
+  </Generic>
+</template>
+
+<script>
+import service from "@/mixins/service.js";
+
+export default {
+  name: "Sftgo",
+  mixins: [service],
+  props: {
+    item: Object,
+  },
+  data: () => ({
+    fetchOk: null,
+    versionstring: null,
+  }),
+  computed: {
+    status: function () {
+      return this.fetchOk ? "online" : "offline";
+    },
+  },
+  created() {
+    this.fetchStatus();
+  },
+  methods: {
+    fetchStatus: async function () {
+      let headers = {};
+      if (this.item.sftpgo_api_key) {
+        headers["X-SFTPGO-API-KEY"] = `${this.item.sftpgo_api_key}`;
+      }
+      try {
+        const response = await this.fetch("/api/v2/version", { headers });
+        this.fetchOk = true;
+        this.versionstring = response.version || "inconnue";
+      } catch (e) {
+        this.fetchOk = false;
+        console.log(e);
+      }
+    },
+  },
+};
+</script>
+
+<style scoped lang="scss">
+.status {
+  font-size: 0.8rem;
+  color: var(--text-title);
+  white-space: nowrap;
+  margin-left: 0.25rem;
+
+  &.online:before {
+    background-color: #94e185;
+    border-color: #78d965;
+    box-shadow: 0 0 5px 1px #94e185;
+  }
+
+  &.offline:before {
+    background-color: #c9404d;
+    border-color: #c42c3b;
+    box-shadow: 0 0 5px 1px #c9404d;
+  }
+
+  &:before {
+    content: " ";
+    display: inline-block;
+    width: 7px;
+    height: 7px;
+    margin-right: 10px;
+    border: 1px solid #000;
+    border-radius: 7px;
+  }
+}
+</style>

--- a/src/components/services/Sftpgo.vue
+++ b/src/components/services/Sftpgo.vue
@@ -8,7 +8,7 @@
         </template>
         <template v-else>
           <span v-if="versionstring">Version {{ versionstring }}</span>
-          <span v-if="activeConnections !== null">
+          <span v-if="activeConnections !== null && !this.showUpdateAvailable">
             – Active connections: {{ activeConnections }}
           </span>
         </template>
@@ -40,11 +40,17 @@ export default {
     status: function () {
       return this.fetchOk ? "online" : "offline";
     },
+    showUpdateAvailable: function () {
+      return this.isSmallScreenMethod();
+    },
   },
   created() {
     this.fetchStatus();
   },
   methods: {
+    isSmallScreenMethod: function () {
+      return window.matchMedia("screen and (max-width: 1023px)").matches;
+    },
     fetchStatus: async function () {
       let headers = {};
       if (this.item.sftpgo_api_key) {

--- a/src/components/services/Sftpgo.vue
+++ b/src/components/services/Sftpgo.vue
@@ -52,7 +52,7 @@ export default {
       }
       try {
         const response = await this.fetch("/api/v2/version", { headers });
-        this.versionstring = response.version || "inconnue";
+        this.versionstring = response.version || "unknown";
 
         const connResponse = await this.fetch("/api/v2/connections", { headers });
         this.activeConnections = Array.isArray(connResponse) ? connResponse.length : null;

--- a/src/components/services/Sftpgo.vue
+++ b/src/components/services/Sftpgo.vue
@@ -51,16 +51,17 @@ export default {
         headers["X-SFTPGO-API-KEY"] = `${this.item.sftpgo_api_key}`;
       }
       try {
-        const response = await this.fetch("/api/v2/version", { headers });
-        this.versionstring = response.version || "unknown";
+        const [versionRes, connRes] = await Promise.all([
+          this.fetch("/api/v2/version", { headers }),
+          this.fetch("/api/v2/connections", { headers }),
+        ]);
 
-        const connResponse = await this.fetch("/api/v2/connections", { headers });
-        this.activeConnections = Array.isArray(connResponse) ? connResponse.length : null;
+        this.versionstring = versionRes.version || "unknown";
+        this.activeConnections = connRes.length;
 
         this.fetchOk = true;
       } catch (e) {
         this.fetchOk = false;
-        console.log(e);
       }
     },
   },

--- a/src/components/services/Sftpgo.vue
+++ b/src/components/services/Sftpgo.vue
@@ -47,8 +47,8 @@ export default {
   methods: {
     fetchStatus: async function () {
       let headers = {};
-      if (this.item.sftpgoApiKey) {
-        headers["X-SFTPGO-API-KEY"] = `${this.item.sftpgoApiKey}`;
+      if (this.item.sftpgo_api_key) {
+        headers["X-SFTPGO-API-KEY"] = `${this.item.sftpgo_api_key}`;
       }
       try {
         const response = await this.fetch("/api/v2/version", { headers });

--- a/src/components/services/Sftpgo.vue
+++ b/src/components/services/Sftpgo.vue
@@ -6,8 +6,11 @@
         <template v-if="item.subtitle">
           {{ item.subtitle }}
         </template>
-        <template v-else-if="versionstring">
-          Version {{ versionstring }}
+        <template v-else>
+          <span v-if="versionstring">Version {{ versionstring }}</span>
+          <span v-if="activeConnections !== null">
+            – Active connections: {{ activeConnections }}
+          </span>
         </template>
       </p>
     </template>
@@ -23,7 +26,7 @@
 import service from "@/mixins/service.js";
 
 export default {
-  name: "Sftgo",
+  name: "SFTPGo",
   mixins: [service],
   props: {
     item: Object,
@@ -31,6 +34,7 @@ export default {
   data: () => ({
     fetchOk: null,
     versionstring: null,
+    activeConnections: null,
   }),
   computed: {
     status: function () {
@@ -43,13 +47,17 @@ export default {
   methods: {
     fetchStatus: async function () {
       let headers = {};
-      if (this.item.sftpgo_api_key) {
-        headers["X-SFTPGO-API-KEY"] = `${this.item.sftpgo_api_key}`;
+      if (this.item.sftpgoApiKey) {
+        headers["X-SFTPGO-API-KEY"] = `${this.item.sftpgoApiKey}`;
       }
       try {
         const response = await this.fetch("/api/v2/version", { headers });
-        this.fetchOk = true;
         this.versionstring = response.version || "inconnue";
+
+        const connResponse = await this.fetch("/api/v2/connections", { headers });
+        this.activeConnections = Array.isArray(connResponse) ? connResponse.length : null;
+
+        this.fetchOk = true;
       } catch (e) {
         this.fetchOk = false;
         console.log(e);


### PR DESCRIPTION
## Description

📌 Issue :

There was no native support to display the current version and display active connection for SFTPGo from Homer.

✅ Solution

    This PR introduces a new service type SFTPGo:
        Shows the current version in the subtitle
        Shows the number of active SFTP connections
        Maintains Homer’s design philosophy: minimalist, clear, and non-intrusive

    Updated customservices.md documentation with configuration instructions

🔥 Motivation

Allows you to see at a glance if there are active connections and the version of our instance

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
