### PR TITLE
fix(neon-theme): add missing highlight-variant-inverted colors for better contrast

### DIFF
--- a/src/assets/themes/neon.scss
+++ b/src/assets/themes/neon.scss
@@ -13,6 +13,7 @@
   --link: #b5ff57;
   --link-hover: #8cce36;
   --background-image: none;
+  --highlight-variant-inverted: #2d2d2d;
 }
 
 .theme-neon.dark {
@@ -29,6 +30,7 @@
   --link: #b5ff57;
   --link-hover: #aeff45;
   --background-image: none;
+  --highlight-variant-inverted: #696969;
 }
 
 // theme


### PR DESCRIPTION
## Summary
- Adds missing `--highlight-variant-inverted` color definitions to both light and dark variants of the neon theme
- Fixes poor text contrast against the bright neon green background (#b5ff57)
- Light mode: `#2d2d2d` (dark gray for good contrast)
- Dark mode: `#696969` (medium gray for optimal readability)

I've found those values using https://app.contrast-finder.org/

## Problem
The neon theme was missing the `--highlight-variant-inverted` CSS variable, causing poor contrast between tag text and the bright neon green `--highlight-secondary` color. This made text difficult to read in certain UI elements.

## Solution
Added the missing color variable to both theme variants with carefully chosen colors that provide sufficient contrast while maintaining the theme's aesthetic.

## Screenshot
before:
<img width="466" height="96" alt="image" src="https://github.com/user-attachments/assets/641bf50b-461a-4a45-96c9-0455c146f7f5" />
after:
<img width="446" height="104" alt="image" src="https://github.com/user-attachments/assets/831f261d-d04c-4316-900e-0dc0b608b70b" />


## Test plan
- [x] Test neon theme in light mode - verify tag text is readable
- [x] Test neon theme in dark mode - verify tag text is readable  
- [x] Verify no visual regression in other theme elements
- [x] Confirm colors maintain neon theme aesthetic