### PR TITLE
feat: upgrade Font Awesome to 7.3.1

### DIFF
--- a/.schema/config-schema.json
+++ b/.schema/config-schema.json
@@ -82,6 +82,13 @@
             "dark"
           ],
           "description": "One of 'auto', 'light', or 'dark'"
+        },
+        "iconWidth": {
+          "enum": [
+            "auto",
+            "fixed"
+          ],
+          "description": "Icon width, either 'auto' (default, each icon keeps its natural width) or 'fixed' (the Font Awesome 7 look, every icon gets the same width)"
         }
       },
       "title": "Defaults"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,6 +47,7 @@ proxy:
 defaults:
   layout: columns # Either 'columns', or 'list'
   colorTheme: auto # One of 'auto', 'light', or 'dark'
+  iconWidth: auto # Either 'auto', or 'fixed'
 
 # Optional theming
 theme: default # 'default' or one of the themes available in 'src/assets/themes'.
@@ -200,6 +201,10 @@ Homer uses [bulma CSS](https://bulma.io/), which provides a [modifiers syntax](h
 - `is-danger` (red)
 
 You can read the [bulma modifiers page](https://bulma.io/documentation/start/syntax/) for other options regarding size, style, or state.
+
+### Icon width
+
+Font Awesome 7 gives every icon the same width, which is what the `fa-fw` class used to do on its own. Homer keeps the previous behaviour by default, so each icon takes up only the space it needs. Set `iconWidth: fixed` under the `defaults` key to opt into the uniform width, which lines up icons in a column when you list several services with different icons.
 
 ## Theming & customization
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -59,3 +59,12 @@ For some basic debugging steps, you can:
 - Check with a large city such as Amsterdam as the specified location within your configuration.
 - Make sure your web browser is running the latest version of the homer configuration after updating the location (Ctrl + Shift + R).
 - Check for errors within the browser console (Ctrl + Shift + I) relating to api.openweathermap.org
+
+## An icon stopped rendering after the Font Awesome 7 upgrade
+
+Homer now ships Font Awesome 7, and the upgrade keeps everything that still exists working. Icons set through the configuration (`icon: "fas fa-server"`) render as before, including the older `fa`, `fas`, `far` and `fab` syntax, and custom stylesheets referencing the `"Font Awesome 6 Free"` and `"Font Awesome 6 Brands"` families keep working too, as Homer aliases them onto the version 7 webfonts.
+
+Only one icon is lost: **`fa-vector-square` no longer exists**. Font Awesome renamed it to `draw-square` and made that icon Pro only, so the free version Homer ships has no glyph for it and it renders as an empty box. Replace it with `object-group` or `crop-simple`, the closest free matches.
+
+> [!NOTE]
+> Font Awesome 7 also gives every icon the same width by default. Homer keeps the previous behaviour, so nothing moves after upgrading. See [icon width](configuration.md#icon-width) if you want the new look.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "format": "prettier --write --experimental-cli src/"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-free": "^6.7.2",
+    "@fortawesome/fontawesome-free": "^7.3.1",
     "bulma": "^1.0.4",
     "lodash.merge": "^4.6.2",
     "vue": "^3.5.39",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@fortawesome/fontawesome-free':
-        specifier: ^6.7.2
-        version: 6.7.2
+        specifier: ^7.3.1
+        version: 7.3.1
       bulma:
         specifier: ^1.0.4
         version: 1.0.4
@@ -771,8 +771,8 @@ packages:
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@fortawesome/fontawesome-free@6.7.2':
-    resolution: {integrity: sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==}
+  '@fortawesome/fontawesome-free@7.3.1':
+    resolution: {integrity: sha512-wmglKKPDIkgV3aWlZzWECCPoGIkYCulzBwxG9+w7rc5BGapZ6cPMpoPOT8k36J0Ni7PPX6c/rsoMWfS4d1MUMg==}
     engines: {node: '>=6'}
 
   '@humanfs/core@0.19.1':
@@ -3470,7 +3470,7 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
-  '@fortawesome/fontawesome-free@6.7.2': {}
+  '@fortawesome/fontawesome-free@7.3.1': {}
 
   '@humanfs/core@0.19.1': {}
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,6 +5,7 @@
     :class="[
       `theme-${config.theme}`,
       `page-${currentPage}`,
+      `fa-width-${config.defaults.iconWidth}`,
       isDark ? 'dark' : 'light',
       !config.footer ? 'no-footer' : '',
     ]"

--- a/src/assets/app.scss
+++ b/src/assets/app.scss
@@ -5,6 +5,7 @@
 @import url("~/bulma/css/bulma.css") layer(framework);
 @import url("@/assets/components/base.scss") layer(base);
 @import url("@/assets/components/highlights.scss") layer(base);
+@import url("@/assets/components/fontawesome-compat.scss") layer(base);
 
 // themes
 @import url("@/assets/themes/classic.scss") layer(theme);

--- a/src/assets/components/base.scss
+++ b/src/assets/components/base.scss
@@ -332,7 +332,7 @@
       }
 
       .search-label::before {
-        font-family: "Font Awesome 6 Free";
+        font-family: "Font Awesome 7 Free";
         position: absolute;
         top: 14px;
         left: 16px;

--- a/src/assets/components/fontawesome-compat.scss
+++ b/src/assets/components/fontawesome-compat.scss
@@ -1,0 +1,29 @@
+// Keeps custom stylesheets and dashboard HTML written against Font Awesome 6 working.
+// Everything here is a bridge to something version 7 removed, and is inert otherwise.
+// The version 6 font family aliases live alongside the other faces, in webfonts.scss.
+
+// Version 7 renamed `--fa-style-family-brands` to `--fa-family-brands`, without mapping the
+// old name. Honour it when set, so a custom icon set overriding the brands family keeps working.
+.fab,
+.fa-brands,
+.fa-classic.fa-brands {
+  --fa-family: var(--fa-style-family-brands, var(--fa-family-brands));
+}
+
+// Version 7 removed these, telling users to bring their own implementation. Dashboards put
+// arbitrary HTML in the footer, the message box and service subtitles, so anything hidden
+// with them would become visible text. Definitions are the version 6 ones.
+.sr-only,
+.fa-sr-only,
+.sr-only-focusable:not(:focus),
+.fa-sr-only-focusable:not(:focus) {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}

--- a/src/assets/defaults.yml
+++ b/src/assets/defaults.yml
@@ -15,6 +15,8 @@ defaults:
   layout: columns
   # auto, light, dark
   colorTheme: auto
+  # auto, fixed
+  iconWidth: auto
 
 theme: default
 colors: ~

--- a/src/assets/webfonts/webfonts.scss
+++ b/src/assets/webfonts/webfonts.scss
@@ -11,3 +11,33 @@
     U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193,
     U+2212, U+2215, U+FEFF, U+FFFD;
 }
+
+// Font Awesome 7 dropped the version 6 family names, keeping only the version 5 and 4 ones.
+// Custom stylesheets drawing an icon through a pseudo element still reference them, so alias
+// them onto the version 7 webfonts. Same files, so this costs no extra download.
+@font-face {
+  font-family: "Font Awesome 6 Free";
+  font-style: normal;
+  font-weight: 900;
+  font-display: block;
+  src: url("~/@fortawesome/fontawesome-free/webfonts/fa-solid-900.woff2")
+    format("woff2");
+}
+
+@font-face {
+  font-family: "Font Awesome 6 Free";
+  font-style: normal;
+  font-weight: 400;
+  font-display: block;
+  src: url("~/@fortawesome/fontawesome-free/webfonts/fa-regular-400.woff2")
+    format("woff2");
+}
+
+@font-face {
+  font-family: "Font Awesome 6 Brands";
+  font-style: normal;
+  font-weight: 400;
+  font-display: block;
+  src: url("~/@fortawesome/fontawesome-free/webfonts/fa-brands-400.woff2")
+    format("woff2");
+}


### PR DESCRIPTION
## Description

Font Awesome 6.7.2 is two years old and version 7 adds a large batch of new free icons, which is what [#1069](https://github.com/bastienwirtz/homer/issues/1069) asks for. The free set grows from 2492 to 2606 usable names.

Version 7 is a major release (changelog [here](https://docs.fontawesome.com/upgrade/whats-changed)), so the work here is mostly about making the jump invisible to existing dashboards. Icons set through the configuration (`icon: "fas fa-server"`) render exactly as before, including the older `fa`, `fas`, `far` and `fab` syntax, and custom stylesheets keep working.

Two things version 7 changes had to be handled:

**Removed CSS surface.** Version 7 drops the `"Font Awesome 6 Free"` and `"Font Awesome 6 Brands"` font families, the `--fa-style-family-brands` custom property, and the `.sr-only` / `.fa-sr-only` classes. Custom icon sets and dashboard HTML in the footer, message box and service subtitles can all depend on these, so `src/assets/components/fontawesome-compat.scss` maps them onto their version 7 equivalents. The family aliases point at the same webfont files version 7 already ships, so they add no download.

**Icon width.** Version 7 gives every icon the same width, which is what `fa-fw` used to do on its own. Applied as-is that widens every stock icon that does not carry `fa-fw`, including the header icon and the Speedtest Tracker, rTorrent, Gatus, OctoPrint, Proxmox, Miniflux and Glances cards, so a dashboard visibly shifts after upgrading. Homer keeps the previous behaviour by default and exposes the new one as an option:

```yaml
defaults:
  iconWidth: auto # Either 'auto', or 'fixed'
```

`auto` is the default and reproduces the version 6 layout. `fixed` opts into the version 7 look, which lines icons up in a column when services use icons of different widths.

### Verification

Rather than trusting the changelog, the version 6.7.2 and 7.3.1 metadata and stylesheets were diffed directly:

* Comparing every free licensed name in both releases, canonical names and aliases across all families, **`vector-square` is the only name that disappears**. Font Awesome renamed it to `draw-square` and made that Pro only. It is called out in `docs/troubleshooting.md` with `object-group` and `crop-simple` as the closest free replacements.
* No icon lost a free style, and no codepoint changed, so stylesheets using literal escapes such as `content: "\f002"` are unaffected.
* Diffing the two `all.css` files at the selector and custom property level, the removals listed above are the complete set. The compat file covers exactly those and nothing more.

### Other notes

* The version 6 font family aliases live in `src/assets/webfonts/webfonts.scss` alongside the existing Noto face, rather than in the compat file, so all `@font-face` declarations stay in one place.
* A production build confirms the aliased families resolve to the same hashed assets as version 7's own faces, so the compat layer costs no extra font request.
* `.schema/config-schema.json` gains the `iconWidth` key.
* The search field's magnifying glass in `base.scss` now names the version 7 family directly instead of relying on the alias.
* No new dependencies. The only lockfile change is the Font Awesome entry.

Not breaking: with `iconWidth` defaulting to `auto`, an existing dashboard renders identically after the upgrade. The only visible difference is `fa-vector-square`, which upstream removed.

Closes #1069

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] I have made corresponding changes to the documentation (`README.md`).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
