### PR TITLE
Add Seerr custom service

### DIFF
--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -54,6 +54,7 @@ Available services are located in `src/components/`:
 - [rTorrent](#rtorrent)
 - [SABnzbd](#sabnzbd)
 - [Scrutiny](#scrutiny)
+- [Seerr](#seerr)
 - [Speedtest Tracker](#speedtesttracker)
 - [Tautulli](#tautulli)
 - [Tdarr](#tdarr)
@@ -790,6 +791,30 @@ Displays info about the total number of disk passed and failed S.M.A.R.T and scr
 ```
 
 Auto refresh is supported by this integration.  
+
+## Seerr
+
+Displays the Seerr version as the subtitle, with icons next to it when an update is available or a restart is required, plus badges counting available media, pending requests, processing requests and open issues.
+
+```yaml
+- name: "Seerr"
+  type: "Seerr"
+  logo: "assets/tools/sample.png"
+  url: "http://seerr.example.com"
+  apikey: "<---insert-api-key-here--->"
+  # subtitle: "Requests"  # (Optional) Overrides the version subtitle.
+  # hide: []              # (Optional) hides items. Possible values are
+  #                       # "updateAvailable", "restartRequired", "media",
+  #                       # "pending", "processing" and "issues".
+```
+
+Auto refresh is supported by this integration.
+
+**Authentication**: generate an API key under **Settings > General** in your Seerr instance. The badges need it; the version subtitle works without one.
+
+**Hiding items**: everything is shown by default; list a key under `hide` to remove it. `updateAvailable` and `restartRequired` are the two subtitle icons; `media`, `pending`, `processing` and `issues` are the four badges. Hide all six for a version-only card. Badge counts are capped at `99+`.
+
+**Available media**: counts partially available shows (those with some requested seasons still missing) alongside fully available ones.
 
 ## SpeedtestTracker
 

--- a/dummy-data/seerr/api/v1/issue/count
+++ b/dummy-data/seerr/api/v1/issue/count
@@ -1,0 +1,9 @@
+{
+  "total": 12,
+  "video": 5,
+  "audio": 3,
+  "subtitles": 2,
+  "others": 2,
+  "open": 7,
+  "closed": 5
+}

--- a/dummy-data/seerr/api/v1/media
+++ b/dummy-data/seerr/api/v1/media
@@ -1,0 +1,34 @@
+{
+  "pageInfo": {
+    "page": 1,
+    "pages": 7,
+    "pageSize": 20,
+    "results": 132
+  },
+  "results": [
+    {
+      "id": 1,
+      "mediaType": "movie",
+      "tmdbId": 693134,
+      "tvdbId": null,
+      "imdbId": null,
+      "status": 5,
+      "status4k": 1,
+      "createdAt": "2026-06-02T18:12:41.000Z",
+      "updatedAt": "2026-06-04T09:31:02.000Z",
+      "mediaAddedAt": "2026-06-04T09:31:02.000Z"
+    },
+    {
+      "id": 2,
+      "mediaType": "tv",
+      "tmdbId": 94997,
+      "tvdbId": 371572,
+      "imdbId": null,
+      "status": 4,
+      "status4k": 1,
+      "createdAt": "2026-06-11T20:03:55.000Z",
+      "updatedAt": "2026-07-09T07:44:18.000Z",
+      "mediaAddedAt": "2026-06-14T22:10:09.000Z"
+    }
+  ]
+}

--- a/dummy-data/seerr/api/v1/request/count
+++ b/dummy-data/seerr/api/v1/request/count
@@ -1,0 +1,11 @@
+{
+  "total": 14,
+  "movie": 9,
+  "tv": 5,
+  "pending": 3,
+  "approved": 10,
+  "declined": 1,
+  "processing": 4,
+  "available": 6,
+  "completed": 4
+}

--- a/dummy-data/seerr/api/v1/status
+++ b/dummy-data/seerr/api/v1/status
@@ -1,0 +1,7 @@
+{
+  "version": "2.7.3",
+  "commitTag": "local",
+  "updateAvailable": true,
+  "commitsBehind": 0,
+  "restartRequired": true
+}

--- a/src/components/services/Seerr.vue
+++ b/src/components/services/Seerr.vue
@@ -1,0 +1,192 @@
+<template>
+  <Generic :item="item">
+    <template #content>
+      <p class="title is-4">{{ item.name }}</p>
+      <p class="subtitle is-6">
+        <template v-if="item.subtitle">{{ item.subtitle }}</template>
+        <template v-else-if="versionstring">
+          Version {{ versionstring }}
+          <i
+            v-for="icon in visibleIcons"
+            :key="icon.key"
+            class="state"
+            :class="icon.class"
+          ></i>
+        </template>
+      </p>
+    </template>
+    <template #indicator>
+      <div class="notifs">
+        <strong
+          v-for="badge in visibleBadges"
+          :key="badge.key"
+          class="notif"
+          :style="{ backgroundColor: badge.color }"
+          :title="badge.label"
+        >
+          {{ badge.text }}
+        </strong>
+        <strong
+          v-if="serverError"
+          class="notif errors"
+          title="Connection error to Seerr API, check url and apikey in config.yml"
+        >
+          ?
+        </strong>
+      </div>
+    </template>
+  </Generic>
+</template>
+
+<script>
+import service from "@/mixins/service.js";
+
+// Key doubles as the data key its response lands on.
+const endpoints = {
+  status: "/api/v1/status",
+  // allavailable counts partially available too; results is a total, so take is moot.
+  media: "/api/v1/media?filter=allavailable",
+  requests: "/api/v1/request/count",
+  issues: "/api/v1/issue/count",
+};
+
+// Subtitle icons; key is also the status flag each one reads.
+const icons = [
+  { key: "updateAvailable", class: "fa-solid fa-circle-arrow-up" },
+  { key: "restartRequired", class: "fa-solid fa-recycle" },
+];
+
+// Indicator badges; count reads the response landed by `from`.
+const badges = [
+  {
+    key: "media",
+    label: "Available media",
+    color: "#2ac194",
+    from: "media",
+    count: (data) => data?.pageInfo?.results,
+  },
+  {
+    key: "pending",
+    label: "Pending requests",
+    color: "#0a4bc4",
+    from: "requests",
+    count: (data) => data?.pending,
+  },
+  {
+    key: "processing",
+    label: "Processing requests",
+    color: "#6f11a6",
+    from: "requests",
+    count: (data) => data?.processing,
+  },
+  {
+    key: "issues",
+    label: "Open issues",
+    color: "#c1942a",
+    from: "issues",
+    count: (data) => data?.open,
+  },
+];
+
+export default {
+  name: "Seerr",
+  mixins: [service],
+  props: {
+    item: Object,
+  },
+  data: () => ({
+    status: null,
+    requests: null,
+    issues: null,
+    media: null,
+    failed: {},
+  }),
+  computed: {
+    serverError() {
+      return Object.values(this.failed).some(Boolean);
+    },
+    visibleBadges() {
+      return badges
+        .map((badge) => {
+          const value = this.isValueShown(badge.key)
+            ? badge.count(this[badge.from]) || 0
+            : 0;
+          return { ...badge, value, text: this.capCount(value) };
+        })
+        .filter((badge) => badge.value > 0);
+    },
+    versionstring() {
+      return this.status?.version;
+    },
+    visibleIcons() {
+      return icons.filter(
+        (icon) => this.isValueShown(icon.key) && this.status?.[icon.key] === true,
+      );
+    },
+  },
+  created() {
+    this.fetchOptions = this.item.apikey
+      ? { headers: { "X-Api-Key": this.item.apikey } }
+      : {};
+    this.endpointsToFetch = this.resolveEndpoints();
+    if (this.endpointsToFetch.length) {
+      this.autoUpdateMethod = this.fetchStats;
+      this.fetchStats();
+    }
+  },
+  methods: {
+    // A subtitle override hides the version, so skip status then.
+    resolveEndpoints() {
+      const keys = [];
+      if (!this.item.subtitle) keys.push("status");
+      if (this.isValueShown("media")) keys.push("media");
+      if (this.isValueShown("pending") || this.isValueShown("processing"))
+        keys.push("requests");
+      if (this.isValueShown("issues")) keys.push("issues");
+      return keys;
+    },
+    load(key) {
+      return this.fetch(endpoints[key], this.fetchOptions)
+        .then((data) => {
+          this[key] = data;
+          this.failed[key] = false;
+        })
+        .catch((e) => {
+          console.error(e);
+          this.failed[key] = true;
+        });
+    },
+    // Each load catches its own failure, so one bad endpoint can't sink the batch.
+    fetchStats() {
+      return Promise.all(this.endpointsToFetch.map((key) => this.load(key)));
+    },
+  },
+};
+</script>
+
+<style scoped lang="scss">
+.state {
+  margin-left: 0.2em;
+}
+
+.notifs {
+  position: absolute;
+  color: white;
+  font-family: sans-serif;
+  top: 0.3em;
+  right: 0.5em;
+
+  .notif {
+    display: inline-block;
+    padding: 0.2em 0.35em;
+    border-radius: 0.25em;
+    position: relative;
+    margin-left: 0.3em;
+    font-size: 0.8em;
+
+    &.errors {
+      background-color: #c12a57;
+    }
+  }
+}
+</style>

--- a/src/mixins/service.js
+++ b/src/mixins/service.js
@@ -33,6 +33,13 @@ export default {
     updateScheduler.unregister(this);
   },
   methods: {
+    isValueShown(key) {
+      return !(this.item.hide || []).includes(key);
+    },
+    // Long counts blow out a small pill.
+    capCount(value, max = 99) {
+      return typeof value === "number" && value > max ? `${max}+` : value;
+    },
     fetch: function (path, init, json = true) {
       let options = {};
 


### PR DESCRIPTION
## Description

[Seerr](https://github.com/seerr-team/seerr) is a self hosted request manager for Plex, Jellyfin and Emby libraries, and the community successor to Overseerr and Jellyseerr. Homer has no card for it, so a Seerr instance can only be a static link: anything worth knowing at a glance means opening Seerr itself.

This adds a `Seerr` card. The subtitle shows the version, with an up arrow icon when an update is available and a recycle icon when a restart is required. Four badges cover available media, pending requests, processing requests and open issues. Badges with a count of `0` are hidden, so a quiet instance stays visually quiet and only speaks up when something needs attention.

Display is controlled with a flat optional `hide` list, matching the existing Proxmox card. Everything shows by default; you only list what you want gone:

```yaml
- name: "Seerr"
  type: "Seerr"
  url: "http://seerr.example.com"
  apikey: "<---insert-api-key-here--->"
  hide:
    - media            # drop the available media badge
    - restartRequired  # drop the restart icon, keep the update one
```

Valid keys: `updateAvailable` and `restartRequired` (the two subtitle icons), plus `media`, `pending`, `processing` and `issues` (the four badges). Hide all six for a version-only card.

### Changes since review

* Replaced the nested `monitor` option with the flat `hide` list above, matching Proxmox, per the standardization point raised in review.
* Added two small reusable helpers to the `service.js` mixin so any card can share them: `isValueShown(key)` (reads `item.hide`, the same shape Proxmox already uses) and `capCount(value, max = 99)`.
* The `/status` endpoint is now part of the auto refresh cycle, so the version and its icons stay current instead of being fetched only once.
* Dropped the computeds that held static config and the `?? null` on the version string.

### Other notes

* Endpoints used, all under `/api/v1`: `/status` for the version and its two flags, `/media?filter=allavailable` for available media, `/request/count` for pending and processing, `/issue/count` for open issues.
* `apikey` is sent as an `X-Api-Key` header. It is only needed for the badges: `/status` is public, so the version subtitle works without one.
* `allavailable` counts partially available shows (some seasons in) alongside fully available ones. No `take` is sent, since `pageInfo.results` is a total regardless of page size.
* The issues badge counts `open` only. Seerr also breaks issues down by type, but that spans the same issues as the open/closed split, so counting both would count each issue twice.
* The endpoints are fetched in parallel and auto refresh runs through the existing `updateIntervalMs` scheduler. Each call keeps its own error state, so one failing endpoint leaves the rest of the card intact instead of blanking it.
* Hiding every badge behind an endpoint skips that request entirely.
* Badge counts are capped at `99+` (via the shared `capCount`), since an available media count can run into the thousands and a badge is a small pill.
* `apikey` is not sent as an empty `headers` object when unset, so any `proxy.headers` or per item `headers` survive.
* Mock data is included under `dummy-data/seerr/` for every endpoint, so `pnpm mock` exercises all four badges and both icons.
* No new dependencies.

Not breaking: the card is new, and `hide` is new and optional.

> **Shared mixin helpers**: this PR and #1063 (Traefik) both add the identical `isValueShown` / `capCount` methods to `src/mixins/service.js`. Whichever merges second just needs the duplicate block dropped; no card code changes either way.

Closes #1064

## Card with everything enabled

<img width="441" height="93" alt="image" src="https://github.com/user-attachments/assets/4804dff0-83c1-49dc-a450-892aa3ca39da" />

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
