### PR TITLE
feat(emby): opt in to modern Jellyfin authorization

### DIFF
--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -161,11 +161,10 @@ The `libraryType` configuration let you choose which stats to show.
   url: https://my-service.url
   apikey: "<---insert-api-key-here--->"
   libraryType: "music" # Choose which stats to show. Can be one of: music, series or movies.
-  # legacyAuth: false # (Optional) Defaults to true. Set to false for Jellyfin 12 and newer.
+  # legacyAuth: false # (Optional) Force the authorization scheme. Auto-detected from the server version by default.
 ```
 
-> [!IMPORTANT]
-> Jellyfin 12 disables legacy authorization on upgrade, which stops the `X-Emby-Token` header this card sends by default from being accepted. Set `legacyAuth: false` to send `Authorization: MediaBrowser Token="..."` instead, which works on every Jellyfin release. Emby is unaffected and should keep the default.
+Jellyfin 12 disables legacy authorization on upgrade, which stops the `X-Emby-Token` header this card sends by default from being accepted. The card detects the server version and sends `Authorization: MediaBrowser Token="..."` instead, which works on every Jellyfin release. Emby is unaffected and keeps the default. Set `legacyAuth` to override that detection on a server configured to accept only one of them.
 
 Auto refresh is supported by this integration.
 

--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -161,7 +161,11 @@ The `libraryType` configuration let you choose which stats to show.
   url: https://my-service.url
   apikey: "<---insert-api-key-here--->"
   libraryType: "music" # Choose which stats to show. Can be one of: music, series or movies.
+  # legacyAuth: false # (Optional) Defaults to true. Set to false for Jellyfin 12 and newer.
 ```
+
+> [!IMPORTANT]
+> Jellyfin 12 disables legacy authorization on upgrade, which stops the `X-Emby-Token` header this card sends by default from being accepted. Set `legacyAuth: false` to send `Authorization: MediaBrowser Token="..."` instead, which works on every Jellyfin release. Emby is unaffected and should keep the default.
 
 Auto refresh is supported by this integration.
 

--- a/src/components/services/Emby.vue
+++ b/src/components/services/Emby.vue
@@ -74,13 +74,21 @@ export default {
         });
     },
     fetchServerMediaStats: async function () {
-      const headers = {
-        "X-Emby-Token": this.item.apikey,
-      };
+      // Jellyfin 12 no longer accepts X-Emby-Token. Opt-in, so Emby stays untouched.
+      const headers =
+        this.item.legacyAuth === false
+          ? {
+              Authorization: `MediaBrowser Token="${encodeURIComponent(this.item.apikey)}"`,
+            }
+          : { "X-Emby-Token": this.item.apikey };
 
-      var data = await this.fetch("/items/counts", { headers }).catch((e) => {
+      const data = await this.fetch("/items/counts", { headers }).catch((e) => {
         console.log(e);
       });
+
+      if (!data) {
+        return;
+      }
 
       this.albumCount = data.AlbumCount;
       this.songCount = data.SongCount;

--- a/src/components/services/Emby.vue
+++ b/src/components/services/Emby.vue
@@ -56,31 +56,39 @@ export default {
   },
   methods: {
     fetchAll: async function () {
-      this.fetchServerStatus();
+      const serverInfo = await this.fetchServerStatus();
 
       if (!this.item.subtitle) {
-        this.fetchServerMediaStats();
+        this.fetchServerMediaStats(serverInfo);
       }
     },
     fetchServerStatus: async function () {
-      this.fetch("/System/info/public")
+      return this.fetch("/System/info/public")
         .then((response) => {
-          if (response.Id) this.status = "running";
-          else throw new Error();
+          if (!response.Id) throw new Error();
+          this.status = "running";
+          return response;
         })
         .catch((e) => {
           console.log(e);
           this.status = "dead";
+          return null;
         });
     },
-    fetchServerMediaStats: async function () {
-      // Jellyfin 12 no longer accepts X-Emby-Token. Opt-in, so Emby stays untouched.
-      const headers =
-        this.item.legacyAuth === false
-          ? {
-              Authorization: `MediaBrowser Token="${encodeURIComponent(this.item.apikey)}"`,
-            }
-          : { "X-Emby-Token": this.item.apikey };
+    // Jellyfin 12 no longer accepts X-Emby-Token.
+    authHeaders: function (serverInfo) {
+      const isJellyfin12OrNewer =
+        serverInfo?.ProductName?.toLowerCase().includes("jellyfin") &&
+        parseInt(serverInfo.Version, 10) >= 12;
+
+      const legacyAuth = this.item.legacyAuth ?? !isJellyfin12OrNewer;
+
+      return legacyAuth
+        ? { "X-Emby-Token": this.item.apikey }
+        : { Authorization: `MediaBrowser Token="${this.item.apikey}"` };
+    },
+    fetchServerMediaStats: async function (serverInfo) {
+      const headers = this.authHeaders(serverInfo);
 
       const data = await this.fetch("/items/counts", { headers }).catch((e) => {
         console.log(e);


### PR DESCRIPTION
### Overview

The `Emby` card authenticates with the `X-Emby-Token` header. That header is deprecated in Jellyfin and stops being accepted in Jellyfin 12, so the card will silently stop reporting library counts for Jellyfin users once they upgrade. The card now detects the server version and sends `Authorization: MediaBrowser Token="..."` on Jellyfin 12 and newer, leaving every other server untouched, with a `legacyAuth` key to override the detection.

### Why this breaks soon

Jellyfin has been retiring the legacy authorization methods (`X-Emby-Token`, `X-MediaBrowser-Token`, `X-Emby-Authorization`, the `api_key` query parameter and the `Emby` scheme) in three steps:

1. [jellyfin/jellyfin#13306](https://github.com/jellyfin/jellyfin/pull/13306) added an `EnableLegacyAuthorization` option, defaulting to `true`. This shipped in 10.11, so nothing broke.
2. [jellyfin/jellyfin#15559](https://github.com/jellyfin/jellyfin/pull/15559) flips it to `false`. Importantly this is not only a new-install default: a [migration](https://github.com/jellyfin/jellyfin/blob/master/Jellyfin.Server/Migrations/Routines/20260531160000_DisableLegacyAuthorization.cs) rewrites the setting on existing installs during upgrade, so current users are affected too.
3. Removal of the legacy paths entirely, in the release after that.

Step 2 ships in what was going to be 10.12 and is now numbered 12.0, currently at rc4. A fresh `jellyfin/jellyfin:12.0-rc4` container comes up with `EnableLegacyAuthorization=false` already set.

The failure mode is quiet, which is part of why this is worth doing ahead of time. The card's status indicator hits `/System/info/public`, which needs no auth, so the card keeps showing "running" while only the library counts break.

### Solution

That same `/System/info/public` response returns `ProductName` and `Version`, so the card can pick the header itself and nothing needs configuring:

```js
const isJellyfin12OrNewer =
  serverInfo?.ProductName?.toLowerCase().includes("jellyfin") &&
  parseInt(serverInfo.Version, 10) >= 12;

const legacyAuth = this.item.legacyAuth ?? !isJellyfin12OrNewer;
```

`legacyAuth` stays as an optional override, because `EnableLegacyAuthorization` is a server setting rather than a property of the version. An admin can turn it off on 10.11, where it defaults to `true`, and detection alone would leave that server on `X-Emby-Token` and a 401 with no way out. Only an explicitly set value is used, so an absent or empty key falls through to detection:

```yaml
- name: "Jellyfin"
  type: "Emby"
  url: "https://jellyfin.example.com"
  apikey: "<---insert-api-key-here--->"
  libraryType: "movies"
  # legacyAuth: false # not needed in normal use, only for a server configured unusually
```

The token is sent verbatim, the same value already used for `X-Emby-Token`

### `legacyAuth: false` is already safe on Emby

This is not obvious from the docs, but Emby also accepts `Authorization: MediaBrowser Token="..."`. Verified against `emby/embyserver:4.10.0.22`, which returns 200 for it. So an Emby user can set `legacyAuth: false` today and the card keeps working.

That means a straight swap of the header would in principle have worked everywhere, and the detection could have been "is this Jellyfin" rather than "is this Jellyfin 12". However, Emby's [own API key documentation](https://dev.emby.media/doc/restapi/API-Key-Authentication.html) only lists `X-Emby-Token` and the `api_key` query parameter, so this support is undocumented and could regress without notice. And I have only verified it on 4.10.0.22, while self-hosters might run much older builds.

### Also fixed

`fetchServerMediaStats` did `.catch((e) => console.log(e))` and then read `data.AlbumCount`. On any failed fetch `data` is `undefined`, so it threw a TypeError as an unhandled rejection rather than degrading. This is exactly what a Jellyfin 12 user hits today, and it is the reason the failure is worth handling rather than just re-authenticating.

### Verification

Tested against real servers, each with a three movie library, so a working card reports `3` and a broken one `0`. All numbers are HTTP status against `/Items/Counts`.

| Method | Emby 4.10.0.22 | Jellyfin 10.11.11 | Jellyfin 12.0.0 |
|---|---|---|---|
| `X-Emby-Token` | 200 | 200 | **401** |
| `Authorization: MediaBrowser Token=` | 200 | 200 | 200 |
| `Authorization: Emby Token=` | 200 | 401 | 401 |
| `?ApiKey=` | 401 | 200 | 200 |
| `?api_key=` | 200 | 200 | 401 |

Confirming along the way that 12.0.0 ships `EnableLegacyAuthorization=false` and 10.11.11 ships `true`, that CORS preflight allows `Authorization` on both servers, and that a bad API key now degrades to a zero count with no unhandled TypeError.

Note the `?ApiKey=` column, which is the one method ungated by `EnableLegacyAuthorization` on every Jellyfin version. It is not used here because it puts the key in URLs and therefore in access logs, but it is the natural fallback if a reverse proxy is ever found stripping `Authorization`.

Detection was then checked by running the card's methods against Emby 4.9.5.0 and Jellyfin 10.10.7, 10.11.11 and 12.0-rc6, each with a scanned library and a server API key. Emby reports no Jellyfin product name and the 10.x servers report `Jellyfin Server` with a version below 12, so all three keep the legacy header, while 12.0.0 gets the modern one; all four render counts. The override was checked on the same servers: `legacyAuth: false` renders counts on Emby and both 10.x servers, `legacyAuth: true` returns 401 on 12.0.0, and a dangling `legacyAuth:` falls back to detection.

### Should Emby and Jellyfin be separate cards?

Probably worth revisiting at some point, though I do not think it is warranted yet. The two APIs still overlap enough that one card serves both, and this change is the first place they meaningfully diverge. That divergence is only going to grow now that Jellyfin is actively removing Emby-era compatibility, and there is no guarantee the endpoints this card relies on stay identical.

If they do split, the detection and the flag both become redundant and the auth method can just be implicit in the card type. I would rather wait until there is a second reason to split than do it on the strength of one config key.

### Related Issues

Closes #1028
