### PR TITLE
Feature/librislog custom service

### DIFF
--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -29,6 +29,7 @@ Available services are located in `src/components/`:
 - [Immich](#immich)
 - [Jellystat](#jellystat)
 - [Lidarr, Prowlarr, Sonarr, Readarr and Radarr](#lidarr-prowlarr-sonarr-readarr-and-radarr)
+- [LibrisLog](#librislog)
 - [Linkding](#linkding)
 - [Matrix](#matrix)
 - [Mealie](#mealie)
@@ -383,6 +384,22 @@ This integration supports at max 15 results from Linkding, but you can add it mu
 ```
 
 Auto refresh is supported by this integration.  
+
+## LibrisLog
+
+Displays library statistics from your LibrisLog book tracker: total books, books read, currently reading, and want-to-read counts.
+
+```yaml
+- name: "LibrisLog"
+  type: "LibrisLog"
+  logo: "https://docs.librislog.app/logo.png"
+  url: "https://my-service.url"
+  apikey: "<---insert-api-key-here--->"
+```
+
+Auto refresh is supported by this integration.
+
+**API Key**: Generate an API key in your LibrisLog instance settings.
 
 ## Matrix
 

--- a/dummy-data/librislog/api/books/stats
+++ b/dummy-data/librislog/api/books/stats
@@ -1,0 +1,1 @@
+{"total_books":295,"books_read":288,"books_reading":1,"books_want_to_read":6,"books_did_not_finish":0}

--- a/src/components/services/LibrisLog.vue
+++ b/src/components/services/LibrisLog.vue
@@ -1,0 +1,108 @@
+<template>
+  <Generic :item="item">
+    <template #content>
+      <p class="title is-4">{{ item.name }}</p>
+      <p class="subtitle is-6">
+        <template v-if="item.subtitle">{{ item.subtitle }}</template>
+        <template v-else-if="statsText">{{ statsText }}</template>
+      </p>
+    </template>
+    <template #indicator>
+      <div class="notifs">
+        <strong
+          v-if="stats && stats.books_reading > 0"
+          class="notif reading"
+          title="Currently reading"
+        >
+          {{ stats.books_reading }}
+        </strong>
+        <strong
+          v-if="stats && stats.books_want_to_read > 0"
+          class="notif want-to-read"
+          title="Want to read"
+        >
+          {{ stats.books_want_to_read }}
+        </strong>
+        <strong
+          v-if="serverError"
+          class="notif errors"
+          title="Connection error to LibrisLog API, check url and apikey in config.yml"
+        >
+          ?
+        </strong>
+      </div>
+    </template>
+  </Generic>
+</template>
+
+<script>
+import service from "@/mixins/service.js";
+
+export default {
+  name: "LibrisLog",
+  mixins: [service],
+  props: {
+    item: Object,
+  },
+  data: () => ({
+    stats: null,
+    serverError: false,
+  }),
+  computed: {
+    statsText() {
+      if (!this.stats) return null;
+      return `${this.stats.books_read} / ${this.stats.total_books} books read`;
+    },
+  },
+  created() {
+    this.autoUpdateMethod = this.fetchStats;
+    this.fetchStats();
+  },
+  methods: {
+    fetchStats() {
+      const headers = {
+        "X-API-Key": this.item.apikey,
+      };
+      this.fetch("/api/books/stats", { headers })
+        .then((data) => {
+          this.stats = data;
+        })
+        .catch((e) => {
+          console.error(e);
+          this.serverError = true;
+        });
+    },
+  },
+};
+</script>
+
+<style scoped lang="scss">
+.notifs {
+  position: absolute;
+  color: white;
+  font-family: sans-serif;
+  top: 0.3em;
+  right: 0.5em;
+
+  .notif {
+    display: inline-block;
+    padding: 0.2em 0.35em;
+    border-radius: 0.25em;
+    position: relative;
+    margin-left: 0.3em;
+    font-size: 0.8em;
+
+    &.reading {
+      background-color: #4fb5d6;
+    }
+
+    &.want-to-read {
+      background-color: #9d00ff;
+    }
+
+    &.errors {
+      background-color: #e51111;
+    }
+  }
+}
+</style>


### PR DESCRIPTION
## Description

Adds a new LibrisLog service component that displays library statistics (total books, books read, currently reading, want-to-read) from a LibrisLog book tracker instance.

The component fetches from `GET /api/books/stats` using the `X-API-Key` header, follows the standard Homer service pattern (extends Generic.vue, uses service.js mixin, auto-update support), and shows error state with a red `?` badge on connection failure.

Includes mock data for testing via `pnpm mock`.

Fixes #1042 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [ ] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] I have made corresponding changes to the documentation (`README.md`).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
Files changed:
- src/components/services/LibrisLog.vue — new service component
- dummy-data/librislog/api/books/stats — mock data for testing
- docs/customservices.md — added LibrisLog documentation entry