### PR TITLE
Add Unifi service

### DIFF
--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -55,6 +55,7 @@ Available services are located in `src/components/`:
 - [Traefik](#traefik)
 - [Transmission](#transmission)
 - [TrueNas Scale](#truenas-scale)
+- [UniFi](#unifi)
 - [Uptime Kuma](#uptime-kuma)
 - [Vaultwarden](#vaultwarden)
 - [Wallabag](#wallabag)
@@ -753,6 +754,43 @@ Displays TrueNAS version.
   url: https://my-service.url
   api_token: "<---insert-api-key-here--->"
 ```
+
+## UniFi
+
+Displays information from your UniFi Network Controller including connected clients, access points, and other network devices. The service automatically handles UniFi's session-based authentication and CSRF protection.
+
+```yaml
+- name: "UniFi Controller"
+  logo: "assets/tools/sample.png"
+  url: "https://unifi.local:8443" # Your UniFi Controller URL
+  type: "Unifi"
+  auth: "username:password" # UniFi Controller credentials
+  site: "default" # Optional: UniFi site name (default: "default")
+  legacy: true # Optional: Use legacy /api/login endpoint (default: true)
+  updateInterval: 30000 # Optional: Refresh interval in milliseconds
+  target: "_blank" # Optional: HTML a tag target attribute
+```
+
+**Configuration Options:**
+
+- `auth`: Required. UniFi Controller credentials in "username:password" format
+- `site`: Optional. UniFi site name to monitor (default: "default")
+- `legacy`: Optional. Set to `false` to use modern `/api/auth/login` endpoint instead of legacy `/api/login` (default: true)
+- `updateInterval`: Optional. How often to refresh data in milliseconds (default: 30000)
+
+**Supported UniFi Controllers:**
+
+- UniFi Network Controller (self-hosted)
+- UniFi Dream Machine (UDM/UDM Pro)
+- UniFi Cloud Key
+
+**Displayed Information:**
+
+- **Connected Clients**: Total number of wireless and wired clients connected to the network
+- **Access Points**: Number of UniFi access points (UAP devices)
+- **Network Devices**: Number of other UniFi network devices (switches, gateways, etc.)
+
+The service uses UniFi's standard API endpoints and maintains session cookies automatically. For UDM/UDM Pro devices, the service will automatically use the `/proxy/network` prefix when `udm: true` is configured.
 
 ## Uptime Kuma
 

--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -775,6 +775,7 @@ Displays information from your UniFi Network Controller including connected clie
 
 - `auth`: Required. UniFi Controller credentials in "username:password" format
 - `site`: Optional. UniFi site name to monitor (default: "default")
+- `udm`: Optional. Set to `true` for UniFi Dream Machine (UDM/UDM Pro) to use `/proxy/network` prefix instead of `/manage` (default: false)
 - `legacy`: Optional. Set to `false` to use modern `/api/auth/login` endpoint instead of legacy `/api/login` (default: true)
 - `updateInterval`: Optional. How often to refresh data in milliseconds (default: 30000)
 

--- a/dummy-data/unifi/api/auth/login
+++ b/dummy-data/unifi/api/auth/login
@@ -1,0 +1,31 @@
+{
+  "meta": {
+    "rc": "ok"
+  },
+  "data": [
+    {
+      "unique_id": "admin",
+      "first_name": "Administrator",
+      "last_name": "",
+      "full_name": "Administrator",
+      "email": "admin@example.com",
+      "email_alert_enabled": false,
+      "email_alert_grouping_enabled": false,
+      "email_alert_grouping_delay": 60,
+      "push_alert_enabled": false,
+      "is_owner": true,
+      "time_created": 1234567890,
+      "last_login_ip": "192.168.1.100",
+      "last_login_time": 1640995200,
+      "ubic_uuid": "00000000-0000-0000-0000-000000000000",
+      "update_id": "5f9f1c1b0000000000000000",
+      "permissions": [
+        "admin"
+      ],
+      "scopes": [
+        "admin:read",
+        "admin:write"
+      ]
+    }
+  ]
+}

--- a/dummy-data/unifi/api/login
+++ b/dummy-data/unifi/api/login
@@ -1,0 +1,24 @@
+{
+  "meta": {
+    "rc": "ok"
+  },
+  "data": [
+    {
+      "unique_id": "admin",
+      "first_name": "Administrator",
+      "last_name": "",
+      "full_name": "Administrator",
+      "email": "admin@example.com",
+      "email_alert_enabled": false,
+      "email_alert_grouping_enabled": false,
+      "email_alert_grouping_delay": 60,
+      "push_alert_enabled": false,
+      "is_owner": true,
+      "time_created": 1234567890,
+      "last_login_ip": "192.168.1.100",
+      "last_login_time": 1640995200,
+      "ubic_uuid": "00000000-0000-0000-0000-000000000000",
+      "update_id": "5f9f1c1b0000000000000000"
+    }
+  ]
+}

--- a/dummy-data/unifi/api/s/default/stat/device
+++ b/dummy-data/unifi/api/s/default/stat/device
@@ -1,0 +1,350 @@
+{
+  "meta": {
+    "rc": "ok"
+  },
+  "data": [
+    {
+      "_id": "5f9f1c1b0000000000000001",
+      "adopted": true,
+      "cfgversion": "0123456789abcdef",
+      "config_network": {
+        "type": "dhcp"
+      },
+      "connect_request_ip": "192.168.1.10",
+      "connect_request_port": "45678",
+      "considered_lost_at": 1640999999,
+      "device_id": "5f9f1c1b0000000000000001",
+      "disabled": false,
+      "discovered_via": "l2",
+      "downlink_table": [],
+      "ethernet_table": [
+        {
+          "mac": "aa:bb:cc:dd:ee:01",
+          "name": "eth0",
+          "num_port": 1
+        }
+      ],
+      "fw_caps": 123456789,
+      "guest_token": "abcdefghijklmnopqrstuvwxyz123456",
+      "has_eth1": false,
+      "has_speaker": false,
+      "inform_ip": "192.168.1.1",
+      "inform_url": "http://192.168.1.1:8080/inform",
+      "ip": "192.168.1.10",
+      "last_seen": 1640995200,
+      "led_override": "default",
+      "led_override_color": "#0066cc",
+      "led_override_color_brightness": 100,
+      "mac": "aa:bb:cc:dd:ee:01",
+      "model": "U6-Lite",
+      "name": "Living Room AP",
+      "next_interval": 30,
+      "num_sta": 8,
+      "port_table": [],
+      "radio_table": [
+        {
+          "radio": "ng",
+          "name": "wifi0",
+          "channel": 6,
+          "ht": 20,
+          "tx_power": 17,
+          "min_rssi_enabled": false,
+          "min_rssi": -79,
+          "sens_level_enabled": false,
+          "antenna_gain": 2,
+          "builtin_antenna": true,
+          "builtin_ant_gain": 2,
+          "nss": 2,
+          "radio_caps": 7679
+        },
+        {
+          "radio": "na",
+          "name": "wifi1",
+          "channel": 36,
+          "ht": 80,
+          "tx_power": 20,
+          "min_rssi_enabled": false,
+          "min_rssi": -79,
+          "sens_level_enabled": false,
+          "antenna_gain": 2,
+          "builtin_antenna": true,
+          "builtin_ant_gain": 2,
+          "nss": 2,
+          "radio_caps": 7679
+        }
+      ],
+      "serial": "ABC1234567890",
+      "state": 1,
+      "type": "uap",
+      "uplink": {
+        "type": "wire",
+        "mac": "aa:bb:cc:dd:ee:ff",
+        "speed": 1000,
+        "full_duplex": true
+      },
+      "uptime": 86400,
+      "version": "6.2.35.14526",
+      "wifi_caps": 123456789,
+      "wlangroup_id_na": "5f9f1c1b0000000000000010",
+      "wlangroup_id_ng": "5f9f1c1b0000000000000010"
+    },
+    {
+      "_id": "5f9f1c1b0000000000000002",
+      "adopted": true,
+      "cfgversion": "0123456789abcdef",
+      "config_network": {
+        "type": "dhcp"
+      },
+      "connect_request_ip": "192.168.1.11",
+      "connect_request_port": "45678",
+      "considered_lost_at": 1640999999,
+      "device_id": "5f9f1c1b0000000000000002",
+      "disabled": false,
+      "discovered_via": "l2",
+      "downlink_table": [],
+      "ethernet_table": [
+        {
+          "mac": "aa:bb:cc:dd:ee:02",
+          "name": "eth0",
+          "num_port": 1
+        }
+      ],
+      "fw_caps": 123456789,
+      "guest_token": "abcdefghijklmnopqrstuvwxyz123457",
+      "has_eth1": false,
+      "has_speaker": false,
+      "inform_ip": "192.168.1.1",
+      "inform_url": "http://192.168.1.1:8080/inform",
+      "ip": "192.168.1.11",
+      "last_seen": 1640995200,
+      "led_override": "default",
+      "led_override_color": "#0066cc",
+      "led_override_color_brightness": 100,
+      "mac": "aa:bb:cc:dd:ee:02",
+      "model": "U6-Pro",
+      "name": "Office AP",
+      "next_interval": 30,
+      "num_sta": 12,
+      "port_table": [],
+      "radio_table": [
+        {
+          "radio": "ng",
+          "name": "wifi0",
+          "channel": 11,
+          "ht": 40,
+          "tx_power": 20,
+          "min_rssi_enabled": false,
+          "min_rssi": -79,
+          "sens_level_enabled": false,
+          "antenna_gain": 2,
+          "builtin_antenna": true,
+          "builtin_ant_gain": 2,
+          "nss": 4,
+          "radio_caps": 7679
+        },
+        {
+          "radio": "na",
+          "name": "wifi1",
+          "channel": 44,
+          "ht": 160,
+          "tx_power": 22,
+          "min_rssi_enabled": false,
+          "min_rssi": -79,
+          "sens_level_enabled": false,
+          "antenna_gain": 2,
+          "builtin_antenna": true,
+          "builtin_ant_gain": 2,
+          "nss": 4,
+          "radio_caps": 7679
+        }
+      ],
+      "serial": "DEF1234567890",
+      "state": 1,
+      "type": "uap",
+      "uplink": {
+        "type": "wire",
+        "mac": "aa:bb:cc:dd:ee:ff",
+        "speed": 1000,
+        "full_duplex": true
+      },
+      "uptime": 172800,
+      "version": "6.2.35.14526",
+      "wifi_caps": 123456789,
+      "wlangroup_id_na": "5f9f1c1b0000000000000010",
+      "wlangroup_id_ng": "5f9f1c1b0000000000000010"
+    },
+    {
+      "_id": "5f9f1c1b0000000000000003",
+      "adopted": true,
+      "cfgversion": "0123456789abcdef",
+      "connect_request_ip": "192.168.1.2",
+      "connect_request_port": "45678",
+      "considered_lost_at": 1640999999,
+      "device_id": "5f9f1c1b0000000000000003",
+      "disabled": false,
+      "discovered_via": "l2",
+      "downlink_table": [
+        {
+          "mac": "aa:bb:cc:dd:ee:01",
+          "port_idx": 1,
+          "speed": 1000,
+          "full_duplex": true
+        },
+        {
+          "mac": "aa:bb:cc:dd:ee:02",
+          "port_idx": 2,
+          "speed": 1000,
+          "full_duplex": true
+        }
+      ],
+      "ethernet_table": [
+        {
+          "mac": "aa:bb:cc:dd:ee:03",
+          "name": "eth0",
+          "num_port": 1
+        }
+      ],
+      "fw_caps": 123456789,
+      "inform_ip": "192.168.1.1",
+      "inform_url": "http://192.168.1.1:8080/inform",
+      "ip": "192.168.1.2",
+      "last_seen": 1640995200,
+      "led_override": "default",
+      "led_override_color": "#0066cc",
+      "led_override_color_brightness": 100,
+      "mac": "aa:bb:cc:dd:ee:03",
+      "model": "USW-24-POE",
+      "name": "Main Switch",
+      "next_interval": 30,
+      "num_sta": 0,
+      "port_overrides": [],
+      "port_table": [
+        {
+          "port_idx": 1,
+          "media": "GE",
+          "port_poe": true,
+          "poe_caps": 7,
+          "poe_class": "Class 0",
+          "poe_enable": true,
+          "poe_mode": "auto",
+          "poe_power": "8.50",
+          "poe_voltage": "53.40",
+          "portconf_id": "5f9f1c1b0000000000000020",
+          "autoneg": true,
+          "enable": true,
+          "flowctrl_rx": false,
+          "flowctrl_tx": false,
+          "full_duplex": true,
+          "is_uplink": false,
+          "mac_table": [
+            {
+              "age": 0,
+              "authorized": true,
+              "hostname": "living-room-ap",
+              "ip": "192.168.1.10",
+              "mac": "aa:bb:cc:dd:ee:01",
+              "oui": "Ubiquiti",
+              "uptime": 86400,
+              "vlan": 1
+            }
+          ],
+          "name": "Port 1",
+          "op_mode": "switch",
+          "rx_broadcast": 1234,
+          "rx_bytes": 123456789,
+          "rx_dropped": 0,
+          "rx_errors": 0,
+          "rx_multicast": 5678,
+          "rx_packets": 987654,
+          "satisfaction": 100,
+          "speed": 1000,
+          "stp_pathcost": 0,
+          "stp_state": "forwarding",
+          "tx_broadcast": 1234,
+          "tx_bytes": 123456789,
+          "tx_dropped": 0,
+          "tx_errors": 0,
+          "tx_multicast": 5678,
+          "tx_packets": 987654,
+          "up": true
+        }
+      ],
+      "serial": "GHI1234567890",
+      "state": 1,
+      "type": "usw",
+      "uplink": {
+        "type": "wire",
+        "mac": "aa:bb:cc:dd:ee:ff",
+        "speed": 1000,
+        "full_duplex": true
+      },
+      "uptime": 259200,
+      "version": "6.2.35.14526"
+    },
+    {
+      "_id": "5f9f1c1b0000000000000004",
+      "adopted": true,
+      "cfgversion": "0123456789abcdef",
+      "connect_request_ip": "192.168.1.1",
+      "connect_request_port": "45678",
+      "considered_lost_at": 1640999999,
+      "device_id": "5f9f1c1b0000000000000004",
+      "disabled": false,
+      "discovered_via": "l2",
+      "ethernet_table": [
+        {
+          "mac": "aa:bb:cc:dd:ee:04",
+          "name": "eth0",
+          "num_port": 1
+        }
+      ],
+      "fw_caps": 123456789,
+      "inform_ip": "192.168.1.1",
+      "inform_url": "http://192.168.1.1:8080/inform",
+      "ip": "192.168.1.1",
+      "last_seen": 1640995200,
+      "led_override": "default",
+      "led_override_color": "#0066cc",
+      "led_override_color_brightness": 100,
+      "mac": "aa:bb:cc:dd:ee:04",
+      "model": "UDM-Pro",
+      "name": "Dream Machine Pro",
+      "next_interval": 30,
+      "num_sta": 0,
+      "port_table": [
+        {
+          "port_idx": 1,
+          "media": "GE",
+          "port_poe": false,
+          "portconf_id": "5f9f1c1b0000000000000021",
+          "autoneg": true,
+          "enable": true,
+          "flowctrl_rx": false,
+          "flowctrl_tx": false,
+          "full_duplex": true,
+          "is_uplink": true,
+          "name": "Port 1",
+          "op_mode": "switch",
+          "rx_bytes": 123456789,
+          "rx_dropped": 0,
+          "rx_errors": 0,
+          "rx_packets": 987654,
+          "satisfaction": 100,
+          "speed": 1000,
+          "stp_pathcost": 0,
+          "stp_state": "forwarding",
+          "tx_bytes": 123456789,
+          "tx_dropped": 0,
+          "tx_errors": 0,
+          "tx_packets": 987654,
+          "up": true
+        }
+      ],
+      "serial": "JKL1234567890",
+      "state": 1,
+      "type": "udm",
+      "uptime": 345600,
+      "version": "2.4.27.14586"
+    }
+  ]
+}

--- a/src/components/services/Unifi.vue
+++ b/src/components/services/Unifi.vue
@@ -51,10 +51,10 @@ import Generic from "./Generic.vue";
 
 export default {
   name: "Unifi",
-  mixins: [service],
   components: {
     Generic,
   },
+  mixins: [service],
   props: {
     item: Object,
   },
@@ -108,7 +108,9 @@ export default {
         // Parse auth field in format "username:password"
         const [username, password] = this.item.auth.split(":");
         if (!username || !password) {
-          throw new Error("Authentication format should be 'username:password'");
+          throw new Error(
+            "Authentication format should be 'username:password'",
+          );
         }
 
         const credentials = {
@@ -116,7 +118,7 @@ export default {
           password: password,
         };
 
-        const response = await this.fetch(this.loginEndpoint, {
+        await this.fetch(this.loginEndpoint, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
@@ -141,7 +143,9 @@ export default {
         }
 
         // Fetch devices data only
-        const devicesData = await this.fetch(`${this.prefix}/api/s/${this.site}/stat/device`);
+        const devicesData = await this.fetch(
+          `${this.prefix}/api/s/${this.site}/stat/device`,
+        );
 
         // Count access points (devices with type 'uap')
         this.accessPoints =
@@ -153,9 +157,10 @@ export default {
 
         // For clients, we can use the total connected clients from devices that report client counts
         // or set to null if we don't have this data from devices endpoint
-        this.clients = devicesData.data?.reduce((total, device) => {
-          return total + (device.num_sta || 0);
-        }, 0) || null;
+        this.clients =
+          devicesData.data?.reduce((total, device) => {
+            return total + (device.num_sta || 0);
+          }, 0) || null;
 
         this.serverError = false;
       } catch (e) {

--- a/src/components/services/Unifi.vue
+++ b/src/components/services/Unifi.vue
@@ -72,14 +72,11 @@ export default {
       return this.item.site || "default";
     },
     prefix() {
-      // Check if URL indicates we need a prefix
-      if (this.item.apiUrl && this.item.apiUrl.includes("/manage")) {
-        return "/manage";
+      if (this.item.url && (this.item.url.includes("/manage") || this.item.url.includes("/proxy/network"))) {
+        // the configuration already include the prefix
+        return "";
       }
-      if (this.item.url && this.item.url.includes("/manage")) {
-        return "/manage";
-      }
-      return this.item.udm ? "/proxy/network" : "";
+      return this.item.udm ? "/proxy/network" : "/manage";
     },
     loginEndpoint() {
       // Most self-hosted controllers use /api/login (legacy endpoint)
@@ -127,7 +124,6 @@ export default {
         });
 
         this.sessionCookie = true;
-        return true;
       } catch (error) {
         console.error("Unifi authentication failed:", error);
         this.sessionCookie = null;

--- a/src/components/services/Unifi.vue
+++ b/src/components/services/Unifi.vue
@@ -1,0 +1,194 @@
+<template>
+  <Generic :item="item">
+    <template #content>
+      <p class="title is-4">{{ item.name }}</p>
+      <p class="subtitle is-6">
+        <template v-if="item.subtitle">
+          {{ item.subtitle }}
+        </template>
+        <template v-else-if="!serverError">
+          <span class="sensors">
+            <span
+              v-if="clients !== null"
+              class="sensor"
+              title="Connected Clients"
+            >
+              <i class="fas fa-users"></i>
+              <span class="sensor-value">{{ clients }}</span>
+            </span>
+            <span
+              v-if="accessPoints !== null"
+              class="sensor"
+              title="Access Points"
+            >
+              <i class="fas fa-wifi"></i>
+              <span class="sensor-value">{{ accessPoints }}</span>
+            </span>
+            <span
+              v-if="devices !== null"
+              class="sensor"
+              title="Other Network Devices"
+            >
+              <i class="fas fa-network-wired"></i>
+              <span class="sensor-value">{{ devices }}</span>
+            </span>
+          </span>
+        </template>
+        <template v-else> Connection Error </template>
+      </p>
+    </template>
+    <template #indicator>
+      <div v-if="serverError" class="status error">
+        <i class="fas fa-exclamation-triangle"></i>
+      </div>
+    </template>
+  </Generic>
+</template>
+
+<script>
+import service from "@/mixins/service.js";
+import Generic from "./Generic.vue";
+
+export default {
+  name: "Unifi",
+  mixins: [service],
+  components: {
+    Generic,
+  },
+  props: {
+    item: Object,
+  },
+  data: () => {
+    return {
+      clients: null,
+      devices: null,
+      accessPoints: null,
+      serverError: false,
+      sessionCookie: null,
+    };
+  },
+  computed: {
+    site() {
+      return this.item.site || "default";
+    },
+    prefix() {
+      // Check if URL indicates we need a prefix
+      if (this.item.apiUrl && this.item.apiUrl.includes("/manage")) {
+        return "/manage";
+      }
+      if (this.item.url && this.item.url.includes("/manage")) {
+        return "/manage";
+      }
+      return this.item.udm ? "/proxy/network" : "";
+    },
+    loginEndpoint() {
+      // Most self-hosted controllers use /api/login (legacy endpoint)
+      // Only explicitly modern controllers use /api/auth/login
+      return this.item.legacy === false ? "/api/auth/login" : "/api/login";
+    },
+  },
+  created() {
+    const interval = parseInt(this.item.interval, 10) || 30000;
+
+    // Set up interval if configured
+    if (interval > 0) {
+      setInterval(() => this.fetchData(), interval);
+    }
+
+    // Initial fetch
+    this.fetchData();
+  },
+  methods: {
+    async authenticateUnifi() {
+      try {
+        const credentials = {
+          username: this.item.username,
+          password: this.item.password,
+        };
+
+        const response = await this.fetch(this.loginEndpoint, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(credentials),
+        });
+
+        this.sessionCookie = true;
+        return true;
+      } catch (error) {
+        console.error("Unifi authentication failed:", error);
+        this.sessionCookie = null;
+        throw error;
+      }
+    },
+
+    async fetchData() {
+      try {
+        // First authenticate if we don't have a session
+        if (!this.sessionCookie) {
+          await this.authenticateUnifi();
+        }
+
+        // Fetch devices data only
+        const devicesData = await this.fetch(`${this.prefix}/api/s/${this.site}/stat/device`);
+
+        // Count access points (devices with type 'uap')
+        this.accessPoints =
+          devicesData.data?.filter((device) => device.type === "uap")?.length ||
+          0;
+
+        // Count other devices (exclude access points to avoid double counting)
+        this.devices = (devicesData.data?.length || 0) - this.accessPoints;
+
+        // For clients, we can use the total connected clients from devices that report client counts
+        // or set to null if we don't have this data from devices endpoint
+        this.clients = devicesData.data?.reduce((total, device) => {
+          return total + (device.num_sta || 0);
+        }, 0) || null;
+
+        this.serverError = false;
+      } catch (e) {
+        console.error("UniFi service error:", e);
+        this.serverError = true;
+        this.sessionCookie = null; // Reset session on error
+      }
+    },
+  },
+};
+</script>
+
+<style scoped lang="scss">
+.sensors {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.sensor {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.status {
+  font-size: 0.8rem;
+  color: var(--text-title);
+
+  &.error:before {
+    background-color: #c9404d;
+    border-color: #c42c3b;
+    box-shadow: 0 0 5px 1px #c9404d;
+  }
+
+  &:before {
+    content: " ";
+    display: inline-block;
+    width: 7px;
+    height: 7px;
+    margin-right: 10px;
+    border: 1px solid #000;
+    border-radius: 7px;
+  }
+}
+</style>

--- a/src/components/services/Unifi.vue
+++ b/src/components/services/Unifi.vue
@@ -101,9 +101,19 @@ export default {
   methods: {
     async authenticateUnifi() {
       try {
+        if (!this.item.auth) {
+          throw new Error("Authentication credentials not provided");
+        }
+
+        // Parse auth field in format "username:password"
+        const [username, password] = this.item.auth.split(":");
+        if (!username || !password) {
+          throw new Error("Authentication format should be 'username:password'");
+        }
+
         const credentials = {
-          username: this.item.username,
-          password: this.item.password,
+          username: username,
+          password: password,
         };
 
         const response = await this.fetch(this.loginEndpoint, {


### PR DESCRIPTION
## Description

This PR adds a new UniFi service integration that displays network information from UniFi Network
  Controllers, including connected clients, access points, and other network devices.
<img width="912" height="232" alt="Screenshot 2025-09-27 at 16 56 59" src="https://github.com/user-attachments/assets/ac212969-329d-489c-be21-e717922c843c" />



  The UniFi service automatically handles session-based authentication and CSRF protection,
  supporting both legacy and modern UniFi API endpoints. It provides real-time monitoring of network
  infrastructure with configurable refresh intervals.

  Key Features:
  - Displays connected clients count with user icon
  - Shows access points count with WiFi icon
  - Shows other network devices count with network icon
  - Automatic session management and authentication
  - Configurable site monitoring
  - Error handling with visual indicators

  Mock Data Included:
  - Complete mock API responses for testing and development
  - Realistic UniFi device data including access points, switches, and gateways
  - Authentication endpoints for both legacy and modern APIs

I only have a self-hosted Unifi controller running locally, so I did not test UDM or Cloud Key but they should work according to Unifi api docs.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] I have made corresponding changes to the documentation (`README.md`).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
