### PR TITLE
Feature - Added optional light and dark logos

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,6 +25,11 @@ logo: "assets/logo.png"
 # Alternatively a fa icon can be provided:
 # icon: "fas fa-skull-crossbones"
 
+# Optional: Provide different logos for light and dark themes
+# logo:
+#   light: "assets/logo-light.png"
+#   dark: "assets/logo-dark.png"
+
 header: true # Set to false to hide the header
 # Optional: Different hotkey for search, defaults to "/"
 # hotkey:
@@ -139,6 +144,10 @@ services:
         logo: "assets/tools/sample.png"
         # Alternatively a fa icon can be provided:
         # icon: "fab fa-jenkins"
+        # Provide different logos for light and dark themes:
+        # logo:
+        #   light: "assets/tools/sample-light.png"
+        #   dark: "assets/tools/sample-dark.png"
         subtitle: "Bookmark example"
         tag: "app"
         keywords: "self hosted reddit" # optional keyword used for searching purpose

--- a/public/assets/config-demo.yml.dist
+++ b/public/assets/config-demo.yml.dist
@@ -7,6 +7,11 @@ subtitle: "Homer"
 logo: "logo.png"
 # icon: "fas fa-skull-crossbones" # Optional icon
 
+# Optional: Provide different logos for light and dark themes
+# logo:
+#   light: "logo-light.png"
+#   dark: "logo-dark.png"
+
 header: true
 footer: '<p>Created with <span class="has-text-danger">❤️</span> with <a href="https://bulma.io/">Bulma</a>, <a href="https://vuejs.org/">Vue.js</a> & <a href="https://fontawesome.com/">font awesome</a> // Fork me on <a href="https://github.com/bastienwirtz/homer"><i class="fab fa-github-alt"></i></a></p>' # set false if you want to hide it.
 
@@ -49,6 +54,12 @@ services:
     items:
       - name: "Get started"
         icon: "fa-solid fa-download"
+        # Alternatively a logo can be provided:
+        # logo: "assets/tools/sample.png"
+        # Provide different logos for light and dark themes:
+        # logo:
+        #   light: "assets/tools/sample-light.png"
+        #   dark: "assets/tools/sample-dark.png"
         subtitle: "Start using Homer in a few minutes"
         tag: "setup"
         url: "https://github.com/bastienwirtz/homer?tab=readme-ov-file#get-started"

--- a/public/assets/config.yml.dist
+++ b/public/assets/config.yml.dist
@@ -7,6 +7,11 @@ subtitle: "Homer"
 logo: "logo.png"
 # icon: "fas fa-skull-crossbones" # Optional icon
 
+# Optional: Provide different logos for light and dark themes
+# logo:
+#   light: "logo-light.png"
+#   dark: "logo-dark.png"
+
 header: true
 footer: '<p>Created with <span class="has-text-danger">❤️</span> with <a href="https://bulma.io/">bulma</a>, <a href="https://vuejs.org/">vuejs</a> & <a href="https://fontawesome.com/">font awesome</a> // Fork me on <a href="https://github.com/bastienwirtz/homer"><i class="fab fa-github-alt"></i></a></p>' # set false if you want to hide it.
 
@@ -76,6 +81,12 @@ services:
     items:
       - name: "Get started"
         icon: "fa-solid fa-download"
+        # Alternatively a logo can be provided:
+        # logo: "assets/tools/sample.png"
+        # Provide different logos for light and dark themes:
+        # logo:
+        #   light: "assets/tools/sample-light.png"
+        #   dark: "assets/tools/sample-dark.png"
         subtitle: "Start using Homer in a few minutes"
         tag: "setup"
         url: "https://github.com/bastienwirtz/homer?tab=readme-ov-file#get-started"

--- a/src/App.vue
+++ b/src/App.vue
@@ -15,7 +15,7 @@
         <div v-cloak class="container">
           <div class="logo">
             <a href="#">
-              <img v-if="config.logo" :src="config.logo" alt="dashboard logo" />
+              <img v-if="logoUrl" :src="logoUrl" alt="dashboard logo" />
             </a>
             <i v-if="config.icon" :class="config.icon"></i>
           </div>
@@ -147,6 +147,23 @@ export default {
   computed: {
     configurationNeeded: function () {
       return (this.loaded && !this.services) || this.configNotFound;
+    },
+    logoUrl: function () {
+      if (!this.config || !this.config.logo) {
+        return null;
+      }
+      
+      // Support both string format and object format (light/dark)
+      if (typeof this.config.logo === "string") {
+        return this.config.logo;
+      }
+      
+      // Object format with light and dark properties
+      if (typeof this.config.logo === "object") {
+        return this.isDark ? this.config.logo.dark : this.config.logo.light;
+      }
+      
+      return null;
     },
   },
   created: async function () {

--- a/src/components/services/Generic.vue
+++ b/src/components/services/Generic.vue
@@ -5,9 +5,9 @@
         <div class="card-content">
           <div :class="mediaClass">
             <slot name="icon">
-              <div v-if="item.logo" class="media-left">
+              <div v-if="logoUrl" class="media-left">
                 <figure class="image is-48x48">
-                  <img :src="item.logo" :alt="`${item.name} logo`" />
+                  <img :src="logoUrl" :alt="`${item.name} logo`" />
                 </figure>
               </div>
               <div v-if="item.icon" class="media-left">
@@ -59,9 +59,61 @@ export default {
   props: {
     item: Object,
   },
+  data() {
+    return {
+      isDark: false,
+    };
+  },
   computed: {
     mediaClass: function () {
       return { media: true, "no-subtitle": !this.item.subtitle };
+    },
+    logoUrl: function () {
+      if (!this.item.logo) {
+        return null;
+      }
+      
+      // Support both string format and object format (light/dark)
+      if (typeof this.item.logo === "string") {
+        return this.item.logo;
+      }
+      
+      // Object format with light and dark properties
+      if (typeof this.item.logo === "object") {
+        return this.isDark ? this.item.logo.dark : this.item.logo.light;
+      }
+      
+      return null;
+    },
+  },
+  mounted() {
+    // Initialize theme state
+    this.updateTheme();
+    
+    // Watch for theme changes on the app element
+    const observer = new MutationObserver(() => {
+      this.updateTheme();
+    });
+    
+    const appElement = document.getElementById('app');
+    if (appElement) {
+      observer.observe(appElement, {
+        attributes: true,
+        attributeFilter: ['class'],
+      });
+    }
+    
+    this._themeObserver = observer;
+  },
+  beforeUnmount() {
+    if (this._themeObserver) {
+      this._themeObserver.disconnect();
+    }
+  },
+  methods: {
+    updateTheme() {
+      const appElement = document.getElementById('app');
+      this.isDark = appElement?.classList.contains('dark') || false;
     },
   },
 };


### PR DESCRIPTION
## Description

Hi bastien,

Thank you so much for your work on this dashboard.
I have been using it for quite a long time now and decided to contribute to it by adding a feature I and others are missing, please see #896.

I have added logic to enable the use of different icons for light and dark themes.
It works with existing configurations, as it just extends the possible yaml values.


Current config (still works with new version):
```yaml
logo: "assets/tools/sample.png"
```

Optional light and dark logos:
```yaml
logo:
  light: "assets/tools/sample-light.png"
  dark: "assets/tools/sample-dark.png"
```
I have updated the default configs as well as the documentations.
There are no new dependencies required for this change.


Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] I have made corresponding changes to the documentation (`README.md`).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
