### PR TITLE
fix: reset service cards state on page switch by using unique keys

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -87,7 +87,7 @@
               </h2>
               <Service
                 v-for="(item, index) in group.items"
-                :key="`service-${groupIndex}-${index}`"
+                :key="`${currentPage}-${group.name}-${item.name}`"
                 :item="item"
                 :proxy="config.proxy"
                 :class="[
@@ -120,7 +120,7 @@
               </h2>
               <Service
                 v-for="(item, index) in group.items"
-                :key="index"
+                :key="`${currentPage}-${group.name}-${item.name}`"
                 :item="item"
                 :proxy="config.proxy"
                 :class="item.class || group.class"

--- a/src/App.vue
+++ b/src/App.vue
@@ -86,7 +86,7 @@
                 {{ group.name }}
               </h2>
               <Service
-                v-for="(item, index) in group.items"
+                v-for="(item) in group.items"
                 :key="`${currentPage}-${group.name}-${item.name}`"
                 :item="item"
                 :proxy="config.proxy"
@@ -119,7 +119,7 @@
                 {{ group.name }}
               </h2>
               <Service
-                v-for="(item, index) in group.items"
+                v-for="(item) in group.items"
                 :key="`${currentPage}-${group.name}-${item.name}`"
                 :item="item"
                 :proxy="config.proxy"


### PR DESCRIPTION
## Description

### The problem encountered

When I navigated between two pages of the Homer dashboard (e.g., #admin → #cams-admin), some cards still displayed the metrics from the previous page.

### Root cause

Vue was reusing<Service> components from one page to another because they had the same index-based key (:key="index" or :key="service-${groupIndex}-${index}").
As a result, the components kept their previous state between two pages.

### The fix

I modified the keys in App.vue (horizontal and vertical layout) to be truly unique by combining currentPage, group.name, and item.name:

```
:key="`${currentPage}-${group.name}-${item.name}`"
```

✅ This forces Vue to destroy and recreate the components each time a page changes.
✅ This cleanly restarts each card from scratch → no more "ghost" values.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [ ] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
