### PR TITLE
Parse environment variables in YAML config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ ENV GID=1000 \
     IPV6_DISABLE=0
 
 RUN addgroup -S lighttpd -g ${GID} && adduser -D -S -u ${UID} lighttpd lighttpd && \
-    apk add -U --no-cache tzdata lighttpd
+    apk add -U --no-cache envsubst tzdata lighttpd
 
 WORKDIR /www
 

--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -82,8 +82,8 @@ Great if you have a lot of services or a lot of tags!
 
 #### `by @sizzlesloth`
 
-Environment variables prefixed with `VITE_` can be included. This is great for when you have
-configuration that changes.
+Environment variables prefixed with `VITE_` can be used in your YAML configuration. This is great
+for when you have values that can change, or want to refer to the same value in multiple places.
 
 For example, if we ran the container with:
 

--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -40,7 +40,7 @@ Using Anchoring, you can define all your tags and their styles once like this: (
 
 ```yaml
 # Some pre-defined tag styles. reference these using <<: *{NAME} inside an item definition; For Example, <<: *Apps
-tags: 
+tags:
   Favourite: &Favourite
     - tag: "Favourite"
       tagstyle: "is-medium is-primary"
@@ -49,7 +49,7 @@ tags:
       tagstyle: "is-medium is-success"
   Apps: &Apps
     - tag: "App"
-      tagstyle: "is-medium is-info"      
+      tagstyle: "is-medium is-info"
 ```
 
 and then simply reference these pre-defined (anchored) tags in each item like so:
@@ -76,11 +76,31 @@ Then when Homer reads your config, it will substitute your anchors automatically
 ```
 
 The end result is that if you want to update the name or style of any particular tag, just update it once, in the tags section!
-Great if you have a lot of services or a lot of tags!  
+Great if you have a lot of services or a lot of tags!
 
-## YAML auto complete with a YAML schema 
+## Environment Variables
 
-A lot of editor support auto completion, see <https://www.schemastore.org/json/>   
+#### `by @sizzlesloth`
+
+Environment variables prefixed with `VITE_` can be included. This is great for when you have
+configuration that changes.
+
+For example, if we ran the container with:
+
+```bash
+docker run ... -e VITE_HOSTNAME=example.com ...
+```
+
+We can refer to the environment variable in our YAML like so:
+
+```yaml
+title: "Demo dashboard for $VITE_HOSTNAME"
+```
+- Note: `${VITE_HOSTNAME}` would also be valid
+
+## YAML auto complete with a YAML schema
+
+A lot of editor support auto completion, see <https://www.schemastore.org/json/>
 The homer schema is available here: <https://raw.githubusercontent.com/bastienwirtz/homer/main/.schema/config-schema.json>
 
 For example with IntelliJ you can define:

--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -98,6 +98,12 @@ title: "Demo dashboard for $VITE_HOSTNAME"
 ```
 - Note: `${VITE_HOSTNAME}` would also be valid
 
+This would evalute to:
+
+```
+Demo dashboard for example.com
+```
+
 ## YAML auto complete with a YAML schema
 
 A lot of editor support auto completion, see <https://www.schemastore.org/json/>

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,24 @@
 #!/bin/sh
 
+# Substitute env vars so they can be available at runtime. Note that Vite only exposes environment
+# variables prefixed with "VITE_" at build time, so that behaviour is replicated here.
+env \
+  | grep '^VITE_' \
+  | sed 's/=\(.*\)/=\1/' \
+  | awk -F= '{print "window.env." $1 " = \"" $2 "\";"}' \
+  > /tmp/env.lines.js
+
+# Replace the placeholder in the template with our env vars
+sed '/__VITE_INJECT__/r /tmp/env.lines.js' \
+  /www/scripts/env.template.js \
+  | envsubst \
+  > /www/scripts/env.js
+sed -i 's/__VITE_INJECT__//' /www/scripts/env.js
+
 # Default assets & example configuration installation
 if [[ "${INIT_ASSETS}" == "1" ]] && [[ ! -f "/www/assets/config.yml" ]]; then
     echo "No configuration found, installing default config & assets"
-    if [[ -w "/www/assets/" ]]; 
+    if [[ -w "/www/assets/" ]];
     then
         while true; do echo n; done | cp -Ri /www/default-assets/* /www/assets/
         yes n | cp -i /www/default-assets/config.yml.dist /www/assets/config.yml

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <link rel="apple-touch-icon" href="assets/icons/apple-touch-icon.png" sizes="180x180">
     <link rel="mask-icon" href="assets/icons/logo.svg">
     <meta name="viewport" content="width=device-width,initial-scale=1.0,viewport-fit=cover">
+    <script src="scripts/env.js"></script>
     <title>Homer</title>
   </head>
   <body>

--- a/public/scripts/env.js
+++ b/public/scripts/env.js
@@ -1,0 +1,4 @@
+// This is a placeholder for when the file is overwritten by the template
+(function (window) {
+  window.env = window.env || {};
+})(window);

--- a/public/scripts/env.template.js
+++ b/public/scripts/env.template.js
@@ -1,0 +1,9 @@
+// Vite does not natively support arbritrary environment variables at runtime. As a workaround,
+// this file acts as a template to populate window.env.
+(function (window) {
+  window.env = window.env || {};
+
+  // Replaced by entrypoint.sh
+  __VITE_INJECT__
+
+})(window);

--- a/src/App.vue
+++ b/src/App.vue
@@ -169,6 +169,12 @@ export default {
         return this.config.hotkey.search;
       }
     },
+    parseEnvVars: function (body) {
+      return body.replace(
+        /\$\{?([A-Za-z0-9_-]+)\}?/g,
+        (_, name) => window.env[name] ?? ''
+      );
+    },
     buildDashboard: async function () {
       const defaults = parse(defaultConfig);
       let config;
@@ -219,6 +225,7 @@ export default {
         const that = this;
         return response
           .text()
+          .then(body => this.parseEnvVars(body))
           .then((body) => {
             return parse(body, { merge: true });
           })


### PR DESCRIPTION
Relates to #609 
Relates to #735 
Closes #788

## Description

My configuration.yaml refers to the same hostname in many places. I thought it would be beneficial for Homer to be able to parse environment variables.

Vite does not natively support using user-defined env vars at runtime (only build time), so this is a 'best effort' workaround which involves using a JS script to populate window.env. The entrypoint script will modify a template dynamically; based on how many environment variables prefixed with `VITE_`, are defined.

### Some notes

- In one of the issues, a potential solution discussed was using mod_magnets. However, this could potentially cause issues with formatting, escapes, etc. My thought-process was to resolve env vars before the YAML is parsed, so we can fail early if the YAML becomes invalid (I am also assuming things are correctly escaped at the point where the YAML is transformed into JS). If the mod_magnet solution is preferable though, feel free to decline this one.

- The choice for the `VITE_` prefix is based on how Vite includes env vars at build-time (for security), so I followed the same behaviour here.

- I'm not very familiar with Vite (I have tried my best to read the docs), so let me know if you think there is a better way of doing this :D

### Caveats

- The container must be restarted in order for env var changes to take effect, since the population of headers.env occurs in `entrypoint.sh`

Fixes #788

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring

## Checklist:

- [X] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [X] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [X] I have made corresponding changes to the documentation (`README.md`).
- [X] I've checked my modifications for any breaking changes, especially in the `config.yml` file
