### PR TITLE
fix: actually remove the search keydown listener on unmount

### DIFF
--- a/src/components/SearchInput.vue
+++ b/src/components/SearchInput.vue
@@ -36,8 +36,8 @@ export default {
       if (event.key === "Escape") {
         this.cancel();
       }
-    };
-    document.addEventListener("keydown", this._keyListener.bind(this));
+    }.bind(this);
+    document.addEventListener("keydown", this._keyListener);
 
     // fill search from get parameter.
     const search = new URLSearchParams(window.location.search).get("search");


### PR DESCRIPTION
### Problem

`SearchInput.vue` registers a global `keydown` listener that is never removed, leaking a handler onto `document` every time the component is recreated.

```js
// mounted()
document.addEventListener("keydown", this._keyListener.bind(this));
...
// beforeUnmount()
document.removeEventListener("keydown", this._keyListener);
```

`.bind(this)` returns a **new** function reference, so the function passed to `addEventListener` is not the same object as `this._keyListener` passed to `removeEventListener`. The references never match, so `removeEventListener` is a no-op and the listener survives unmount.

Because the whole app is gated behind `v-if="config"` and the config/page reloads on hash-route changes (and on dev hot-reload), `SearchInput` gets recreated repeatedly. Each recreation adds another orphaned global handler, and they all keep firing on the search hotkey / `Escape`.

### Fix

Bind once, store that bound reference in `this._keyListener`, and use the same reference for both `addEventListener` and `removeEventListener`.

### Verification

`pnpm lint` and `pnpm build` both pass.