### PR TITLE
fix: merge custom headers with the ones set by services

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,8 @@ All service components follow this architecture:
 - Extend `Generic.vue` using Vue slots (`<template #indicator>`, `<template #content>`, `<template #icon>`)
 - Use the `service.js` mixin (`src/mixins/service.js`) for common API functionality
 - Use a custom `fetch` method provided by the service mixin to seamlessly support proxy configuration, custom headers, and credentials.
+- Never call the native `fetch` in a service component. `OpenWeather` (third-party public API) and `Rtorrent` (XML-RPC on a separate host) are the only exceptions, and are not examples to follow.
+- Pass the service's own headers (an API key, an `Authorization` header, ...) as the `init.headers` argument of `this.fetch(path, init, json)`. They layer over the user's `proxy.headers` and item `headers` rather than replacing them, so a card must never build its headers from `proxy` or `item.headers` itself. Names are compared case-insensitively, and the card value wins on conflict.
 
 ### Auto-Update Configuration
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ All service components follow this architecture:
 - Extend `Generic.vue` using Vue slots (`<template #indicator>`, `<template #content>`, `<template #icon>`)
 - Use the `service.js` mixin (`src/mixins/service.js`) for common API functionality
 - Use a custom `fetch` method provided by the service mixin to seamlessly support proxy configuration, custom headers, and credentials.
-- Never call the native `fetch` in a service component. `OpenWeather` (third-party public API) and `Rtorrent` (XML-RPC on a separate host) are the only exceptions, and are not examples to follow.
+- Never call the native `fetch` in a service component unless you have a specific reason not to. See `OpenWeather` (third-party public API) or `Rtorrent` (XML-RPC on a separate host) for use case where the service fetch is not suitable.
 - Pass the service's own headers (an API key, an `Authorization` header, ...) as the `init.headers` argument of `this.fetch(path, init, json)`. They layer over the user's `proxy.headers` and item `headers` rather than replacing them, so a card must never build its headers from `proxy` or `item.headers` itself. Names are compared case-insensitively, and the card value wins on conflict.
 
 ### Auto-Update Configuration

--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -83,7 +83,7 @@ Available services are located in `src/components/`:
   url: https://my-service.url # Optional: Card link and API base url unless 'endpoint' is provided (see below) 
   endpoint: https://my-service-api.url # Optional: alternative base URL used to fetch service data when necessary.
   useCredentials: false # Optional: Override global proxy.useCredentials configuration.
-  headers: # Optional: Override global proxy.headers configuration.
+  headers: # Optional: Per-item headers, layered over (and overriding) proxy.headers. A card setting the same header wins over both.
 ```
 
 If a subtitle is provided, (using the `subtitle` configuration key), **it will override (hide)** any custom information displayed on the subtitle line by the custom integration.

--- a/docs/development.md
+++ b/docs/development.md
@@ -29,7 +29,7 @@ Any service consuming an API must use the [`service`](https://github.com/bastien
 - **Refresh**: assign the method to re-run to `this.autoUpdateMethod`, the mixin schedules it using `updateIntervalMs`.
 
 > [!NOTE]
-> `OpenWeather` and `Rtorrent` bypass the mixin, respectively for a third-party public API and an XML-RPC host. Don't use them as an example for a new service.
+> Some services like `OpenWeather` and `Rtorrent` bypass the mixin, respectively for a third-party public API and an XML-RPC host. Don't use them as an example for a new service.
 
 ### Skeleton
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -18,6 +18,19 @@ Each one is **optional**, and will display the usual information if omitted.
 
 Each service must implement the `item` [property](https://vuejs.org/v2/guide/components-props.html) and bind it the Generic component if used.
 
+### Fetching data
+
+Any service consuming an API must use the [`service`](https://github.com/bastienwirtz/homer/blob/main/src/mixins/service.js) mixin and its `this.fetch(path, init, json)` helper instead of the native `fetch`. The mixin takes care of everything the user can configure:
+
+- **URL**: `path` is appended to the service endpoint (`item.endpoint`, or `item.url`), so it only needs the part that follows it.
+- **Headers**: pass the service ones (an API key, an `Authorization` header, ...) as `init.headers`. The mixin layers them over the user's `proxy.headers` and item `headers`, so never read those yourself. If both set the same header, the service value wins.
+- **Credentials**: `proxy.useCredentials` and its per-item override are applied for you.
+- **Response**: returned as parsed JSON, or as text when `json` is `false`.
+- **Refresh**: assign the method to re-run to `this.autoUpdateMethod`, the mixin schedules it using `updateIntervalMs`.
+
+> [!NOTE]
+> `OpenWeather` and `Rtorrent` bypass the mixin, respectively for a third-party public API and an XML-RPC host. Don't use them as an example for a new service.
+
 ### Skeleton
 
 ```Vue
@@ -37,15 +50,34 @@ Each service must implement the `item` [property](https://vuejs.org/v2/guide/com
 
 <script>
 import Generic from "./Generic.vue";
+import service from "@/mixins/service.js";
 
 export default {
   name: "MyNewService",
+  mixins: [service],
+  components: {
+    Generic,
+  },
   props: {
     item: Object,
   },
-  components: {
-    Generic,
-  }
+  data: () => ({
+    stats: null,
+  }),
+  created() {
+    this.autoUpdateMethod = this.fetchStatus;
+    this.fetchStatus();
+  },
+  methods: {
+    fetchStatus: async function () {
+      const headers = this.item.apikey
+        ? { "X-Api-Key": this.item.apikey }
+        : {};
+      this.stats = await this.fetch("/api/stats", { headers }).catch((e) =>
+        console.error(e),
+      );
+    },
+  },
 };
 </script>
 ```

--- a/src/components/services/Plex.vue
+++ b/src/components/services/Plex.vue
@@ -89,10 +89,11 @@ export default {
           let seriesCount = 0;
           Promise.all(
             seriesDirIds.map((seriesDirId) =>
-              fetch(
-                `${this.endpoint}/library/sections/${seriesDirId}/all?X-Plex-Token=${this.item.token}`,
+              this.fetch(
+                `/library/sections/${seriesDirId}/all?X-Plex-Token=${this.item.token}`,
+                {},
+                false,
               )
-                .then((response) => response.text())
                 .then((str) => {
                   const xml = parser.parseFromString(str, "application/xml");
                   seriesCount += xml.getElementsByTagName("Directory").length;
@@ -108,10 +109,11 @@ export default {
           let movieCount = 0;
           Promise.all(
             movieDirIds.map((movieDirId) =>
-              fetch(
-                `${this.endpoint}/library/sections/${movieDirId}/all?X-Plex-Token=${this.item.token}`,
+              this.fetch(
+                `/library/sections/${movieDirId}/all?X-Plex-Token=${this.item.token}`,
+                {},
+                false,
               )
-                .then((response) => response.text())
                 .then((str) => {
                   const xml = parser.parseFromString(str, "application/xml");
                   movieCount += xml.getElementsByTagName("Video").length;

--- a/src/mixins/service.js
+++ b/src/mixins/service.js
@@ -1,5 +1,20 @@
 import updateScheduler from "@/utils/updateScheduler.js";
 
+// Header names are case-insensitive, so they are lowercased before merging and
+// each source overrides the previous one whatever its casing. Unset values are
+// skipped: a card must not replace a configured header with `undefined`.
+function mergeHeaders(...sources) {
+  const merged = {};
+  for (const source of sources) {
+    for (const [name, value] of Object.entries(source ?? {})) {
+      if (value !== undefined && value !== null) {
+        merged[name.toLowerCase()] = value;
+      }
+    }
+  }
+  return merged;
+}
+
 export default {
   props: {
     proxy: Object,
@@ -40,22 +55,21 @@ export default {
         options.credentials = "include";
       }
 
-      if (this.proxy?.headers && !!this.proxy.headers) {
-        options.headers = this.proxy.headers;
-      }
-
       // Each item can override the credential settings
       if (this.item.useCredentials !== undefined) {
         options.credentials =
           this.item.useCredentials === true ? "include" : "omit";
       }
 
-      // Each item can have their own headers
-      if (this.item.headers !== undefined && !!this.item.headers) {
-        options.headers = this.item.headers;
-      }
-
       options = Object.assign(options, init);
+
+      // Headers are layered: proxy configuration, then item configuration,
+      // then the ones built by the service itself.
+      options.headers = mergeHeaders(
+        this.proxy?.headers,
+        this.item.headers,
+        init?.headers,
+      );
 
       if (path.startsWith("/")) {
         path = path.slice(1);


### PR DESCRIPTION
## Description

Custom headers set through `proxy.headers` or a service's own `headers` key are silently dropped by any card that sends headers of its own, which is what [#971](https://github.com/bastienwirtz/homer/issues/971) reports for Portainer and Proxmox. 23 of the 53 service cards send headers, across 34 call sites, so this affects a large part of the smart card surface.

The cause is in the `service.js` mixin. `this.fetch()` assigned the configured headers to the request options, then merged the card's `init` over them with `Object.assign`. Because `headers` is a single key, `init.headers` replaced the whole configured set instead of adding to it, so a card sending `X-Api-Key` erased the user's `Authorization` header rather than sending both.

The mixin now merges the three sources in order of specificity:

```js
options.headers = mergeHeaders(
  this.proxy?.headers,
  this.item.headers,
  init?.headers,
);
```

Precedence is `proxy.headers`, then the item `headers`, then the ones the card builds itself, each layer overriding the previous one by name. Two details were needed to make that correct:

**Header names are compared case-insensitively.** HTTP header names are case-insensitive but object keys are not, so merging `{authorization: ...}` from the configuration with `{Authorization: ...}` from a card would keep both keys, and `fetch` would join them into a single `authorization: Basic aaa, Bearer bbb` value that servers reject. Names are lowercased while merging, so one header name always means one header.

**Unset values no longer count as values.** Several cards build their headers unconditionally, for example Portainer with `{"X-Api-Key": this.item.apikey}`. When that config key is absent the value is `undefined` and `fetch` sends the literal string `"undefined"`, overwriting a header the user did set. Undefined and null values are skipped, so the configured header survives.

**Cards that only sometimes send a header are fixed too.** Traefik, TrueNAS Scale and HyperHDR build `let headers = {}` and fill it only when their optional auth key is present. That empty object used to erase the configured headers on every request where the key was unset. Same bug as #971, never reported separately.

**Plex** was the last card still using the native `fetch` for part of its work, so its library requests bypassed the proxy configuration entirely. Its two remaining native calls now go through `this.fetch`, which also gives it `successCodes` support.

### Verification

The repository has no test suite, so the change was checked by diffing the requests the mixin builds before and after, rather than by inspection:

* Every `this.fetch()` call in `src/components/services` was parsed to collect the shape of its `init` argument: 88 call sites in eight distinct shapes, 34 of them carrying the card's own headers.
* Those eight shapes, plus the two "optional config key unset" variants, were run against seven proxy and item configurations, comparing the complete request options with header lists normalised through `new Headers()` so that casing and key order cannot hide a difference. 44 of the 70 combinations are byte identical.
* **For a dashboard that sets neither `proxy.headers` nor item `headers`, which is the default, only one of the ten shapes changes at all**: a card header whose value is `undefined` is no longer sent. Every other call site builds exactly the request it built before.
* The remaining 25 differences are configured headers now reaching cards that used to discard them, which is the fix itself.
* Nothing outside the header path moved. `method`, `cache`, `body`, `credentials` and the `AbortSignal` the Ping card passes are identical in every combination.

`pnpm lint` passes and a production build succeeds.

### Other notes

* Item `headers` used to replace `proxy.headers` entirely. They now layer, so a header set only at the proxy level survives alongside item headers. `docs/customservices.md` documents the new precedence.
* Plex now inherits `proxy.useCredentials`. A dashboard that enables it globally will send credentialed requests to Plex, which answers `Access-Control-Allow-Origin: *` and therefore refuses them. `useCredentials: false` on the item restores the previous behaviour. Plex also now shows a connection error instead of zero counts when the server answers with an error status.
* `docs/development.md` gains a short "Fetching data" section and `AGENTS.md` the matching rules, so a new card does not reintroduce the bug by reading `proxy.headers` itself.
* This does not close [#1008](https://github.com/bastienwirtz/homer/issues/1008). The Prometheus card sends no headers at all and does not read `basic_auth`, which needs its own change. Setting `headers: {Authorization: "Basic <base64>"}` on the item works today.
* No new dependencies and no lockfile change.

Not breaking: a dashboard that sets neither `proxy.headers` nor item `headers` sends exactly the same requests as before.

Closes #971

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [ ] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] I have made corresponding changes to the documentation (`README.md`).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
