### PR TITLE
Fix v2 auth header traefik

### DIFF
--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -706,11 +706,14 @@ for transcoding on your Tdarr instance as well as the number of errored items.
 This service displays a version string instead of a subtitle. Example configuration:
 
 ```yaml
-- name: Traefik
-  type: Traefik
-  logo: assets/tools/sample.png
-  url: http://traefik.example.com
+- name: "Traefik"
+  type: "Traefik"
+  logo: "assets/tools/sample.png"
+  url: "http://traefik.example.com"
+  basic_auth: "admin:password"
 ```
+- Authentication: If BasicAuth is set, credentials will be encoded in Base64 and sent as an Authorization header (Basic <encoded_value>).
+- Format: The value must be formatted as "admin:password".
 
 ## Truenas Scale
 

--- a/src/components/services/Traefik.vue
+++ b/src/components/services/Traefik.vue
@@ -42,7 +42,12 @@ export default {
   },
   methods: {
     fetchStatus: async function () {
-      this.fetch("/api/version")
+      let headers = {};
+      if (this.item.basic_auth) {
+        const encodedCredentials = btoa(this.item.basic_auth);
+        headers["Authorization"] = `Basic ${encodedCredentials}`;
+      }
+      this.fetch("/api/version", { headers })
         .then((response) => {
           this.fetchOk = true;
           this.versionstring = response.Version;


### PR DESCRIPTION
## Description

This PR is a clean version of the previous one (#892) which got messy after a bad rebase / force-push.
✅  It now contains only the intended changes for supporting Basic Auth in the Traefik service, along with its documentation update.
💡 I believe this feature has a real positive impact — it improves security and makes authentication easier to manage across services.
Feel free to close the previous PR. Let me know if anything needs adjustment!


Added support for BasicAuth authentication for the Traefik service.

:pushpin: **Issue** :  
Currently, Homer does not allow sending an `Authorization` header to authenticate with **Traefik**.

:white_check_mark: **Solution** :  
- Checks if `this.item.basic_auth` is defined.
- Encode credentials in Base64 (`btoa(user:password)`).
- Adds the `Authorization: Basic ...` header to **Traefik** API requests.

:fire: **Motivation** :  
Allows **Traefik** status to be correctly displayed even if authentication is required.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file