### PR TITLE
feat(services): add Iframe service for embedding pages in cards

### DIFF
--- a/src/components/services/Iframe.vue
+++ b/src/components/services/Iframe.vue
@@ -1,0 +1,107 @@
+<template>
+  <Generic :item="item" class="h-iframe" :style="{ height: cardHeight }">
+    <template #content>
+      <div class="h-iframe__wrap" :style="{ height: wrapHeight }">
+        <iframe
+          :src="item.src || item.url"
+          :title="item.name || 'Embed'"
+          :loading="item.loading || 'lazy'"
+          :referrerpolicy="item.referrerpolicy || 'no-referrer'"
+          frameborder="0"
+        ></iframe>
+      </div>
+    </template>
+  </Generic>
+</template>
+
+<script>
+    import Generic from "./Generic.vue";
+
+    export default {
+    name: "Iframe",
+    components: { Generic },
+    props: {
+        item: { type: Object, required: true },
+        proxy: Object,
+    },
+    computed: {
+        rowUnit() {
+        const u = this.item.unit ?? this.item.rowUnit;
+        if (typeof u === "number") return `${u}px`;
+        if (typeof u === "string" && u.trim()) return u.trim();
+        return "85px";
+        },
+
+        cardHeight() {
+        if (this.item.height) {
+            return typeof this.item.height === "number"
+            ? `${this.item.height}px`
+            : this.item.height;
+        }
+        const rows = Number(this.item.rows || 2);
+        
+        return `calc(${rows} * var(--h-row-unit, ${this.rowUnit}))`;
+        },
+
+        wrapHeight() {
+        const rows = Number(this.item.rows || 2);
+        
+        return `calc(${rows} * var(--h-row-unit, ${this.rowUnit}))`;
+        },
+    },
+    };
+</script>
+
+<style scoped>
+
+    .h-iframe :deep(.card) {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    }
+
+
+    .h-iframe :deep(.card-content) {
+    height: 100% !important;
+    padding: 0 !important;
+    display: flex;
+    flex: 1 1 auto;
+    }
+
+
+    .h-iframe :deep(.service-content) {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    padding: 0 !important;
+    margin: 0 !important;
+    flex: 1 1 auto;
+    }
+
+
+    .h-iframe :deep(.service-icon),
+    .h-iframe :deep(.service-name),
+    .h-iframe :deep(.service-subtitle),
+    .h-iframe :deep(.badge),
+    .h-iframe :deep(.meta) {
+    display: none !important;
+    }
+
+
+    .h-iframe__wrap {
+    flex: 1 1 auto;
+    width: 100%;
+    border-radius: 10px;
+    overflow: hidden;
+    border: 1px solid rgba(0,0,0,.10);
+    background: var(--card-background);
+    display: flex;
+    }
+
+    .h-iframe__wrap iframe {
+    flex: 1 1 auto;
+    width: 100%;
+    height: 100%;
+    border: 0;
+    }
+</style>


### PR DESCRIPTION
## Description

Adds a new lightweight `Iframe` service extending the built-in `Generic` card.

- Renders only the content area (title/subtitle/header are hidden) and fills the card with an `<iframe>`.
- Height can be controlled by:
  - `rows` (number of card-heights, default `2`)
  - optional base height per row via `unit` / `rowUnit` (default `85px`, accepts any CSS length), or globally via CSS variable `--h-row-unit`
  - `height` (CSS length; hard override of `rows`)
- No new dependencies. No breaking changes.

**Props**
- `src` *(required)* – URL to embed  
- `rows` *(optional, default `2`)*  
- `unit` / `rowUnit` *(optional, default `85px`)*  


> Note: Some sites may block embedding via CSP or `X-Frame-Options`. This is documented.

### Iframe (service)

Embed a web page inside a card.

**Config**
```yaml
- type: Iframe
  src: "https://example.com/embed"
  rows: 3         # optional, default 2
  # unit: 90px    # optional per-item base height; default 85px
  # height: 520px # optional hard override (CSS length)

- type: Iframe
    src: https://example.com/embed
    rows: 3
    unit: 100px 
```

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactoring

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] I have made corresponding changes to the documentation (`README.md`) – see snippet below.
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file.
