### PR TITLE
feat(container): support PUID/PGID for assets directory ownership

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
-assets/*
+public/assets/config.yml
+dist
 dockerfile
 *.md
 .git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 # build stage
 FROM --platform=$BUILDPLATFORM node:24-alpine3.23 AS build-stage
 
@@ -19,6 +21,10 @@ FROM alpine:3.23
 
 ARG VERSION_TAG=latest
 
+# Build-time only. Use PUID/PGID, or docker's --user, to pick the runtime user.
+ARG UID=1000
+ARG GID=1000
+
 LABEL \
     org.label-schema.schema-version="1.0" \
     org.label-schema.version="$VERSION_TAG" \
@@ -30,25 +36,22 @@ LABEL \
     org.opencontainers.image.source="https://github.com/bastienwirtz/homer" \
     org.opencontainers.image.url="https://hub.docker.com/r/b4bz/homer"
 
-ENV GID=1000 \
-    UID=1000 \
-    PORT=8080 \
+ENV PORT=8080 \
     SUBFOLDER="/_" \
     INIT_ASSETS=1 \
     IPV6_DISABLE=0
 
 RUN addgroup -S lighttpd -g ${GID} && adduser -D -S -u ${UID} lighttpd lighttpd && \
-    apk add -U --no-cache tzdata lighttpd
+    apk add -U --no-cache tzdata lighttpd su-exec
 
 WORKDIR /www
 
 COPY lighttpd.conf /lighttpd.conf
 COPY lighttpd-ipv6.sh /etc/lighttpd/ipv6.sh
 COPY entrypoint.sh /entrypoint.sh
-COPY --from=build-stage --chown=${UID}:${GID} /app/dist /www/
+COPY --from=build-stage --chown=${UID}:${GID} --exclude=assets /app/dist /www/
 COPY --from=build-stage --chown=${UID}:${GID} /app/dist/assets /www/default-assets
-
-USER ${UID}:${GID}
+RUN mkdir /www/assets && chown ${UID}:${GID} /www/assets
 
 HEALTHCHECK --start-period=10s --start-interval=1s --interval=30s --timeout=5s --retries=3 \
     CMD wget --no-verbose -Y off --tries=1 --spider http://127.0.0.1:${PORT}/ || exit 1

--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ docker run -d \
 ```
 
 > [!NOTE]  
-> The container will run using a user uid and gid 1000 by default, add `--user <your-UID>:<your-GID>` to the docker command to adjust it if necessary. Make sure this match the permissions of your assets directory.
+> The web server runs as uid and gid 1000 by default. If your assets directory is owned by a different user, set the `PUID` & `PGID` env vars to match it (ex: `-e PUID=1001 -e PGID=1001`): the container fixes the ownership of the assets directory on startup, then drops to that user.
+>
+> Alternatively, add `--user <your-UID>:<your-GID>` to the docker command. In that case nothing is chowned for you, and `PUID`/`PGID` are ignored: you own the permissions of the assets directory.
 
 **or `docker-compose`**
 
@@ -101,16 +103,20 @@ services:
       - /path/to/config/dir:/www/assets # Make sure your local config directory exists
     ports:
       - 8080:8080
-    user: 1000:1000 # default
     environment:
-      - INIT_ASSETS=1 # default, requires the config directory to be writable for the container user (see user option)
+      - INIT_ASSETS=1 # default, requires the config directory to be writable for the container user
+      - PUID=1000 # default, the user the web server runs as
+      - PGID=1000 # default
     restart: unless-stopped
 ```
 
 **Environment variables:**
 
 - **`INIT_ASSETS`** (default: `1`)
-Install example configuration file & assets (favicons, ...) to help you get started.
+Install example configuration file & assets (favicons, ...) to help you get started. Only missing files are added, so your own files are never modified or overwritten, and a directory created by an older version picks up newly shipped assets. Requires the assets directory to be writable. Set to `0` to leave the directory completely untouched.
+
+- **`PUID`** / **`PGID`** (default: `1000`)
+User and group the web server runs as. The container starts as root, fixes the ownership of the assets directory, then drops to `PUID`:`PGID` before starting the web server, which never runs as root. Setting them to `0` is refused. Because it starts as root, this requires the `CHOWN`, `SETUID` and `SETGID` capabilities (see [troubleshooting](docs/troubleshooting.md#my-docker-container-exits-immediately-after-dropping-capabilities)). Both they and the capabilities are unnecessary if the container is started with the docker `--user` option, which bypasses this whole mechanism (a warning is logged if they are set anyway).
 
 - **`SUBFOLDER`** (default: `null`)
 If you would like to host Homer in a subfolder, (ex: *<http://my-domain/homer>*), set this to the subfolder path (ex `/homer`).

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -8,6 +8,7 @@ We have different solution to install Homer on Kubernetes Cluster, each solution
 - [Controller With CRDs](#controller-crds)
 - [Controller With Ingress Annotations](#controller-annotations)
 - [Operator](#Operator)
+- [Security Context](#security-context)
 
 ## Helm Chart
 
@@ -81,3 +82,28 @@ kubectl apply -f operator.yaml
 ### Usage
 
 - [usage](https://github.com/rajsinghtech/homer-operator?tab=readme-ov-file#usage)
+
+## Security Context
+
+The container starts as root to fix the ownership of the assets directory, then drops to `PUID`:`PGID` (default `1000`) before starting the web server, which never runs as root.
+
+On Kubernetes you usually want to skip that mechanism entirely and set `runAsUser` instead, because `fsGroup` already solves volume ownership natively:
+
+```yaml
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+```
+
+This is equivalent to the docker `--user` option: the container runs unprivileged from the start, `PUID` / `PGID` are ignored, and nothing is chowned for you, so the assets volume must already be readable and writable by that user. Use `fsGroup` to arrange that.
+
+The Helm charts listed above already set `runAsUser`, so they are unaffected.
+
+> [!IMPORTANT]
+> The image does not declare a non-root user. Setting `runAsNonRoot: true` **without** a `runAsUser` will fail with `container has runAsNonRoot and image will run as root`, because the kubelet then checks the image itself. Always set `runAsUser` alongside it.
+
+> [!NOTE]
+> Setting `runAsUser` requires no capability at all, which is why it pairs naturally with `capabilities: drop: [ALL]` and the `restricted` pod security standard.
+>
+> Leaving the security context unset instead keeps the ownership fixing behavior, but then the container starts as root and needs the `CHOWN`, `SETUID` and `SETGID` capabilities (plus `DAC_OVERRIDE` if the assets volume is not readable by root). Dropping those makes the startup fail.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -7,23 +7,68 @@ You might be facing a permission issue. First of all, check your container logs 
 ```sh
 $ docker logs homer
 [...]
-Assets directory not writable. Check assets directory permissions & docker user or skip default assets install by setting the INIT_ASSETS env var to 0
+Assets directory not writable. Check assets directory permissions & docker user or skip default assets install by setting the INIT_ASSETS env var to 0.
 ```
 
-In this case you need to make sure your mounted assets directory have the same GID / UID the container user have (default 1000:1000), and that the read and write permission is granted for the user or the group.
+In this case you need to make sure your mounted assets directory have the same GID / UID the web server runs as (default 1000:1000), and that the read and write permission is granted for the user or the group.
 
 You can either:
 
-- Update your assets directory permissions (ex: `chown -R 1000:1000 /your/assets/folder/`, `chmod -R u+rw /your/assets/folder/`)
+- Set the `PUID` / `PGID` env vars to the owner of your assets directory (ex: `-e PUID=1001 -e PGID=1001`). The container will fix the ownership of the assets directory for you on startup, then drop to that user.
+- Update your assets directory permissions yourself (ex: `chown -R 1000:1000 /your/assets/folder/`, `chmod -R u+rw /your/assets/folder/`)
 - Change the docker user by using the `--user` arguments with docker cli or `user: 1000:1000` with docker compose.
 
 > [!NOTE]
 >
-> - **Do not** use env var to set the GID / UID of the user running container. Use the Docker `user` option.
-> - **Do not** use 0:0 as a user value, it would be a security risk, and it's not guaranty to work.
+> - **Do not** use the `UID` / `GID` env vars: they are build time only and have no effect at runtime. Use `PUID` / `PGID`, or the Docker `user` option.
+> - `PUID` / `PGID` and the Docker `user` option are mutually exclusive. `--user` means the container never runs as root, so it cannot fix the ownership of the assets directory for you, and `PUID` / `PGID` are ignored (a warning is logged).
+> - **Do not** use `0:0` as a `PUID` / `PGID` value, it would be a security risk. It is refused.
 
 Check this [thread](https://github.com/bastienwirtz/homer/issues/459) for more information about debugging
 permission issues.
+
+## My config.yml shows up as a directory
+
+Docker creates a **directory** when the host path of a bind mounted file does not exist yet, so mounting a single configuration file that has not been created first gives you a directory named `config.yml`:
+
+```sh
+$ docker logs homer
+[...]
+Error: /www/assets/config.yml is a directory, not a file.
+Docker creates a directory when the host path of a bind mounted file does not exist.
+Create the file on the host, remove the directory, then restart the container.
+```
+
+Create the file on the host first, remove the directory docker made, then restart the container:
+
+```sh
+docker compose down
+rmdir /path/to/your/config.yml
+curl -o /path/to/your/config.yml https://raw.githubusercontent.com/bastienwirtz/homer/main/public/assets/config.yml.dist
+docker compose up -d
+```
+
+> [!TIP]
+> Mounting the whole assets directory (`/path/to/assets:/www/assets`) instead of a single file avoids this entirely, and lets Homer install its default assets for you.
+
+## My docker container exits immediately after dropping capabilities
+
+By default the container starts as root, fixes the ownership of the assets directory, then drops to `PUID`:`PGID`. That requires the `CHOWN`, `SETUID` and `SETGID` [capabilities](https://docs.docker.com/engine/containers/run/#runtime-privilege-and-linux-capabilities), so dropping them (ex: `--cap-drop=ALL`, or the `restricted` Kubernetes [pod security standard](https://kubernetes.io/docs/concepts/security/pod-security-standards/)) makes the startup fail:
+
+```sh
+$ docker logs homer
+[...]
+su-exec: setgroups(1000): Operation not permitted   # SETUID / SETGID are missing
+Starting as root requires the CHOWN capability, add it back or use the docker user option.
+```
+
+You can either:
+
+- Add the required capabilities back (ex: `--cap-drop=ALL --cap-add=CHOWN --cap-add=SETUID --cap-add=SETGID`).
+- Run the container with the docker `user` option (ex: `--user 1000:1000`). **This needs no capability at all**: the container never runs as root, so it never changes any ownership and never drops privileges. Your assets directory must already be readable and writable by that user.
+
+> [!NOTE]
+> If your assets directory is not readable by root (ex: mode `700` and owned by another user), the `DAC_OVERRIDE` capability is needed as well, otherwise only its top level is fixed and `Warning: some entries of /www/assets could not be chowned.` is logged.
 
 ## My service card doesn't work, nothing appears or offline status is displayed (pi-hole, sonarr, ping, ...)
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,15 +1,69 @@
 #!/bin/sh
 
-# Default assets & example configuration installation
-if [[ "${INIT_ASSETS}" == "1" ]] && [[ ! -f "/www/assets/config.yml" ]]; then
-    echo "No configuration found, installing default config & assets"
-    if [[ -w "/www/assets/" ]]; 
-    then
-        while true; do echo n; done | cp -Ri /www/default-assets/* /www/assets/
-        yes n | cp -i /www/default-assets/config.yml.dist /www/assets/config.yml
+# When started as root, fix the assets ownership then drop to PUID:PGID.
+if [ -z "${HOMER_PRIVDROP_DONE}" ]; then
+    if [ "$(id -u)" = "0" ]; then
+        PUID="${PUID:-1000}"
+        PGID="${PGID:-1000}"
+
+        if [ "${PUID}" = "0" ] || [ "${PGID}" = "0" ]; then
+            echo "Refusing to run the web server as root: set PUID/PGID to a non-zero user."
+            exit 1
+        fi
+
+        # The access log reopens this fifo by path (/dev/fd/3), and docker leaves it owned by root
+        if ! chown "${PUID}:${PGID}" /proc/self/fd/1 2>/dev/null; then
+            echo "Unable to change the ownership of the container output."
+            echo "Starting as root requires the CHOWN capability, add it back or use the docker user option."
+            exit 1
+        fi
+        chown "${PUID}:${PGID}" /proc/self/fd/2 2>/dev/null || true
+
+        # Probe first: `chown -R` on a read-only mount errors once per file.
+        if chown "${PUID}:${PGID}" /www/assets 2>/dev/null; then
+            chown -R "${PUID}:${PGID}" /www/assets 2>/dev/null ||
+                echo "Warning: some entries of /www/assets could not be chowned."
+        else
+            echo "Warning: unable to change the ownership of /www/assets, continuing anyway."
+            echo "Is the volume mounted as read-only?"
+        fi
+
+        echo "Switching to ${PUID}:${PGID}"
+        export HOMER_PRIVDROP_DONE=1
+        # Not executable, it has to go through the shell.
+        exec su-exec "${PUID}:${PGID}" /bin/sh "$0" "$@"
+    elif [ -n "${PUID}${PGID}" ]; then
+        echo "Warning: PUID/PGID are set but the container is not running as root, ignoring them."
+    fi
+fi
+
+if [ "${INIT_ASSETS}" = "1" ]; then
+    # `test -w` reports a read-only mount as writable on busybox, so try for real.
+    if touch /www/assets/.write-test 2>/dev/null; then
+        rm -f /www/assets/.write-test
+
+        # Copy file by file: `cp -n` skips a whole directory when the destination one already exists
+        # Docker creates a new directory when the host path of a bind mounted file does not exist
+        (
+            cd /www/default-assets || exit
+            find . -type f | while read -r file; do
+                if [ ! -e "/www/assets/${file}" ]; then
+                    mkdir -p "/www/assets/$(dirname "${file}")"
+                    cp "${file}" "/www/assets/${file}"
+                fi
+            done
+        )
+
+        if [ -d "/www/assets/config.yml" ]; then
+            echo "Error: /www/assets/config.yml is a directory, not a file."
+            echo "Docker creates a directory when the host path of a bind mounted file does not exist."
+            echo "Create the file on the host, remove the directory, then restart the container."
+        elif [ ! -f "/www/assets/config.yml" ]; then
+            echo "No configuration found, installing the default one."
+            cp /www/default-assets/config.yml.dist /www/assets/config.yml
+        fi
     else
-        echo "Assets directory not writable, skipping default config install.";
-        echo "Check assets directory permissions & docker user or skip default assets install by setting the INIT_ASSETS env var to 0."
+        echo "Assets directory not writable. Check assets directory permissions & docker user or skip default assets install by setting the INIT_ASSETS env var to 0."
     fi
 fi
 

--- a/lighttpd.conf
+++ b/lighttpd.conf
@@ -2,6 +2,7 @@ include_shell "/etc/lighttpd/ipv6.sh"
 
 server.port            = env.PORT
 server.modules         = ( "mod_alias", "mod_accesslog" )
+# Only used if lighttpd is started as root, which the entrypoint prevents.
 server.username        = "lighttpd"
 server.groupname       = "lighttpd"
 server.document-root   = "/www"


### PR DESCRIPTION
## Description

The image is hard-wired to run as uid/gid `1000` and never adjusts the ownership of the mounted assets directory. `Dockerfile` sets `USER ${UID}:${GID}`, which docker resolves at **build** time, so the `UID` / `GID` env vars that look like they should fix this do nothing at runtime. The result is that the container only works out of the box when the assets directory happens to be owned by `1000:1000`.

That assumption breaks as soon as the user who generated the config, or the directory the config lives in, is not `1000:1000`:

- the bind mount was created by `root` (a bare `docker run` on a path that did not exist yet, or a `mkdir` under `sudo`),
- the config was written by a second host account, so it is `1001` or higher,
- the directory comes from a NAS or a network share that maps to its own uid,
- the daemon runs rootless, so the container uid is remapped on the host.

In all of those cases the startup check fails and the user gets:

```
Assets directory not writable, skipping default config install.
Check assets directory permissions & docker user or skip default assets install by setting the INIT_ASSETS env var to 0.
```

The alternative we currently have is "chown the directory yourself" or "pass `--user`", and `--user` alone is not enough because the directory still has to be chowned by hand first. That is why the same report keeps coming back, and why people end up on `chmod 777` as a workaround, which is not desirable.

Fixes https://github.com/bastienwirtz/homer/issues/950 https://github.com/bastienwirtz/homer/issues/558

### What this does

The entrypoint now starts as root, fixes the ownership of `/www/assets`, and drops to `PUID`:`PGID` with `su-exec` before starting lighttpd. The web server itself never runs as root: `PUID` / `PGID` of `0` is refused outright, and the privilege drop happens before `exec`.

This is not a new mechanism. It is the model the image used until `049f852` (2020 to 2022), restored and exposed under the `PUID` / `PGID` names that the self-hosting ecosystem already expects. The alternative, keeping `--user` as the only answer, does not solve the bootstrap case: something has to own the directory before an unprivileged process can write the default config into it, and only root inside the container can arrange that.

Two smaller things came along with it:

- `entrypoint.sh` declared `#!/bin/sh` but used the `[[ ]]` bashism. Those are now POSIX `[ ]`.
- The access log fifo (`/dev/fd/3`) is left owned by root by docker and is reopened by path, so it is chowned too. Without it the log silently fails once privileges are dropped.

The read-only mount case is probed before the recursive `chown` rather than letting `chown -R` emit one error per file, and it warns and continues instead of failing.

### The assets directory had to change too

Fixing the ownership only solves half of it. `/www/assets` is the user's configuration directory, but the image has always shipped it pre-populated:

```dockerfile
COPY --from=build-stage --chown=${UID}:${GID} /app/dist /www/
```

`dist/assets` is vite's `public/assets/` passthrough plus the generated `manifest.json`, so that one line lands a complete assets directory inside the image, and the `default-assets` copy on the next line is a duplicate of it.

The consequence is that the entrypoint cannot tell what `/www/assets` actually is. All of these look identical from the inside:

- nothing mounted, so the directory is the image's own,
- an empty directory mounted,
- a directory mounted with an existing configuration in it,
- a single file mounted, such as `config.yml` or a replacement `favicon.ico`, where docker creates the parent directories of the mount point.

Every one of them reads as "a populated directory". That is why the install step had to resort to `while true; do echo n; done | cp -Ri`: it could never assume the destination was empty, so it copied everything and answered "no" to every overwrite prompt. It also means the ownership fix above spends most of its effort chowning files the image itself put there, rather than the user's.

So the image now ships nothing at that path:

```dockerfile
COPY --from=build-stage --chown=${UID}:${GID} --exclude=assets /app/dist /www/
COPY --from=build-stage --chown=${UID}:${GID} /app/dist/assets /www/default-assets
RUN mkdir /www/assets && chown ${UID}:${GID} /www/assets
```

The directory ships empty, so whatever is in it at runtime belongs to the user. The install step then has a single rule: add the files that are missing, never touch the ones that are already there. A directory created by an older version picks up newly shipped assets, a mounted configuration is never modified, and `INIT_ASSETS=0` leaves the directory completely alone.

The `chown` is deliberate rather than redundant. On the `--user` path the entrypoint never runs as root, so it cannot fix the ownership itself, and a root owned `/www/assets` would leave that setup unable to install anything.

#### Three bugs this uncovered

**A `config.yml` mounted as a single file could be turned into a directory.** Docker creates a directory when the host path of a bind mounted file does not exist yet, which is easy to hit with `- /path/to/config.yml:/www/assets/config.yml`. `[ ! -f "/www/assets/config.yml" ]` is true for a directory, so the entrypoint then ran `cp config.yml.dist /www/assets/config.yml` **into** it, leaving a `config.yml/config.yml.dist` on the user's host. This reproduces on `main`. The case is now detected, explained in the logs, and nothing is written.

**`cp -n` cannot merge directories on busybox.** It skips an entire directory when the destination directory already exists, silently and with exit status 0. With a single file mounted into `assets/icons/`, docker creates `icons/`, and every other icon would then be skipped. The install walks the file list explicitly instead.

**`test -w` reports a read-only mount as writable on busybox** (see [alpinelinux/docker-alpine#156](https://github.com/alpinelinux/docker-alpine/issues/156), the same misreport behind #558). A read-only assets mount produced 32 lines of `cp: can't create ...: Read-only file system` before the server started. The entrypoint now probes by creating and removing a file, which is accurate for both permissions and read-only mounts, and prints a single actionable line.

#### Supporting changes

- `COPY --exclude` requires Dockerfile syntax `1.19`, so the `Dockerfile` declares `# syntax=docker/dockerfile:1`. Builds now need BuildKit, which has been the default since Docker 23.
- `.dockerignore` had `assets/*`, which matches nothing, because there is no top level `assets/` directory. An untracked local `public/assets/config.yml` was therefore baked into the image. That was harmless while it was only one more served default, but now that the same files seed the user's configuration directory it would ship a contributor's personal configuration to everyone.
- The recursive `chown` no longer short circuits when the top level directory already matches the target ownership. It was skipping the directories docker creates for single file mounts, which are owned by root.

#### Known limitation, not addressed here

`assets/manifest.json` is generated by the build but lives in the user's configuration directory, and it is the only entry under `assets/` that the generated service worker precaches, so a directory without it fails the service worker install. The change above repairs that in every writable case, but it still applies to read-only mounts and to `INIT_ASSETS=0`. Moving the generated files out of the user's directory is the real fix and is better done on its own.

### Why this is not a breaking change for the vast majority of setups

**The default runtime user is unchanged.** `PUID` / `PGID` default to `1000` / `1000`, which is exactly the uid/gid the image already ran as. A user who sets nothing gets the same web server, running as the same user, serving the same paths. The only difference is that the assets directory is now chowned to `1000:1000` on startup, which is the state those setups were being told to arrange manually anyway.

**Anyone already using `--user` is untouched.** If the container does not start as root, the whole block is skipped: nothing is chowned, `PUID` / `PGID` are ignored, and a warning is logged if they were set. This is the same behavior as today, and it covers a large share of existing users, because the compose example in the README has been shipping `user: 1000:1000` for years. The same applies to Kubernetes `runAsUser`, so the Helm charts listed in `docs/kubernetes.md` are unaffected.

**The one real change** is that the image no longer declares `USER`, so it starts as root before dropping privileges. That is only visible to setups that deliberately restrict what the container may do:

- dropping `CHOWN`, `SETUID` or `SETGID` (`--cap-drop=ALL`, or the Kubernetes `restricted` pod security standard),
- setting `runAsNonRoot: true` without a `runAsUser`, which makes the kubelet inspect the image itself.

Both have a documented escape hatch that needs no capability at all: run with `--user` / `runAsUser` and keep owning the permissions yourself, exactly as today. Both cases are covered in `docs/troubleshooting.md` and a new "Security Context" section in `docs/kubernetes.md`, including the `DAC_OVERRIDE` corner case where the assets volume is not readable by root.

**The assets change adds two smaller ones.** Example files are installed whenever they are missing rather than only on a first run, so an example someone deleted to tidy their configuration directory reappears on the next start; `INIT_ASSETS=0` disables the step entirely. And `INIT_ASSETS=0` with no volume mounted now leaves a genuinely empty directory, where the image used to bake one in. Nothing a user wrote is ever modified or overwritten in either case.

### Testing

Neither workflow covers this: `dockerhub.yml` only builds on `v*` tags and never starts the image, and `integration.yml` runs lint. Verified by hand against a local build:

nothing mounted, an empty directory mounted, a populated directory (configuration edit preserved, file tree byte identical across restarts), a single `config.yml` mount, a single `favicon.ico` mount into `assets/icons/`, `config.yml` present as a directory, a read-only mount, `INIT_ASSETS=0` (byte identical before and after), `PUID` / `PGID` set to `1002`, `--user` with a matching uid, with a foreign uid and with `PUID` also set, `--cap-drop=ALL` with `CHOWN`, `SETUID` and `SETGID` added back, `SUBFOLDER`, and `PUID=0` correctly refused.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [ ] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] I have made corresponding changes to the documentation (`README.md`).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
