### PR TITLE
fix: restore auto-update registration broken by interval refactor

### DIFF
--- a/src/mixins/service.js
+++ b/src/mixins/service.js
@@ -90,7 +90,7 @@ export default {
       }
 
       const interval = this.getUpdateInterval();
-      if (interval > 0) {
+      if (interval <= 0) {
         return;
       }
       updateScheduler.register(this, interval, this.autoUpdateMethod);
@@ -128,7 +128,7 @@ export default {
 
       // Use service-specific interval if defined
       if (interval) {
-        return parseInt(this.item.updateInterval, 10) || 0;
+        return parseInt(interval, 10) || 0;
       }
 
       // Use global auto-update configuration


### PR DESCRIPTION
### Problem

Auto-update / auto-refresh is currently broken for every service. The recent **"improve updater registration"** refactor (`6260b13`) introduced two regressions in `src/mixins/service.js`:

**1. Inverted guard in `initAutoUpdate()`**

```js
const interval = this.getUpdateInterval();
if (interval > 0) {
  return;                       // bails out exactly when the interval is VALID
}
updateScheduler.register(this, interval, this.autoUpdateMethod);  // only runs with interval === 0
```

A valid interval skips registration, and a disabled one (`0`) is the only case that reaches `register()`.

**2. Wrong key parsed in `getUpdateInterval()`**

```js
let interval = this.item[intervalKey];   // resolves updateIntervalMs / deprecated keys
...
if (interval) {
  return parseInt(this.item.updateInterval, 10) || 0;  // but parses the OLD hardcoded key
}
```

The interval is resolved into the local `interval` variable, but the service-specific branch still parses `this.item.updateInterval`. Setting `updateIntervalMs: 10000` leaves `this.item.updateInterval` undefined, so it returns `0` (disabled).

### Fix

- Register when `interval > 0` (invert the early-return to `interval <= 0`).
- Parse the already-resolved `interval` value instead of the hardcoded `this.item.updateInterval` key.

Two-line change; behaviour now matches the pre-refactor logic and the documented `updateIntervalMs` config.

### Verification

`pnpm lint` and `pnpm build` both pass.