### PR TITLE
Restoring focus outline on links

### DIFF
--- a/src/assets/components/base.scss
+++ b/src/assets/components/base.scss
@@ -243,10 +243,6 @@
         box-shadow: 0 2px 15px 0 rgba(0, 0, 0, 0.1);
         transition: cubic-bezier(0.165, 0.84, 0.44, 1) 300ms;
         overflow: visible;
-
-        a {
-          outline: none;
-        }
       }
 
       .card:hover {


### PR DESCRIPTION
Browsers have a focus outline for a reason: accessibility, letting users interact with the page using just the keyboard.

We, web developers, must not remove the focus outline without providing an equivalent alternative.

* https://accessiblewebsiteservices.com/accessible-css-focus-on-the-outline/
* https://theadminbar.com/accessibility-weekly/focus-outlines/
* https://stackoverflow.com/questions/9274948/css-outline-best-practices

I considered using the same visual feedback as the mouse-over effect, but that's not possible in the current HTML/CSS. That `transform: translateY(-3px)` effect is being applied to the parent `div.card`, which is not focusable, and thus we cannot trigger the same effect. The solution would require reworking both the HTML and CSS. (It can also be argued that tiny 3px offset is too subtle to be used as a focus indicator.)

For now, I've restored the default browser focus outline, and someday in the future someone could try to provide a different focus indication.

## Description

1. Open a Homer page.
2. Press `↹ Tab` a few times.

What should happen: I should be able to know the currently focused element using just keyboard navigation. I should be able to completely use the website using just the keyboard.

What happens instead: There is no visual indication of the currently focused element.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
