### PR TITLE
Gatus service fix: endpoint duration is factor 1000 too high

### DIFF
--- a/dummy-data/gatus/api/v1/endpoints/statuses
+++ b/dummy-data/gatus/api/v1/endpoints/statuses
@@ -7,7 +7,7 @@
       {
         "status": 200,
         "hostname": "gateway.example.com",
-        "duration": 10000,
+        "duration": 10000000,
         "conditionResults": [
           {
             "condition": "[STATUS] == 200",
@@ -24,7 +24,7 @@
       {
         "status": 200,
         "hostname": "gateway.example.com",
-        "duration": 10000,
+        "duration": 10000000,
         "conditionResults": [
           {
             "condition": "[STATUS] == 200",
@@ -41,7 +41,7 @@
       {
         "status": 200,
         "hostname": "gateway.example.com",
-        "duration": 10000,
+        "duration": 10000000,
         "conditionResults": [
           {
             "condition": "[STATUS] == 200",
@@ -58,7 +58,7 @@
       {
         "status": 200,
         "hostname": "gateway.example.com",
-        "duration": 10000,
+        "duration": 10000000,
         "conditionResults": [
           {
             "condition": "[STATUS] == 200",
@@ -82,7 +82,7 @@
       {
         "status": 200,
         "hostname": "www.example.com",
-        "duration": 10000,
+        "duration": 10000000,
         "conditionResults": [
           {
             "condition": "[STATUS] == 200",
@@ -99,7 +99,7 @@
       {
         "status": 200,
         "hostname": "gateway.example.com",
-        "duration": 10000,
+        "duration": 10000000,
         "conditionResults": [
           {
             "condition": "[STATUS] == 200",
@@ -116,7 +116,7 @@
       {
         "status": 200,
         "hostname": "gateway.example.com",
-        "duration": 10000,
+        "duration": 10000000,
         "conditionResults": [
           {
             "condition": "[STATUS] == 200",
@@ -133,7 +133,7 @@
       {
         "status": 200,
         "hostname": "gateway.example.com",
-        "duration": 10000,
+        "duration": 10000000,
         "conditionResults": [
           {
             "condition": "[STATUS] == 200",
@@ -157,7 +157,7 @@
       {
         "status": 200,
         "hostname": "ns1.example",
-        "duration": 20000,
+        "duration": 20000000,
         "conditionResults": [
           {
             "condition": "[STATUS] == 200",
@@ -170,7 +170,7 @@
       {
         "status": 200,
         "hostname": "ns1.example.com",
-        "duration": 20000,
+        "duration": 20000000,
         "conditionResults": [
           {
             "condition": "[STATUS] == 200",
@@ -183,7 +183,7 @@
       {
         "status": 200,
         "hostname": "ns1.example.com",
-        "duration": 20000,
+        "duration": 20000000,
         "conditionResults": [
           {
             "condition": "[STATUS] == 200",
@@ -196,7 +196,7 @@
       {
         "status": 200,
         "hostname": "ns1.example.com",
-        "duration": 20000,
+        "duration": 20000000,
         "conditionResults": [
           {
             "condition": "[STATUS] == 200",

--- a/src/components/services/Gatus.vue
+++ b/src/components/services/Gatus.vue
@@ -74,7 +74,7 @@ export default {
             let totalduration = 0;
             let rescounter = 0;
             job.results.forEach((res) => {
-              totalduration += parseInt(res.duration, 10) / 1000;
+              totalduration += parseInt(res.duration, 10) / 1000000;
               rescounter++;
             })
 


### PR DESCRIPTION
## Description

Thanks for merging https://github.com/bastienwirtz/homer/pull/941.

However, in the meantime Gatus seems to have changed the format (from us to ns) of the duration time in the API. The average times shown are wrong (factor 1000 too high).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] I have made corresponding changes to the documentation (`README.md`).
- [ ] I've checked my modifications for any breaking changes, especially in the `config.yml` file
