### PR TITLE
fix(message): refetch remote content when the config is rebuilt

### DIFF
--- a/src/components/Message.vue
+++ b/src/components/Message.vue
@@ -23,6 +23,7 @@ export default {
   data: function () {
     return {
       message: {},
+      refreshTimer: null,
     };
   },
   computed: {
@@ -31,50 +32,70 @@ export default {
     },
   },
   watch: {
-    item: function (item) {
-      this.message = Object.assign({}, item);
+    item: {
+      immediate: true,
+      // A page switch rebuilds the config and replaces this prop, so the
+      // endpoint has to be queried again, not just reset to the config value.
+      handler: function (item) {
+        clearInterval(this.refreshTimer);
+        this.message = { ...item };
+        this.getMessage();
+
+        if (item?.url && item.refreshInterval) {
+          this.refreshTimer = setInterval(
+            this.getMessage,
+            item.refreshInterval,
+          );
+        }
+      },
     },
   },
-  created: async function () {
-    // Look for a new message if an endpoint is provided.
-    this.message = Object.assign({}, this.item);
-    await this.getMessage();
+  beforeUnmount: function () {
+    clearInterval(this.refreshTimer);
   },
   methods: {
     getMessage: async function () {
-      if (!this.item) {
+      const item = this.item;
+      if (!item?.url) {
         return;
       }
-      if (this.item.url) {
-        let fetchedMessage = await this.downloadMessage(this.item.url);
-        if (this.item.mapping) {
-          fetchedMessage = this.mapRemoteMessage(fetchedMessage);
-        }
 
-        // keep the original config value if no value is provided by the endpoint
-        const message = this.message;
-        for (const prop of ["title", "style", "content", "icon"]) {
-          if (prop in fetchedMessage && fetchedMessage[prop] !== null) {
-            message[prop] = fetchedMessage[prop];
-          }
-        }
-        this.message = { ...message }; // Force computed property to re-evaluate
+      let fetchedMessage = await this.downloadMessage(item.url);
+
+      // A page switch during the fetch makes this response obsolete.
+      if (item !== this.item) {
+        return;
       }
 
-      if (this.item.refreshInterval) {
-        setTimeout(this.getMessage, this.item.refreshInterval);
+      if (item.mapping) {
+        fetchedMessage = this.mapRemoteMessage(fetchedMessage);
+      }
+
+      // keep the original config value if no value is provided by the endpoint
+      for (const prop of ["title", "style", "content", "icon"]) {
+        if (prop in fetchedMessage && fetchedMessage[prop] !== null) {
+          this.message[prop] = fetchedMessage[prop];
+        }
       }
     },
 
-    downloadMessage: function (url) {
-      return fetch(url, { headers: { Accept: "application/json" } }).then(
-        function (response) {
-          if (response.status != 200) {
-            return;
-          }
-          return response.json();
-        },
-      );
+    // Never rejects, so a failing endpoint cannot break the refresh loop.
+    downloadMessage: async function (url) {
+      try {
+        const response = await fetch(url, {
+          headers: { Accept: "application/json" },
+        });
+
+        if (!response.ok) {
+          throw new Error(`${response.status} error`);
+        }
+
+        const message = await response.json();
+        return message instanceof Object ? message : {};
+      } catch (error) {
+        console.warn(`Fail to fetch message from ${url}:`, error);
+        return {};
+      }
     },
 
     mapRemoteMessage: function (message) {


### PR DESCRIPTION
### Overview

A `message` configured with a `url` loses the content provided by its endpoint as soon as the dashboard config is rebuilt, which happens on any hash navigation: clicking a navbar link to a subpage, or clicking the header logo. The title stays visible because it comes from `config.yml`, while the content disappears because it only ever came from the endpoint. A manual browser reload restores it.

### Root Cause

The remote fetch ran only in `created()`, but nothing ever re-created the component:

- `App.vue` renders `<Message :item="config.message" />` with no `:key`, so Vue reuses the same instance for the life of the page.
- `window.onhashchange` is bound to `buildDashboard`, which reassigns `this.config = merge(defaults, config)`. Both operands are freshly built, so `config.message` is a brand new object identity on every rebuild.
- The `item` watcher reacted to that new identity with `this.message = Object.assign({}, item)`, resetting state to the raw YAML and discarding every field the endpoint supplied. It never called `getMessage()`, so nothing refetched.

This also explains the second half of #828. The refresh chain was armed only at the end of the `created()` call, so it captured the first page's config permanently: a page whose config added `refreshInterval` never started a timer, and a single failed fetch ended the chain for good because the scheduling line was never reached.

### Solution

The watcher becomes the single entry point for both the initial load and every later config rebuild, and it owns the refresh timer:

```js
watch: {
  item: {
    immediate: true,
    handler: function (item) {
      clearInterval(this.refreshTimer);
      this.message = { ...item };
      this.getMessage();

      if (item?.url && item.refreshInterval) {
        this.refreshTimer = setInterval(this.getMessage, item.refreshInterval);
      }
    },
  },
},
```

`created()` is dropped, since `immediate: true` covers it.

### Key Implementation Details

**Scheduling moved out of the async path.** Previously the chain rescheduled itself after an `await`, which meant a fetch settling after the component unmounted would arm a fresh timer on a dead instance. `<Message>` sits inside `v-if="!offline"`, so a connectivity blip unmounts it, and every offline/online cycle would leave another orphaned loop running. Arming the timer synchronously in the watcher makes `clearInterval` in `beforeUnmount` sufficient.

**`setInterval` instead of a self-rescheduling `setTimeout`.** This matches how service cards already refresh through `updateScheduler`. The tradeoff is that a period no longer includes the fetch duration, so an endpoint slower than its own interval can have overlapping requests. That is the same property `updateScheduler` already has repo wide, and it is self correcting on the next tick.

**Stale responses are discarded.** `getMessage` pins `item` on entry and returns if the prop changed while the request was in flight, so a slow response from the previous page cannot land on the new one.

**A failing endpoint no longer breaks the refresh loop.** `downloadMessage` previously returned `undefined` for any non 200 and rejected on network errors, both of which threw in the caller before the scheduling line. It now resolves to `{}` and logs a warning, so the configured fallback message stays on screen and the next tick retries. It also checks `response.ok` rather than `status != 200`, consistent with the `service.js` mixin.

**No timer without an endpoint.** A config carrying `refreshInterval` but no `url` used to arm an interval whose only effect was rescheduling itself forever.


### Scope

No change outside `src/components/Message.vue`. The `refreshInterval` config key and its semantics are unchanged.

This does not address the unsanitized `v-html` on remote content. #1047 proposes that separately.

**Consolidating the refresh path is worth a follow up.** `Message.vue` still owns a private timer keyed on `refreshInterval`, while every service card refreshes through the shared single-timer `updateScheduler` keyed on `updateIntervalMs`. That is two config keys and two timer implementations for one concept, and it is the same kind of divergence #940 is addressing on the proxy side, where the message path gains a single shared management point instead of its own copy. Doing the same for refresh would also give messages the scheduler's tab-hide pausing and its interval sanitization, neither of which the message path has today.

I kept it out of this PR for two reasons. It would mean deprecating `refreshInterval` in favour of `updateIntervalMs`, which is a config-facing change rather than a bug fix. And `updateScheduler` resets `tickCount` on restart without resetting each component's `lastUpdate`, so refreshes appear to stall for a while after a tab hide/show cycle. That looks worth fixing before anything else is moved onto it. Happy to tackle both as part of subsequent consolidation work, if you agree @bastienwirtz .


### Related Issues

Closes #828 and #867. Both are the same defect: #867's title says "local json", but its config uses `url: assets/menu.json`, which is fetched over HTTP through the same code path as any remote endpoint. The reporter's final comment on #867 confirms the navbar page switch reproduction from #828.
