### PR TITLE
Fixed small typo in demo site

### DIFF
--- a/public/assets/config-demo.yml.dist
+++ b/public/assets/config-demo.yml.dist
@@ -120,7 +120,7 @@ services:
         units: "metric"
         endpoint: "/dummy-data/openweather/weather"
         type: "OpenWeather"
-  - name: "Ressources"
+  - name: "Resources"
     icon: "fa-regular fa-bookmark"
     class: highlight-inverted
     items:


### PR DESCRIPTION
## Description

There was a small error in the demo site's heading: "Resources" was spelled "Ressources". In looking for "Ressources" in the base repo, this seems to be the only place where it appears.

<img width="904" height="444" alt="image" src="https://github.com/user-attachments/assets/6b114b9d-fc09-4424-a307-165916d7e9ad" />

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] I have made corresponding changes to the documentation (`README.md`).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
