### PR TITLE
fix: rewrite peanut smartcard status

### DIFF
--- a/src/components/services/PeaNUT.vue
+++ b/src/components/services/PeaNUT.vue
@@ -32,28 +32,18 @@ export default {
   }),
   computed: {
     status_text: function () {
-      switch (this.ups_status) {
-        case "OL":
-          return "online";
-        case "OB":
-          return "on battery";
-        case "LB":
-          return "low battery";
-        default:
-          return "unknown";
-      }
+      const status = this.ups_status;
+      if (status.includes("LB"))     return "low battery";
+      if (status.includes("OB"))     return "on battery";
+      if (status.includes("OL"))     return "online";
+      return "unknown";
     },
     status_class: function () {
-      switch (this.ups_status) {
-        case "OL":
-          return "online";
-        case "OB": // On battery
-          return "pending";
-        case "LB": // Low battery
-          return "offline";
-        default:
-          return "unknown";
-      }
+      const status = this.ups_status;
+      if (status.includes("LB"))     return "offline";
+      if (status.includes("OB"))     return "pending";
+      if (status.includes("OL"))     return "online";
+      return "unknown";
     },
     load: function () {
       if (this.ups_load) {


### PR DESCRIPTION
## Description

[RFC 9271](https://www.rfc-editor.org/rfc/rfc9271.pdf) gives the value requirement of ups.status:

> The status of a hardware device, such as a UPS unit, is a symbolic description of the state of the unit. It consists of a space-separated list of symbols from the set {ALARM BOOST BYPASS CAL CHRG COMM DISCHRG FSD LB NOCOMM OB OFF OL OVER RB TEST TRIM}.

Rewrite lines of PeaNUT component to show ups.status correctly.

Fixes #1044 .

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] I have made corresponding changes to the documentation (`README.md`).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file

