### PR TITLE
Fix prometheous inactive alerts and print version

### DIFF
--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -536,14 +536,13 @@ See <https://docs.portainer.io/api/access#creating-an-access-token>
 
 ## Prometheus
 
-For Prometheus you need to set the type to Prometheus and provide a url.
+For Prometheus you need to set the type to Prometheus and provide a url. This will display the version on desktops.  
 
 ```yaml
 - name: "Prometheus"
-  type: Prometheus
+  type: "Prometheus"
   logo: "assets/tools/sample.png"
   url: "http://192.168.0.151/"
-  # subtitle: "Monitor data server"
 ```
 
 ## Proxmox

--- a/dummy-data/prometheus/api/v1/alerts
+++ b/dummy-data/prometheus/api/v1/alerts
@@ -10,8 +10,8 @@
 				"annotations": {
 					"summary": "Demo Alert"
 				},
-				"state": "firing",
-				"activeAt": "2025-07-04T23:09:29.244509801Z",
+				"state": "pending",
+				"activeAt": "2025-07-04T23:41:29.244509801Z",
 				"value": "1e+00"
 			},
 			{
@@ -23,7 +23,7 @@
 					"summary": "Critical Test Alert"
 				},
 				"state": "firing",
-				"activeAt": "2025-07-04T23:09:29.244509801Z",
+				"activeAt": "2025-07-04T23:41:29.244509801Z",
 				"value": "1e+00"
 			}
 		]

--- a/dummy-data/prometheus/api/v1/alerts
+++ b/dummy-data/prometheus/api/v1/alerts
@@ -1,0 +1,31 @@
+{
+	"status": "success",
+	"data": {
+		"alerts": [
+			{
+				"labels": {
+					"alertname": "DemoPendingThenFiring",
+					"severity": "warning"
+				},
+				"annotations": {
+					"summary": "Demo Alert"
+				},
+				"state": "firing",
+				"activeAt": "2025-07-04T23:09:29.244509801Z",
+				"value": "1e+00"
+			},
+			{
+				"labels": {
+					"alertname": "DemoAlwaysFiring",
+					"severity": "critical"
+				},
+				"annotations": {
+					"summary": "Critical Test Alert"
+				},
+				"state": "firing",
+				"activeAt": "2025-07-04T23:09:29.244509801Z",
+				"value": "1e+00"
+			}
+		]
+	}
+}

--- a/dummy-data/prometheus/api/v1/rules
+++ b/dummy-data/prometheus/api/v1/rules
@@ -7,7 +7,7 @@
 				"file": "/etc/prometheus/alert.rules.yml",
 				"rules": [
 					{
-						"state": "firing",
+						"state": "pending",
 						"name": "DemoPendingThenFiring",
 						"query": "vector(1)",
 						"duration": 120,
@@ -27,14 +27,14 @@
 								"annotations": {
 									"summary": "Demo Alert"
 								},
-								"state": "firing",
-								"activeAt": "2025-07-04T23:09:29.244509801Z",
+								"state": "pending",
+								"activeAt": "2025-07-04T23:41:29.244509801Z",
 								"value": "1e+00"
 							}
 						],
 						"health": "ok",
-						"evaluationTime": 0.000211901,
-						"lastEvaluation": "2025-07-05T01:33:29.245332571+02:00",
+						"evaluationTime": 0.00031672,
+						"lastEvaluation": "2025-07-05T01:41:29.244670258+02:00",
 						"type": "alerting"
 					},
 					{
@@ -59,20 +59,20 @@
 									"summary": "Critical Test Alert"
 								},
 								"state": "firing",
-								"activeAt": "2025-07-04T23:09:29.244509801Z",
+								"activeAt": "2025-07-04T23:41:29.244509801Z",
 								"value": "1e+00"
 							}
 						],
 						"health": "ok",
-						"evaluationTime": 0.000074511,
-						"lastEvaluation": "2025-07-05T01:33:29.245547238+02:00",
+						"evaluationTime": 0.000093386,
+						"lastEvaluation": "2025-07-05T01:41:29.244989354+02:00",
 						"type": "alerting"
 					}
 				],
 				"interval": 60,
 				"limit": 0,
-				"evaluationTime": 0.000303826,
-				"lastEvaluation": "2025-07-05T01:33:29.245319516+02:00"
+				"evaluationTime": 0.000432731,
+				"lastEvaluation": "2025-07-05T01:41:29.244651703+02:00"
 			},
 			{
 				"name": "wireguard",
@@ -93,8 +93,8 @@
 						},
 						"alerts": [],
 						"health": "ok",
-						"evaluationTime": 0.000193607,
-						"lastEvaluation": "2025-07-05T01:34:02.853540745+02:00",
+						"evaluationTime": 0.00037991,
+						"lastEvaluation": "2025-07-05T01:41:02.847097789+02:00",
 						"type": "alerting"
 					},
 					{
@@ -112,15 +112,15 @@
 						},
 						"alerts": [],
 						"health": "ok",
-						"evaluationTime": 0.000102034,
-						"lastEvaluation": "2025-07-05T01:34:02.853736466+02:00",
+						"evaluationTime": 0.000122432,
+						"lastEvaluation": "2025-07-05T01:41:02.847481226+02:00",
 						"type": "alerting"
 					}
 				],
 				"interval": 60,
 				"limit": 0,
-				"evaluationTime": 0.000306811,
-				"lastEvaluation": "2025-07-05T01:34:02.853533091+02:00"
+				"evaluationTime": 0.000533061,
+				"lastEvaluation": "2025-07-05T01:41:02.8470724+02:00"
 			}
 		]
 	}

--- a/dummy-data/prometheus/api/v1/rules
+++ b/dummy-data/prometheus/api/v1/rules
@@ -1,0 +1,127 @@
+{
+	"status": "success",
+	"data": {
+		"groups": [
+			{
+				"name": "demo",
+				"file": "/etc/prometheus/alert.rules.yml",
+				"rules": [
+					{
+						"state": "firing",
+						"name": "DemoPendingThenFiring",
+						"query": "vector(1)",
+						"duration": 120,
+						"keepFiringFor": 0,
+						"labels": {
+							"severity": "warning"
+						},
+						"annotations": {
+							"summary": "Demo Alert"
+						},
+						"alerts": [
+							{
+								"labels": {
+									"alertname": "DemoPendingThenFiring",
+									"severity": "warning"
+								},
+								"annotations": {
+									"summary": "Demo Alert"
+								},
+								"state": "firing",
+								"activeAt": "2025-07-04T23:09:29.244509801Z",
+								"value": "1e+00"
+							}
+						],
+						"health": "ok",
+						"evaluationTime": 0.000211901,
+						"lastEvaluation": "2025-07-05T01:33:29.245332571+02:00",
+						"type": "alerting"
+					},
+					{
+						"state": "firing",
+						"name": "DemoAlwaysFiring",
+						"query": "vector(1)",
+						"duration": 0,
+						"keepFiringFor": 0,
+						"labels": {
+							"severity": "critical"
+						},
+						"annotations": {
+							"summary": "Critical Test Alert"
+						},
+						"alerts": [
+							{
+								"labels": {
+									"alertname": "DemoAlwaysFiring",
+									"severity": "critical"
+								},
+								"annotations": {
+									"summary": "Critical Test Alert"
+								},
+								"state": "firing",
+								"activeAt": "2025-07-04T23:09:29.244509801Z",
+								"value": "1e+00"
+							}
+						],
+						"health": "ok",
+						"evaluationTime": 0.000074511,
+						"lastEvaluation": "2025-07-05T01:33:29.245547238+02:00",
+						"type": "alerting"
+					}
+				],
+				"interval": 60,
+				"limit": 0,
+				"evaluationTime": 0.000303826,
+				"lastEvaluation": "2025-07-05T01:33:29.245319516+02:00"
+			},
+			{
+				"name": "wireguard",
+				"file": "/etc/prometheus/alert.rules.yml",
+				"rules": [
+					{
+						"state": "inactive",
+						"name": "WireGuardClientConnected",
+						"query": "(time() - wireguard_latest_handshake_seconds) \u003c 30 and absent(wireguard_latest_handshake_seconds offset 10m)",
+						"duration": 30,
+						"keepFiringFor": 0,
+						"labels": {
+							"severity": "info"
+						},
+						"annotations": {
+							"description": "🔌 Peer : {{ $labels.name }} ({{ $labels.ipv4Address }}) connected to WireGuard",
+							"summary": "🔌 Login : {{ $labels.name }}"
+						},
+						"alerts": [],
+						"health": "ok",
+						"evaluationTime": 0.000193607,
+						"lastEvaluation": "2025-07-05T01:34:02.853540745+02:00",
+						"type": "alerting"
+					},
+					{
+						"state": "inactive",
+						"name": "WireGuardClientDisconnected",
+						"query": "(time() - wireguard_latest_handshake_seconds) \u003e 300 and (time() - wireguard_latest_handshake_seconds offset 10m) \u003c 600",
+						"duration": 120,
+						"keepFiringFor": 0,
+						"labels": {
+							"severity": "warning"
+						},
+						"annotations": {
+							"description": "📴 No more WireGuard activity for {{ $labels.name }} ({{ $labels.ipv4Address }}) since >5 min",
+							"summary": "📴 Logout : {{ $labels.name }}"
+						},
+						"alerts": [],
+						"health": "ok",
+						"evaluationTime": 0.000102034,
+						"lastEvaluation": "2025-07-05T01:34:02.853736466+02:00",
+						"type": "alerting"
+					}
+				],
+				"interval": 60,
+				"limit": 0,
+				"evaluationTime": 0.000306811,
+				"lastEvaluation": "2025-07-05T01:34:02.853533091+02:00"
+			}
+		]
+	}
+}

--- a/dummy-data/prometheus/api/v1/status/buildinfo
+++ b/dummy-data/prometheus/api/v1/status/buildinfo
@@ -1,0 +1,11 @@
+{
+	"status": "success",
+	"data": {
+		"version": "2.53.5",
+		"revision": "d344ea7bf4cc9e9e131a0318d10025982e9c4cc1",
+		"branch": "HEAD",
+		"buildUser": "root@31e33add4c49",
+		"buildDate": "20250630-10:18:05",
+		"goVersion": "go1.23.10"
+	}
+}


### PR DESCRIPTION
## Description

Fixed the counting of "inactive" alerts
Previously: only firing and pending alerts were counted from /api/v1/alerts

Fix: Added a call to /api/v1/rules to iterate through groups[].rules[] and filter those with state: inactive.
Corrected display in the badge ({{ count }}) and in the text (x inactive alerts).

Added the Prometheus version (buildinfo) on desktop only.
New query to /api/v1/status/buildinfo.
Mobile detected via window.matchMedia.

Visual UX improvement
The API status is initialized to null (instead of an empty object), which prevents the badge from flashing or alerts with a default value of 0 at startup.

For your information:
Note on Prometheus Basic Authentication
Limitation of Prometheus + Basic Auth + CORS:
When using Authorization: Basic, the browser first sends an OPTIONS request (pre-flight CORS) without an authentication header. Prometheus rejects this with a 401 without CORS headers, thus blocking the actual request.
Result: It is impossible to use the Prometheus API directly from the browser with Basic Auth.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
