### PR TITLE
feat(Pi-hole): add enable/disable toggle button

### DIFF
--- a/src/components/services/PiHole.vue
+++ b/src/components/services/PiHole.vue
@@ -1,7 +1,16 @@
 <template>
   <Generic :item="item">
     <template #content>
-      <p class="title is-4">{{ item.name }}</p>
+      <p class="title is-4">
+        {{ item.name }}
+        <i
+          @click.stop.prevent="toggleBlocking"
+          @touchstart.stop.prevent="toggleBlocking"
+          class="control-icon fas"
+          :class="status === 'enabled' ? 'fa-pause' : 'fa-play'"
+          :title="status === 'enabled' ? 'Disable blocking for 5 minutes' : 'Enable blocking'"
+        ></i>
+      </p>
       <p class="subtitle is-6">
         <template v-if="item.subtitle">
           {{ item.subtitle }}
@@ -204,6 +213,58 @@ export default {
       this.status = result.status;
       this.percent_blocked = result.ads_percentage_today;
     },
+    toggleBlocking: async function () {
+      if (parseInt(this.item.apiVersion, 10) === 6) {
+        await this.toggleBlocking_v6();
+      } else {
+        await this.toggleBlocking_v5();
+      }
+    },
+    async toggleBlocking_v6() {
+      try {
+        if (!this.isAuthenticated && this.item.apikey) {
+          const authenticated = await this.authenticate();
+          if (!authenticated) return;
+        }
+
+        const newBlockingState = this.status !== 'enabled';
+        const body = newBlockingState
+          ? { blocking: true }
+          : { blocking: false, timer: 300 }; // 5 minutes = 300 seconds
+
+        await this.fetch(`api/dns/blocking?sid=${encodeURIComponent(this.sessionId)}`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(body),
+        });
+
+        // Immediately update status for responsive UI
+        this.status = newBlockingState ? 'enabled' : 'disabled';
+
+        // Fetch the latest status to confirm
+        await this.fetchStatus();
+      } catch (e) {
+        this.handleError(`Failed to toggle blocking: ${e.message || e}`, "error");
+      }
+    },
+    async toggleBlocking_v5() {
+      try {
+        const endpoint = this.status === 'enabled' ? 'disable=300' : 'enable';
+        const authParam = this.item.apikey ? `&auth=${this.item.apikey}` : '';
+
+        await this.fetch(`/api.php?${endpoint}${authParam}`);
+
+        // Immediately update status for responsive UI
+        this.status = this.status === 'enabled' ? 'disabled' : 'enabled';
+
+        // Fetch the latest status to confirm
+        await this.fetchStatus_v5();
+      } catch (e) {
+        this.handleError(`Failed to toggle blocking: ${e}`, "error");
+      }
+    },
   },
 };
 </script>
@@ -239,6 +300,50 @@ export default {
     margin-right: 10px;
     border: 1px solid #000;
     border-radius: 7px;
+  }
+}
+
+.control-icon {
+  margin-left: 0.6em;
+  font-size: 0.6em;
+  cursor: pointer;
+  opacity: 0.7;
+  transition: opacity 0.2s ease, transform 0.1s ease, border-color 0.2s ease;
+  vertical-align: middle;
+  position: relative;
+  top: -0.1em;
+  z-index: 9999;
+  pointer-events: all;
+  border: 1.5px solid;
+  border-radius: 0.3em;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.8em;
+  height: 1.8em;
+
+  &:hover {
+    opacity: 1;
+  }
+
+  &.fa-play {
+    color: #4caf50;
+    border-color: rgba(76, 175, 80, 0.4);
+
+    &:hover {
+      border-color: rgba(76, 175, 80, 0.7);
+    }
+  }
+
+  &.fa-pause {
+    color: #f39c12;
+    border-color: rgba(243, 156, 18, 0.4);
+    padding-top: 1px;
+    padding-left: 0;
+
+    &:hover {
+      border-color: rgba(243, 156, 18, 0.7);
+    }
   }
 }
 </style>


### PR DESCRIPTION
Add interactive toggle button to Pi-hole service card for quick enable/disable control directly from the dashboard.

Features:
- Toggle button with play/pause icon (enable/disable)
- Visual feedback during state changes
- Properly centered pause icon in button
- Maintains existing status display and statistics
- Works with both Pi-hole API v5 and v6
- Error handling for failed toggle operations

The toggle button provides quick access to the most common Pi-hole action without opening the web interface. Particularly useful for temporarily disabling ad blocking when needed.

Maintains backwards compatibility with existing Pi-hole configurations.

## Description

  This enhancement adds a simple but frequently-requested feature: the ability to quickly enable/disable Pi-hole from the dashboard. The toggle respects the existing API configuration (v5 or v6) and provides visual feedback during state changes.

  No new dependencies added. No issues fixed (proactive enhancement).

  Fixes # (N/A - enhancement)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] I have made corresponding changes to the documentation (`README.md`).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
