### PR TITLE
Do not append subtitle to document title when empty

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -186,7 +186,7 @@ export default {
 
       document.title =
         this.config.documentTitle ||
-        `${this.config.title} | ${this.config.subtitle}`;
+        [this.config.title, this.config.subtitle].filter(Boolean).join(" | ");
       if (this.config.stylesheet) {
         let stylesheet = "";
         let addtionnal_styles = this.config.stylesheet;


### PR DESCRIPTION
## Description

I want to show just my title without any subtitle as the website title. If I set the subtitle to empty string it still shows after | so I added a condition not to add | when subtitle is empty.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] I have made corresponding changes to the documentation (`README.md`).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
