### PR TITLE
feat(Traefik): show /api/overview stats as colored badges

### DIFF
--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -846,15 +846,38 @@ Auto refresh is supported by this integration.
 
 ## Traefik
 
-Displays Traefik.
+Displays Traefik stats counts as colored badges: routers, services, middlewares, certificates, warnings and errors. Each count is the sum across all sections.
+
+Auto refresh is supported by this integration.
+
+> [!IMPORTANT]
+> **Potentially breaking change**: on version `26.04.2` and earlier, this card only displayed the Traefik version.
+> It now also shows badges for routers, services, middlewares, certificates, warnings and errors.
+>
+> To keep the old version-only card, hide every badge:
+>
+> ```yaml
+> - name: "Traefik"
+>   type: "Traefik"
+>   url: "http://traefik.example.com"
+>   hide: ["routers", "services", "middlewares", "certificates", "warnings", "errors"]
+> ```
 
 ```yaml
 - name: "Traefik"
   type: "Traefik"
   logo: "assets/tools/sample.png"
   url: "http://traefik.example.com"
-  # basic_auth: "admin:password"  # (Optional) Send Authorization header. 
+  # basic_auth: "admin:password"  # (Optional) Send Authorization header.
+  # subtitle: "Reverse proxy"     # (Optional) Overrides the version subtitle (skips the /api/version call).
+  # hide: []                      # (Optional) hides badges. Possible values are
+  #                               # "routers", "services", "middlewares",
+  #                               # "certificates", "warnings" and "errors".
 ```
+
+**Hiding badges**: every badge is shown by default; list a key under `hide` to remove it. Routers, services and middlewares are summed across `http`, `tcp` and `udp`; warnings and errors are summed across those plus `certificates`. Hide all six for a version-only card. Badge counts are capped at `99+`.
+
+**Version**: the version (from `/api/version`) is shown as the subtitle. Setting `subtitle` overrides it, in which case the version request is skipped.
 
 **Authentication**: If BasicAuth is set, credentials will be encoded in Base64 and sent as an Authorization header (`Basic <encoded_value>`). The value must be formatted as "admin:password".
 

--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -879,7 +879,7 @@ Displays Traefik stats counts as colored badges: routers, services, middlewares,
 Auto refresh is supported by this integration.
 
 > [!IMPORTANT]
-> **Potentially breaking change**: on version `26.04.2` and earlier, this card only displayed the Traefik version.
+> **Potentially breaking change**: on version `26.08.3` and earlier, this card only displayed the Traefik version.
 > It now also shows badges for routers, services, middlewares, certificates, warnings and errors.
 >
 > To keep the old version-only card, hide every badge:

--- a/dummy-data/traefik/api/overview
+++ b/dummy-data/traefik/api/overview
@@ -1,0 +1,23 @@
+{
+    "http": {
+        "routers": { "total": 12, "warnings": 1, "errors": 1 },
+        "services": { "total": 11, "warnings": 0, "errors": 2 },
+        "middlewares": { "total": 5, "warnings": 1, "errors": 0 }
+    },
+    "tcp": {
+        "routers": { "total": 3, "warnings": 0, "errors": 0 },
+        "services": { "total": 3, "warnings": 0, "errors": 0 },
+        "middlewares": { "total": 1, "warnings": 0, "errors": 0 }
+    },
+    "udp": {
+        "routers": { "total": 2, "warnings": 0, "errors": 0 },
+        "services": { "total": 2, "warnings": 0, "errors": 0 }
+    },
+    "certificates": { "total": 4, "warnings": 0, "errors": 0 },
+    "features": {
+        "tracing": "",
+        "metrics": "",
+        "accessLog": true
+    },
+    "providers": ["Docker", "File", "KubernetesIngress"]
+}

--- a/src/components/services/Traefik.vue
+++ b/src/components/services/Traefik.vue
@@ -3,17 +3,30 @@
     <template #content>
       <p class="title is-4">{{ item.name }}</p>
       <p class="subtitle is-6">
-        <template v-if="item.subtitle">
-          {{ item.subtitle }}
-        </template>
-        <template v-else-if="versionstring">
-          Version {{ versionstring }}
-        </template>
+        <template v-if="item.subtitle">{{ item.subtitle }}</template>
+        <template v-else-if="versionstring"
+          >Version {{ versionstring }}</template
+        >
       </p>
     </template>
     <template #indicator>
-      <div v-if="status" class="status" :class="status">
-        {{ status }}
+      <div class="notifs">
+        <strong
+          v-for="badge in visibleBadges"
+          :key="badge.key"
+          class="notif"
+          :style="{ backgroundColor: badge.color }"
+          :title="badge.label"
+        >
+          {{ badge.text }}
+        </strong>
+        <strong
+          v-if="serverError"
+          class="notif errors"
+          title="Connection error to Traefik API, check url in config.yml"
+        >
+          ?
+        </strong>
       </div>
     </template>
   </Generic>
@@ -22,6 +35,26 @@
 <script>
 import service from "@/mixins/service.js";
 
+// Protocol sections nest categories; certificates is a flat {total, warnings, errors}.
+const protocols = ["http", "tcp", "udp"];
+const categories = ["routers", "services", "middlewares"];
+
+// Key doubles as the data key its response lands on.
+const endpoints = {
+  overview: "/api/overview",
+  version: "/api/version",
+};
+
+// Indicator badges; key doubles as the hide key.
+const badges = [
+  { key: "routers", label: "Routers", color: "#2ac194" },
+  { key: "services", label: "Services", color: "#2aa2c1" },
+  { key: "middlewares", label: "Middlewares", color: "#2a57c1" },
+  { key: "certificates", label: "Certificates", color: "#c1482a" },
+  { key: "warnings", label: "Warnings", color: "#c1942a" },
+  { key: "errors", label: "Errors", color: "#c12a57" },
+];
+
 export default {
   name: "Traefik",
   mixins: [service],
@@ -29,65 +62,108 @@ export default {
     item: Object,
   },
   data: () => ({
-    fetchOk: null,
-    versionstring: null,
+    overview: null,
+    version: null,
+    failed: {},
   }),
   computed: {
-    status: function () {
-      return this.fetchOk ? "online" : "offline";
+    serverError() {
+      return Object.values(this.failed).some(Boolean);
+    },
+    versionstring() {
+      return this.version?.Version;
+    },
+    counts() {
+      const totals = Object.fromEntries(badges.map((badge) => [badge.key, 0]));
+      const overview = this.overview;
+      if (!overview) return totals;
+      for (const protocol of protocols) {
+        const section = overview[protocol];
+        if (!section) continue;
+        for (const category of categories) {
+          const entry = section[category];
+          if (!entry) continue;
+          totals[category] += entry.total || 0;
+          totals.warnings += entry.warnings || 0;
+          totals.errors += entry.errors || 0;
+        }
+      }
+      const certificates = overview.certificates;
+      if (certificates) {
+        totals.certificates += certificates.total || 0;
+        totals.warnings += certificates.warnings || 0;
+        totals.errors += certificates.errors || 0;
+      }
+      return totals;
+    },
+    visibleBadges() {
+      return badges
+        .filter(
+          (badge) => this.isValueShown(badge.key) && this.counts[badge.key] > 0,
+        )
+        .map((badge) => ({
+          ...badge,
+          text: this.capCount(this.counts[badge.key]),
+        }));
     },
   },
   created() {
-    this.fetchStatus();
+    this.fetchOptions = this.item.basic_auth
+      ? { headers: { Authorization: `Basic ${btoa(this.item.basic_auth)}` } }
+      : {};
+    this.endpointsToFetch = this.resolveEndpoints();
+    if (this.endpointsToFetch.length) {
+      this.autoUpdateMethod = this.fetchStats;
+      this.fetchStats();
+    }
   },
   methods: {
-    fetchStatus: async function () {
-      let headers = {};
-      if (this.item.basic_auth) {
-        const encodedCredentials = btoa(this.item.basic_auth);
-        headers["Authorization"] = `Basic ${encodedCredentials}`;
-      }
-      this.fetch("/api/version", { headers })
-        .then((response) => {
-          this.fetchOk = true;
-          this.versionstring = response.Version;
+    // A subtitle override hides the version, so skip it then.
+    resolveEndpoints() {
+      const keys = [];
+      if (!this.item.subtitle) keys.push("version");
+      if (badges.some((badge) => this.isValueShown(badge.key)))
+        keys.push("overview");
+      return keys;
+    },
+    load(key) {
+      return this.fetch(endpoints[key], this.fetchOptions)
+        .then((data) => {
+          this[key] = data;
+          this.failed[key] = false;
         })
         .catch((e) => {
-          this.fetchOk = false;
-          console.log(e);
+          console.error(e);
+          this.failed[key] = true;
         });
+    },
+    // Each load catches its own failure, so one bad endpoint can't sink the batch.
+    fetchStats() {
+      return Promise.all(this.endpointsToFetch.map((key) => this.load(key)));
     },
   },
 };
 </script>
 
 <style scoped lang="scss">
-.status {
-  font-size: 0.8rem;
-  color: var(--text-title);
-  white-space: nowrap;
-  margin-left: 0.25rem;
+.notifs {
+  position: absolute;
+  color: white;
+  font-family: sans-serif;
+  top: 0.3em;
+  right: 0.5em;
 
-  &.online:before {
-    background-color: #94e185;
-    border-color: #78d965;
-    box-shadow: 0 0 5px 1px #94e185;
-  }
-
-  &.offline:before {
-    background-color: #c9404d;
-    border-color: #c42c3b;
-    box-shadow: 0 0 5px 1px #c9404d;
-  }
-
-  &:before {
-    content: " ";
+  .notif {
     display: inline-block;
-    width: 7px;
-    height: 7px;
-    margin-right: 10px;
-    border: 1px solid #000;
-    border-radius: 7px;
+    padding: 0.2em 0.35em;
+    border-radius: 0.25em;
+    position: relative;
+    margin-left: 0.3em;
+    font-size: 0.8em;
+
+    &.errors {
+      background-color: #c12a57;
+    }
   }
 }
 </style>

--- a/src/mixins/service.js
+++ b/src/mixins/service.js
@@ -33,6 +33,13 @@ export default {
     updateScheduler.unregister(this);
   },
   methods: {
+    isValueShown(key) {
+      return !(this.item.hide || []).includes(key);
+    },
+    // Long counts blow out a small pill.
+    capCount(value, max = 99) {
+      return typeof value === "number" && value > max ? `${max}+` : value;
+    },
     fetch: function (path, init, json = true) {
       let options = {};
 


### PR DESCRIPTION
## Description

Traefik's card only displayed the version string from `/api/version`, which says nothing about whether the proxy is healthy or how much it is actually serving.

It now also reads `/api/overview` and surfaces the numbers as colored badges: routers, services, middlewares, certificates, warnings and errors. Routers, services and middlewares are summed across `http`, `tcp` and `udp`; warnings and errors are summed across those plus `certificates`. Badges with a count of `0` are hidden, so a healthy instance stays visually quiet and only speaks up when something needs attention.

Display is controlled with a flat optional `hide` list, matching the existing Proxmox card and the Seerr card in #1065. Everything is shown by default; you only list the badges you want gone:

```yaml
- name: "Traefik"
  type: "Traefik"
  url: "http://traefik.example.com"
  hide:
    - certificates
    - warnings
```

Valid keys are the six badge names: `routers`, `services`, `middlewares`, `certificates`, `warnings` and `errors`. Hide all six to restore the old version-only card.

### Other notes

* Display uses the standardized flat `hide` list rather than a bespoke `monitor` object, matching Proxmox and #1065.
* The version subtitle is unchanged. Since a `subtitle` override hides the version anyway, the `/api/version` call is skipped in that case.
* Overview and version are fetched in parallel and both run through the existing `updateIntervalMs` scheduler, so the version now refreshes alongside the badges instead of loading only once.
* Two small reusable helpers were added to the `service.js` mixin: `isValueShown(key)` and `capCount(value, max = 99)`. Badge counts are capped at `99+`.
* `basic_auth` still works as before. It is no longer sent as an empty `headers` object when unset, which previously overwrote any `proxy.headers` or per item `headers`.
* Mock data is included under `dummy-data/traefik/`, so `pnpm mock` exercises every badge.
* No new dependencies.

**Potentially breaking**: existing version-only cards will gain badges after upgrading. The config stays backwards compatible (`hide` is new and optional), and hiding all six badges restores the previous appearance. This is documented with an `[!IMPORTANT]` callout in `customservices.md`, in the same spirit as the recent Uptime Kuma card link change.

> **Shared mixin helpers**: this PR and #1065 (Seerr) both add the identical `isValueShown` / `capCount` methods to `src/mixins/service.js`. Whichever merges second just needs the duplicate block dropped; no card code changes either way.

Closes #1062, https://github.com/bastienwirtz/homer/issues/729

## Card with all badges enabled:

<img width="441" height="99" alt="image" src="https://github.com/user-attachments/assets/e96d57e1-17ce-40f8-84e8-600199285828" />

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
