### PR TITLE
feat(Tennis): add Live Tennis smart card

### DIFF
--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -57,6 +57,7 @@ Available services are located in `src/components/`:
 - [Speedtest Tracker](#speedtesttracker)
 - [Tautulli](#tautulli)
 - [Tdarr](#tdarr)
+- [Tennis](#tennis)
 - [Traefik](#traefik)
 - [Transmission](#transmission)
 - [TrueNas Scale](#truenas-scale)
@@ -843,6 +844,41 @@ Displays the number of currently queued items for transcoding on your Tdarr inst
 ```
 
 Auto refresh is supported by this integration.  
+
+## Tennis
+
+Displays the live tennis match currently in progress, using the
+[Live Tennis API](https://livetennisapi.com): the two players, the tournament and round,
+the sets won and the current game (games and points of the set being played). A dot marks
+the player serving. When several matches are live, the first one is shown and the others
+are counted in the subtitle.
+
+```yaml
+- name: "Tennis"
+  type: "Tennis"
+  logo: "assets/tools/sample.png"
+  url: "https://livetennisapi.com" # Card link, not used for the API call
+  endpoint: "https://api.livetennisapi.com/api/public/v1"
+  apikey: "<---insert-api-key-here--->"
+  tour: "atp" # Optional: atp, wta, challenger, itf or juniors. Defaults to all tours.
+  limit: 5 # Optional: how many live matches to fetch (1-10, default 5). The first is displayed.
+  updateIntervalMs: 120000 # Optional: see the rate limit note below.
+```
+
+Auto refresh is supported by this integration.
+
+**API key**: a free key is available at <https://livetennisapi.com/subscribe/free>. It is
+sent as an `X-API-Key` header.
+
+**Rate limit**: the free tier allows **30 requests per minute**. Homer sends one request per
+refresh and per card, so keep `updateIntervalMs` well above the limit — `120000` (2 minutes)
+is a safe default. Lower it only if your plan allows it.
+
+> [!WARNING]  
+> As stated at the top of this page, your `config.yml` is served at `/assets/config.yml`, so
+> the `apikey` above is readable by anyone who can reach your Homer instance. Only put a key
+> there if your instance is protected by authentication, or use a proxy such as
+> [`CORSair`](https://github.com/bastienwirtz/corsair) to inject the key server-side.
 
 ## Traefik
 

--- a/dummy-data/tennis/matches
+++ b/dummy-data/tennis/matches
@@ -1,0 +1,323 @@
+{
+  "data": [
+    {
+      "event_status": null,
+      "format": "BO3",
+      "id": 21635,
+      "indoor": false,
+      "is_doubles": false,
+      "players": {
+        "p1": {
+          "backhand": null,
+          "birthday": "2006-08-05",
+          "country": "srb",
+          "data_completeness": {
+            "known": 3,
+            "missing": [
+              "backhand",
+              "hand"
+            ],
+            "of": 5
+          },
+          "hand": null,
+          "id": 2317,
+          "is_doubles_team": false,
+          "name": "Vlado Jankanj",
+          "ranking": 1036,
+          "ranking_movement": "down",
+          "ranking_points": 17,
+          "tour": "atp"
+        },
+        "p2": {
+          "backhand": 2,
+          "birthday": "2001-06-24",
+          "country": "ita",
+          "data_completeness": {
+            "known": 5,
+            "missing": [],
+            "of": 5
+          },
+          "hand": "R",
+          "id": 4977,
+          "is_doubles_team": false,
+          "name": "Alessandro Bellifemine",
+          "ranking": 1548,
+          "ranking_movement": "down",
+          "ranking_points": 4,
+          "tour": "atp"
+        }
+      },
+      "round": "M15 Kursumlijska Banja 10 - 1/16-finals",
+      "scheduled_time": "2026-07-22T10:30:00Z",
+      "score": {
+        "games": [
+          [
+            7,
+            6
+          ],
+          [
+            5,
+            5
+          ]
+        ],
+        "is_tiebreak": false,
+        "points": [
+          "30",
+          "15"
+        ],
+        "server": 1,
+        "sets": [
+          1,
+          0
+        ],
+        "timestamp": "2026-07-22T15:59:32.026688Z"
+      },
+      "status": "live",
+      "surface": "clay",
+      "tournament": "M15 Kursumlijska Banja 10"
+    },
+    {
+      "event_status": null,
+      "format": "BO3",
+      "id": 21584,
+      "indoor": false,
+      "is_doubles": true,
+      "players": {
+        "p1": {
+          "backhand": null,
+          "birthday": null,
+          "country": null,
+          "data_completeness": {
+            "known": null,
+            "missing": [],
+            "note": "doubles team \u2014 per-player profile fields do not apply",
+            "of": null
+          },
+          "hand": null,
+          "id": 1355,
+          "is_doubles_team": true,
+          "name": "Constantin Frantzen / Haase",
+          "ranking": null,
+          "ranking_movement": null,
+          "ranking_points": null,
+          "tour": "ATP"
+        },
+        "p2": {
+          "backhand": null,
+          "birthday": null,
+          "country": null,
+          "data_completeness": {
+            "known": null,
+            "missing": [],
+            "note": "doubles team \u2014 per-player profile fields do not apply",
+            "of": null
+          },
+          "hand": null,
+          "id": 11962,
+          "is_doubles_team": true,
+          "name": "Goransson / N. Sriram Balaji",
+          "ranking": null,
+          "ranking_movement": null,
+          "ranking_points": null,
+          "tour": "ATP"
+        }
+      },
+      "round": "ATP Kitzbuhel - Quarter-finals",
+      "scheduled_time": "2026-07-22T12:55:00Z",
+      "score": {
+        "games": [
+          [
+            4,
+            5
+          ],
+          [
+            6,
+            6
+          ]
+        ],
+        "is_tiebreak": false,
+        "points": [
+          "15",
+          "0"
+        ],
+        "server": 1,
+        "sets": [
+          0,
+          1
+        ],
+        "timestamp": "2026-07-22T15:59:33.286361Z"
+      },
+      "status": "live",
+      "surface": "clay",
+      "tournament": "Kitzbuhel"
+    },
+    {
+      "event_status": null,
+      "format": "BO3",
+      "id": 21652,
+      "indoor": false,
+      "is_doubles": false,
+      "players": {
+        "p1": {
+          "backhand": null,
+          "birthday": null,
+          "country": "aut",
+          "data_completeness": {
+            "known": 1,
+            "missing": [
+              "backhand",
+              "birthday",
+              "hand",
+              "ranking"
+            ],
+            "of": 5
+          },
+          "hand": null,
+          "id": 1054,
+          "is_doubles_team": false,
+          "name": "K. T. Rosenkranz",
+          "ranking": null,
+          "ranking_movement": null,
+          "ranking_points": null,
+          "tour": null
+        },
+        "p2": {
+          "backhand": null,
+          "birthday": null,
+          "country": "aut",
+          "data_completeness": {
+            "known": 1,
+            "missing": [
+              "backhand",
+              "birthday",
+              "hand",
+              "ranking"
+            ],
+            "of": 5
+          },
+          "hand": null,
+          "id": 12298,
+          "is_doubles_team": false,
+          "name": "Alex Huszar",
+          "ranking": null,
+          "ranking_movement": null,
+          "ranking_points": null,
+          "tour": "atp"
+        }
+      },
+      "round": "M25 Ollersbach - 1/16-finals",
+      "scheduled_time": "2026-07-22T14:25:00Z",
+      "score": {
+        "games": [
+          [
+            1,
+            6,
+            0
+          ],
+          [
+            6,
+            1,
+            3
+          ]
+        ],
+        "is_tiebreak": false,
+        "points": [
+          "0",
+          "0"
+        ],
+        "server": null,
+        "sets": [
+          1,
+          1
+        ],
+        "timestamp": "2026-07-22T15:59:06.626794Z"
+      },
+      "status": "live",
+      "surface": "clay",
+      "tournament": "M25 Ollersbach"
+    },
+    {
+      "event_status": null,
+      "format": "BO3",
+      "id": 21660,
+      "indoor": false,
+      "is_doubles": false,
+      "players": {
+        "p1": {
+          "backhand": null,
+          "birthday": "2003-11-13",
+          "country": "esp",
+          "data_completeness": {
+            "known": 3,
+            "missing": [
+              "backhand",
+              "hand"
+            ],
+            "of": 5
+          },
+          "hand": null,
+          "id": 3037,
+          "is_doubles_team": false,
+          "name": "Victoria O'Hayon Gomez",
+          "ranking": 969,
+          "ranking_movement": "up",
+          "ranking_points": 24,
+          "tour": "wta"
+        },
+        "p2": {
+          "backhand": null,
+          "birthday": null,
+          "country": "aus",
+          "data_completeness": {
+            "known": 2,
+            "missing": [
+              "backhand",
+              "birthday",
+              "hand"
+            ],
+            "of": 5
+          },
+          "hand": null,
+          "id": 11828,
+          "is_doubles_team": false,
+          "name": "Naomi McKenzie",
+          "ranking": 1273,
+          "ranking_movement": "up",
+          "ranking_points": 9,
+          "tour": "wta"
+        }
+      },
+      "round": "W15 Las Palmas de Gran Canaria - 1/16-finals",
+      "scheduled_time": "2026-07-22T12:00:00Z",
+      "score": {
+        "games": [
+          [
+            4
+          ],
+          [
+            2
+          ]
+        ],
+        "is_tiebreak": false,
+        "points": [
+          "0",
+          "0"
+        ],
+        "server": 2,
+        "sets": [
+          0,
+          0
+        ],
+        "timestamp": "2026-07-22T15:59:29.583824Z"
+      },
+      "status": "live",
+      "surface": "clay",
+      "tournament": "W15 Las Palmas de Gran Canaria"
+    }
+  ],
+  "meta": {
+    "count": 4,
+    "limit": 5,
+    "offset": 0
+  }
+}

--- a/src/components/services/Tennis.vue
+++ b/src/components/services/Tennis.vue
@@ -1,0 +1,194 @@
+<template>
+  <Generic :item="item">
+    <template #content>
+      <p class="title is-4">
+        <span
+          v-if="match"
+          class="players"
+          :title="`${match.p1} vs ${match.p2}`"
+        >
+          <span v-if="match.server === 1" class="serving" title="Serving"
+            >●</span
+          >{{ match.p1 }} <span class="versus">vs</span> {{ match.p2
+          }}<span v-if="match.server === 2" class="serving" title="Serving"
+            >●</span
+          >
+        </span>
+        <template v-else>{{ item.name }}</template>
+      </p>
+      <p class="subtitle is-6">
+        <template v-if="item.subtitle">{{ item.subtitle }}</template>
+        <template v-else-if="serverError">Live Tennis API unreachable</template>
+        <template v-else-if="!matches">Loading…</template>
+        <template v-else-if="match">{{ subtitle }}</template>
+        <template v-else>No live match</template>
+      </p>
+    </template>
+    <template #indicator>
+      <div class="score">
+        <strong v-if="match && match.sets" class="sets" title="Sets">{{
+          match.sets
+        }}</strong>
+        <span v-if="match && match.games" class="games" title="Current set">{{
+          match.games
+        }}</span>
+        <strong
+          v-if="serverError"
+          class="error"
+          title="Connection error to the Live Tennis API, check endpoint and apikey in config.yml"
+          >?</strong
+        >
+      </div>
+    </template>
+  </Generic>
+</template>
+
+<script>
+import service from "@/mixins/service.js";
+
+export default {
+  name: "Tennis",
+  mixins: [service],
+  props: {
+    item: Object,
+  },
+  data: () => ({
+    matches: null,
+    serverError: false,
+  }),
+  computed: {
+    limit() {
+      const limit = parseInt(this.item.limit, 10) || 5;
+      return Math.min(Math.max(limit, 1), 10);
+    },
+    match() {
+      return this.matches?.[0] ?? null;
+    },
+    subtitle() {
+      const others = this.matches.length - 1;
+      return others > 0
+        ? `${this.match.tournament} · +${others} more`
+        : this.match.tournament;
+    },
+  },
+  created() {
+    this.autoUpdateMethod = this.fetchMatches;
+    this.fetchMatches();
+  },
+  methods: {
+    fetchMatches() {
+      const headers = {};
+      if (this.item.apikey) {
+        headers["X-API-Key"] = this.item.apikey;
+      }
+
+      let path = `matches?status=live&limit=${this.limit}`;
+      if (this.item.tour) {
+        path += `&tour=${encodeURIComponent(this.item.tour)}`;
+      }
+
+      this.fetch(path, { headers })
+        .then((response) => {
+          // List endpoints answer with `{data: [...], meta: {...}}`.
+          this.matches = (response.data ?? []).map(this.summarize);
+          this.serverError = false;
+        })
+        .catch((e) => {
+          console.error(e);
+          this.serverError = true;
+        });
+    },
+    // Reduce the payload to the few strings the card displays, so rendering
+    // never has to walk the (partly nullable) nested objects.
+    summarize(match) {
+      const players = match.players ?? {};
+      const score = match.score;
+      return {
+        id: match.id,
+        tournament: this.event(match.tournament, match.round),
+        p1: players.p1?.name ?? "?",
+        p2: players.p2?.name ?? "?",
+        server: score?.server,
+        // Sets won, e.g. "1-0". `score` is null until a match starts.
+        sets: this.pair(score?.sets),
+        // Games of the set in progress and current points, e.g. "6-5 40-40".
+        // `games` holds one list of games per player, one entry per set, so
+        // the set being played is the last entry of each.
+        games: [
+          this.pair(score?.games?.map((perSet) => perSet?.at(-1))),
+          this.pair(score?.points),
+        ]
+          .filter(Boolean)
+          .join(" "),
+      };
+    },
+    // `round` usually repeats the tournament ("W50 Horb - 1/16-finals"), so
+    // only its last segment is kept to build "W50 Horb (Germany) · 1/16-finals".
+    event(tournament, round) {
+      const phase = (round ?? "").split(" - ").at(-1).trim();
+      if (!phase || tournament?.includes(phase)) {
+        return tournament ?? phase;
+      }
+      return tournament ? `${tournament} · ${phase}` : phase;
+    },
+    pair(values) {
+      if (!Array.isArray(values) || values.length !== 2) {
+        return "";
+      }
+      return values.every((value) => value !== undefined && value !== null)
+        ? `${values[0]}-${values[1]}`
+        : "";
+    },
+  },
+};
+</script>
+
+<style scoped lang="scss">
+.players {
+  .serving {
+    color: var(--highlight-primary);
+    font-size: 0.6em;
+    margin: 0 0.3em;
+    vertical-align: middle;
+
+    &:first-child {
+      margin-left: 0;
+    }
+  }
+
+  .versus {
+    color: var(--text-subtitle);
+    font-size: 0.8em;
+    font-weight: 400;
+  }
+}
+
+.score {
+  align-self: center;
+  font-variant-numeric: tabular-nums;
+  padding-left: 0.5em;
+  text-align: right;
+  white-space: nowrap;
+
+  .sets {
+    color: var(--text-title);
+    display: block;
+    font-size: 1.1em;
+    line-height: 1.2;
+  }
+
+  .games {
+    color: var(--text-subtitle);
+    font-size: 0.8em;
+  }
+
+  .error {
+    background-color: #e51111;
+    border-radius: 0.25em;
+    color: white;
+    display: inline-block;
+    font-size: 0.8em;
+    padding: 0.2em 0.35em;
+  }
+}
+</style>


### PR DESCRIPTION
Adds a `Tennis` smart card showing the live match in progress from the [Live Tennis API](https://livetennisapi.com): both players, tournament and round, sets won and the current game, with a dot marking the server. Extends `Generic` via the `content`/`indicator` slots and uses the `service.js` mixin `fetch`, so proxy config and auto refresh behave as for other cards. Mock data added under `dummy-data/tennis/`.

**Type of change:** New feature.

- [x] I've read & comply with the contributing guidelines
- [x] I have tested my code for new features & regressions on both mobile & desktop devices — *desktop: Chromium 1280px. Mobile: a **320px emulated Chromium viewport**, not real hardware, and Chromium only (no Firefox/Safari).*
- [x] I have made corresponding changes to the documentation (`docs/customservices.md`)
- [x] I've checked my modifications for breaking changes — additive only, no existing `config.yml` key changed

### Verified against the live API

With a real key, observed rather than inferred: the card rendering, the 401 error state, and auto refresh issuing repeat requests at the configured interval (+0s / +15s / +30s). The `tour` filter was checked per value (`atp`, `wta`, `itf`, and a bogus value returning `400`). Mock data under `dummy-data/tennis/` is a **captured real response**, not hand-written — including a doubles match, a `server: null` row, and a one-set-in-progress score, so `pnpm mock` exercises the shapes production actually returns.

That mattered: testing against real data caught a bug the idealised mock hid. The API's `round` repeats the tournament name on lower tours (`tournament: "M15 Kursumlijska Banja 10"`, `round: "M15 Kursumlijska Banja 10 - 1/16-finals"`), so a naive join rendered the name twice. The card now keeps only the trailing segment, verified against all 24 distinct tournament/round pairs in the live feed, including one row with no separator at all.

### Known limitation

At 320px, long lower-tour names truncate (`Vlado Jankan…`, `M15 Kursumlijska …`). The 85px `.card-content` height allows two lines, and a `title` tooltip carries the full text. I chose truncation over abbreviating names, since surname-shortening breaks doubles pairs like `Blake Bayldon / Cleeve Harper`, and a round-abbreviation lookup would mislabel unrecognised strings.

### Security note

The `apikey` goes in `config.yml`, which Homer serves at `/assets/config.yml` — readable by anyone who can reach the dashboard. This is Homer-wide and already flagged at the top of `customservices.md`; the new section repeats the warning and points at [CORSair](https://github.com/bastienwirtz/corsair) for server-side credential injection. A free tier is available without a card, so the card is usable without exposing a paid credential.