### PR TITLE
feat(cards): one shared layout for every service card

### DIFF
--- a/.schema/config-schema.json
+++ b/.schema/config-schema.json
@@ -61,6 +61,42 @@
         },
         "background-image": {
           "type": "string"
+        },
+        "status-online": {
+          "type": "string"
+        },
+        "status-offline": {
+          "type": "string"
+        },
+        "status-warning": {
+          "type": "string"
+        },
+        "status-busy": {
+          "type": "string"
+        },
+        "status-unknown": {
+          "type": "string"
+        },
+        "badge-info": {
+          "type": "string"
+        },
+        "badge-success": {
+          "type": "string"
+        },
+        "badge-warning": {
+          "type": "string"
+        },
+        "badge-danger": {
+          "type": "string"
+        },
+        "badge-accent": {
+          "type": "string"
+        },
+        "badge-neutral": {
+          "type": "string"
+        },
+        "badge-text": {
+          "type": "string"
         }
       }
     },
@@ -265,9 +301,53 @@
         "type": {
           "type": "string",
           "description": "Optional, loads a specific component that provides extra features. MUST MATCH a file name (without file extension) available in `src/components/services`"
+        },
+        "class": {
+          "type": "string",
+          "description": "Optional css class to add on the item, useful with a custom stylesheet. Example 'highlight-purple'"
+        },
+        "background": {
+          "type": "string",
+          "description": "Optional color for the card, to set it directly without a custom stylesheet"
+        },
+        "quick": {
+          "type": "array",
+          "description": "Shortcut links shown as small pills along the bottom of the card",
+          "items": {
+            "$ref": "#/definitions/QuickLink"
+          }
         }
       },
       "title": "Item"
+    },
+    "QuickLink": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "description": "Url of this shortcut"
+        },
+        "icon": {
+          "type": "string",
+          "description": "Fontawesome icon shown inside the pill"
+        },
+        "target": {
+          "type": "string",
+          "description": "html tag target attribute like _blank for a new page"
+        },
+        "color": {
+          "type": "string",
+          "description": "Optional background color for the pill"
+        }
+      },
+      "required": [
+        "url"
+      ],
+      "title": "QuickLink"
     }
   },
   "properties": {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -141,13 +141,20 @@ services:
     items:
       - name: "Awesome app"
         logo: "assets/tools/sample.png"
-        # Alternatively a fa icon can be provided:
+        # Alternatively a fa icon can be provided. Note that icon take precedence if both icon and logo are set.
         # icon: "fab fa-jenkins"
         subtitle: "Bookmark example"
         tag: "app"
         keywords: "self hosted reddit" # optional keyword used for searching purpose
         url: "https://www.reddit.com/r/selfhosted/"
         target: "_blank" # optional html tag target attribute
+        # Optional shortcut links, shown as small pills along the bottom of the card.
+        quick:
+          - name: "Wiki"
+            url: "https://www.reddit.com/r/selfhosted/wiki/"
+            icon: "fas fa-book" # optional
+            target: "_blank" # optional
+            color: "#4285f4" # optional, overrides the default pill background
       - name: "Another one"
         logo: "assets/tools/sample2.png"
         subtitle: "Another application"

--- a/docs/development.md
+++ b/docs/development.md
@@ -14,7 +14,7 @@ A dashboard can contain a lot of items, so performance is very important.
 
 The [`Generic`](https://github.com/bastienwirtz/homer/blob/main/src/components/services/Generic.vue) service provides a typical card layout which
 you can extend to add specific features. Unless you want a completely different design, extended the generic service is the recommended way. It gives you 3 [slots](https://vuejs.org/v2/guide/components-slots.html#Named-Slots) to extend: `icon`, `content` and `indicator`. 
-Each one is **optional**, and will display the usual information if omitted.
+Each one is **optional**, and will display the usual information if omitted. Content given to `icon` must be a `.card-icon` element: the card is a grid, and anything else lands outside the icon zone.
 
 Each service must implement the `item` [property](https://vuejs.org/v2/guide/components-props.html) and bind it the Generic component if used.
 
@@ -27,6 +27,7 @@ Any service consuming an API must use the [`service`](https://github.com/bastien
 - **Credentials**: `proxy.useCredentials` and its per-item override are applied for you.
 - **Response**: returned as parsed JSON, or as text when `json` is `false`.
 - **Refresh**: assign the method to re-run to `this.autoUpdateMethod`, the mixin schedules it using `updateIntervalMs`.
+- **Formatting**: `capCount(value, max)` lives in [`@/utils/format.js`](https://github.com/bastienwirtz/homer/blob/main/src/utils/format.js), not on the mixin. It is a pure function, so import it where you need it, including from components that are not cards. Anything needing `this` (the item config, the proxy, the lifecycle) belongs on the mixin instead.
 
 > [!NOTE]
 > Some services like `OpenWeather` and `Rtorrent` bypass the mixin, respectively for a third-party public API and an XML-RPC host. Don't use them as an example for a new service.

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -30,10 +30,30 @@ Default colors and background can be customized for each theme variant (light an
 | `text-title`          | `--text-title`          | service card title color |
 | `text-subtitle`       | `--text-subtitle`       | service card subtitle color  |
 | `card-shadow`         | `--card-shadow`         | Service card `box-shadow` |
-| `link`                | `--link`                | Links color (footer & message), service card icon color  |
+| `link`                | `--link`                | Links color (footer & message), service card icon color (unless the item carries a `highlight-*` class) |
 | `link-hover`          | `--link-hover`          | Links hover color (footer & message), service card icon hover color |
 | `background-image`    | `--background-image`    | page background image url (when used in css, set `url(<image-url>)` instead of just the url. see example below)|
 
+Service card colors are shared by every card. Set them under both `light` and `dark` unless you want them to differ.
+
+| yaml | css | description |
+| --------------------- | ----------------------- | --- |
+| `status-online`       | `--status-online`       | status dot, reachable and healthy |
+| `status-offline`      | `--status-offline`      | status dot, down or errored |
+| `status-warning`      | `--status-warning`      | status dot, needs attention |
+| `status-busy`         | `--status-busy`         | status dot, working (pulsing) |
+| `status-unknown`      | `--status-unknown`      | status dot, state not known |
+| `badge-info`          | `--badge-info`          | badge, activity counters |
+| `badge-success`       | `--badge-success`       | badge, healthy totals |
+| `badge-warning`       | `--badge-warning`       | badge, warnings |
+| `badge-danger`        | `--badge-danger`        | badge, errors |
+| `badge-accent`        | `--badge-accent`        | badge, secondary counters |
+| `badge-neutral`       | `--badge-neutral`       | badge, plain totals |
+| `badge-text`          | `--badge-text`          | badge text color |
+
+Card geometry is not part of `colors:`, but the same custom properties can be overridden from an additional stylesheet (see below). Defaults are in `assets/components/base.scss`: `--card-height` (`85px`), `--card-icon-size` (`48px`), `--card-pad` (`1.3rem`), `--card-pad-block` (`0.75rem`), `--card-radius` (`0.75rem`) and `--card-lift` (`3px`, the hover rise).
+
+The icon is pinned `--card-pad` from the top of the card, so keep `--card-height` above `--card-pad` plus `--card-icon-size` (about `70px` at the defaults) or it overflows the bottom. Lower `--card-icon-size` to go shorter than that.
 
 YAML example
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -68,3 +68,20 @@ Only one icon is lost: **`fa-vector-square` no longer exists**. Font Awesome ren
 
 > [!NOTE]
 > Font Awesome 7 also gives every icon the same width by default. Homer keeps the previous behaviour, so nothing moves after upgrading. See [icon width](configuration.md#icon-width) if you want the new look.
+
+## My custom stylesheet stopped styling the service cards
+
+Every card moved onto a shared layout, so a few selectors no longer match:
+
+- `.media`, `.media-left`, `.media-content` and `.media.no-subtitle` are gone. The icon is now `.card-icon`, and the title and subtitle sit in `.card-body`.
+- Paths through the card gained a level: `.card-wrapper` sits between the item and `.card`, and the card link is `.card > .card-content > a.card-link`.
+- `.tag` collapses with `max-width` rather than `width`, so a rule setting `width` has no effect.
+- `.quicklinks` is a flex lane at the bottom of the card, so `float` no longer applies.
+- `.card-lane` reaches both card edges and clips what overflows them, so anything positioned inside it stops at the card. The tag sits at the lane's inline end rather than overhanging by its own offset.
+- The status dot animation is named `status-pulse`.
+
+`.card:hover` still matches, so hover rules keyed on the card itself keep working.
+
+## I cannot select card text, and some tooltips stopped appearing
+
+The whole card is one link, drawn as a transparent overlay on top of the content. That overlay takes the pointer, so text inside a card can no longer be selected, and a native `title` tooltip on an element in the card body no longer opens. Tooltips on the badges and the tag are unaffected, as those sit above the overlay.

--- a/src/assets/components/badges.scss
+++ b/src/assets/components/badges.scss
@@ -1,0 +1,43 @@
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.2em 0.35em;
+  border-radius: 0.3em;
+  font-size: 0.8rem;
+  font-weight: 700;
+  line-height: 1.25;
+  font-variant-numeric: tabular-nums;
+  color: var(--badge-text);
+  background-color: var(--badge-color, var(--badge-neutral));
+
+  &.info {
+    --badge-color: var(--badge-info);
+  }
+
+  &.success {
+    --badge-color: var(--badge-success);
+  }
+
+  &.warning {
+    --badge-color: var(--badge-warning);
+  }
+
+  &.danger {
+    --badge-color: var(--badge-danger);
+  }
+
+  &.accent {
+    --badge-color: var(--badge-accent);
+  }
+
+  &.neutral {
+    --badge-color: var(--badge-neutral);
+  }
+}
+
+@media (forced-colors: active) {
+  .badge {
+    border: 1px solid currentColor;
+  }
+}

--- a/src/assets/components/base.scss
+++ b/src/assets/components/base.scss
@@ -1,5 +1,6 @@
 @import url("~/@fortawesome/fontawesome-free/css/all.css") layer(base);
 @import url("@/assets/components/status.scss") layer(base);
+@import url("@/assets/components/badges.scss") layer(base);
 @import url("@/assets/webfonts/webfonts.scss") layer(base);
 
 @mixin ellipsis() {
@@ -25,6 +26,13 @@
     font-variation-settings: "wdth" 100;
 
     #app {
+      --card-height: 85px;
+      --card-icon-size: 48px;
+      --card-pad: 1.3rem;
+      --card-pad-block: 0.75rem;
+      --card-radius: 0.75rem;
+      --card-lift: 3px;
+
       height: auto;
       min-height: 100%;
       background-image: var(--background-image);
@@ -51,10 +59,8 @@
       .card {
         background-color: var(--card-background);
         box-shadow: 0 2px 15px 0 var(--card-shadow);
-        &:hover {
-          background-color: var(--card-background);
-        }
       }
+
       .component-error .card {
         border: 1px solid rgba(255, 33, 33, 0.664);
         background-color: rgba(255, 58, 58, 0.24);
@@ -204,67 +210,278 @@
         }
       }
 
-      .media.no-subtitle {
+      .card {
+        border: none;
+        border-radius: var(--card-radius);
+        box-shadow: 0 2px 15px 0 rgba(0, 0, 0, 0.1);
+        transition:
+          transform 300ms cubic-bezier(0.165, 0.84, 0.44, 1),
+          border-color 300ms cubic-bezier(0.165, 0.84, 0.44, 1);
+        overflow: visible;
+      }
+
+      // Stacking context, or hover flip-flops between adjacent cards.
+      .card-wrapper {
+        position: relative;
+        z-index: 0;
+      }
+
+      .card-wrapper:hover {
+        .card {
+          transform: translateY(calc(-1 * var(--card-lift)));
+        }
+
+        .card-badges .badge,
+        .tag {
+          pointer-events: auto;
+        }
+
+        .tag {
+          max-width: 100%;
+          padding: 0 0.75em;
+
+          .tag-text {
+            opacity: 1;
+          }
+        }
+
+        .tag-slot:hover .tag {
+          z-index: 4;
+          max-width: max-content;
+        }
+      }
+
+      .card-content {
+        --card-text-start: var(--card-pad);
+
+        position: relative;
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) auto;
+        grid-template-rows: auto minmax(0, 1fr);
+        grid-template-areas:
+          "body badges"
+          "body aside";
+        align-items: center;
+        column-gap: 0.5rem;
+        row-gap: 2px;
+        height: var(--card-height);
+        padding: var(--card-pad-block) var(--card-pad);
+        padding-inline-start: var(--card-text-start);
+        border-radius: inherit;
+        color: var(--link);
+
+        &.has-icon {
+          --card-text-start: calc(
+            var(--card-pad) + var(--card-icon-size) + 0.5rem
+          );
+        }
+
+        &.has-lane {
+          --card-pad-block: 0.5rem;
+          grid-template-rows: auto minmax(0, 1fr) auto;
+          grid-template-areas:
+            "body badges"
+            "body aside"
+            "lane lane";
+          row-gap: 0;
+        }
+      }
+
+      .card-wrapper:hover .card-content {
+        color: var(--link-hover);
+      }
+
+      .card-link {
+        position: absolute;
+        inset: 0;
+        z-index: 1;
+        border-radius: inherit;
+
+        &:not([href]),
+        &[href=""] {
+          pointer-events: none;
+          cursor: default;
+        }
+
+        &:focus-visible {
+          outline: 2px solid var(--highlight-secondary);
+          outline-offset: -2px;
+        }
+      }
+
+      // Lifts real controls above the `.card-link` overlay. Not the tag: it
+      // keeps `z-index: 2` so an unfurled tag passes under the badges.
+      .card-content :is(a, button, select, input):not(.card-link, .tag) {
+        position: relative;
+        z-index: 3;
+      }
+
+      .card-icon {
+        position: absolute;
+        inset-inline-start: var(--card-pad);
+        inset-block-start: var(--card-pad);
+        width: var(--card-icon-size);
+        height: var(--card-icon-size);
+
+        .image {
+          display: flex;
+          align-items: center;
+          width: 100%;
+          height: 100%;
+        }
+
+        img {
+          max-height: 100%;
+          object-fit: contain;
+        }
+
+        i {
+          font-size: calc(var(--card-icon-size) * 0.667);
+        }
+      }
+
+      .card-body {
+        grid-area: body;
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        gap: 2px;
+
+        > .title,
+        > .subtitle {
+          margin: 0;
+        }
+      }
+
+      .card-aside {
+        grid-area: aside;
+        // TODO(cards-migrate-to-api): keeps unmigrated indicators above `.card-link` so
+        // their `title` shows, at the cost of the click. Drop with the last card.
+        z-index: 3;
         display: flex;
         align-items: center;
+        gap: 0.5rem;
+        justify-self: end;
       }
 
-      .media-left {
-        margin-inline-end: 0.5rem;
-      }
-
-      .media-content {
+      .card-lane {
+        grid-area: lane;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        min-width: 0;
+        min-height: 1.25rem;
+        margin-inline-start: calc(-1 * var(--card-text-start));
+        margin-inline-end: calc(-1 * var(--card-pad) - 0.2rem);
+        padding-inline-start: var(--card-text-start);
         overflow: hidden;
-        text-overflow: inherit;
+        pointer-events: none;
+      }
+
+      .card-content:not(.has-lane) .card-lane {
+        position: absolute;
+        inset-inline: 0 -0.2rem;
+        inset-block-end: var(--card-pad-block);
+        margin-inline: 0;
+        padding-inline-start: 0;
+      }
+
+      .tag-slot {
+        position: relative;
+        flex: 1 1 0;
+        min-width: 2rem;
+        // Anchors the tag to the lane's bottom, not its moving centre.
+        align-self: stretch;
+      }
+
+      .quicklinks {
+        display: flex;
+        min-width: 0;
+        gap: 0.35rem;
+        max-width: calc(100% - var(--card-pad));
+
+        a {
+          pointer-events: auto;
+          min-width: 0;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          font-size: 0.75rem;
+          line-height: 1.35;
+          padding: 1px 7px;
+          border-radius: 100px;
+          background-color: var(--background);
+        }
+      }
+
+      .card-badges {
+        grid-area: badges;
+        display: flex;
+        align-items: center;
+        gap: 0.3rem;
+        justify-self: end;
+        align-self: start;
+        position: relative;
+        z-index: 3;
+        pointer-events: none;
+        margin-inline-end: calc(0.5rem - var(--card-pad));
+
+        .badge {
+          // Not in badges.scss: `#app a` outranks it there.
+          color: var(--badge-text);
+          text-decoration: none;
+
+          &:hover {
+            color: var(--badge-text);
+          }
+        }
       }
 
       .tag {
-        color: #ffffff;
         position: absolute;
-        bottom: 1rem;
-        right: -0.2rem;
-        width: 3px;
-        overflow: hidden;
-        transition: all 0.2s ease-out;
+        z-index: 2;
+        inset-inline-end: 0;
+        inset-block-end: 0;
+        height: 1.25rem;
+        width: max-content;
+        max-width: 3px;
+        border-radius: 0.3125rem;
         padding: 0;
+        overflow: hidden;
+        color: #ffffff;
+        // Collapsed, it is a sliver in the gutter between two cards.
+        pointer-events: none;
+        transition: padding 0.12s ease-out;
+
+        &:hover {
+          color: #ffffff;
+        }
 
         &:not([class*="is-"]) {
           background-color: var(--highlight-secondary);
         }
 
         .tag-text {
-          display: none;
+          opacity: 0;
+          min-width: 0;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          transition: opacity 0.1s ease-out;
         }
       }
 
-      .card {
-        border: none;
-        border-radius: 0.75rem;
-        box-shadow: 0 2px 15px 0 rgba(0, 0, 0, 0.1);
-        transition: cubic-bezier(0.165, 0.84, 0.44, 1) 300ms;
-        overflow: visible;
-
-        a {
-          outline: none;
+      @media (prefers-reduced-motion: reduce) {
+        .card,
+        .tag,
+        .tag .tag-text {
+          transition: none;
         }
-      }
 
-      .card:hover {
-        transform: translate(0, -3px);
-
-        .tag {
-          width: auto;
-          padding: 0 0.75em;
-
-          .tag-text {
-            display: block;
-          }
+        .card-wrapper:hover .card {
+          transform: none;
         }
-      }
-
-      .card-content {
-        height: 85px;
-        padding: 1.3rem;
       }
 
       .layout-vertical {
@@ -276,14 +493,14 @@
           border-radius: 0;
         }
 
-        .column div:first-of-type .card {
-          border-top-left-radius: 0.75rem;
-          border-top-right-radius: 0.75rem;
+        .column > div:first-of-type .card {
+          border-top-left-radius: var(--card-radius);
+          border-top-right-radius: var(--card-radius);
         }
 
-        .column div:last-child .card {
-          border-bottom-left-radius: 0.75rem;
-          border-bottom-right-radius: 0.75rem;
+        .column > div:last-child .card {
+          border-bottom-left-radius: var(--card-radius);
+          border-bottom-right-radius: var(--card-radius);
         }
       }
     }
@@ -368,5 +585,6 @@
 
   .group-logo {
     float: left;
+    margin-inline-end: 0.5rem;
   }
 }

--- a/src/assets/components/status.scss
+++ b/src/assets/components/status.scss
@@ -1,52 +1,70 @@
 .status {
+  --status-color: transparent;
+
+  display: inline-flex;
+  align-items: center;
   font-size: 0.8rem;
+  white-space: nowrap;
   color: var(--text-title);
 
-  &.offline:before,
-  &.error:before {
-    background-color: #d65c68;
-    box-shadow: 0 0 5px 1px #d65c68;
-    color: #d65c68;
-  }
-
-  &.pending:before {
-    background-color: #e8bb7d;
-    box-shadow: 0 0 5px 1px #e8bb7d;
-  }
-
-  &.online:before,
-  &.ready:before {
-    background-color: #94e185;
-    box-shadow: 0 0 5px 1px #94e185;
-  }
-
-  &.in-progress:before {
-    background-color: #8fe87d;
-    box-shadow: 0 0 5px 1px #8fe87d;
-    animation: pulse 1s alternate infinite;
-  }
-
-  @keyframes pulse {
-    0% {
-      background: rgba(255, 255, 255, 0.2);
-      box-shadow:
-        inset 0px 0px 10px 2px rgba(0, 255, 182, 0.3),
-        0px 0px 5px 2px rgba(0, 255, 135, 0.2);
-    }
-    100% {
-      background: rgba(255, 255, 255, 1);
-      box-shadow:
-        inset 0px 0px 10px 2px rgba(0, 255, 182, 0.5),
-        0px 0px 15px 2px rgba(0, 255, 135, 1);
-    }
-  }
-
-  &:before {
-    content: " ";
-    display: inline-block;
+  &::before {
+    content: "";
+    flex-shrink: 0;
     width: 8px;
     height: 8px;
-    margin-right: 10px;
-    border-radius: 8px;
+    // TODO(cards-migrate-to-api): a `gap` on `.status` once no card ships its own
+    // margin here, which is unlayered and would stack rather than override.
+    margin-inline-end: 0.625rem;
+    border-radius: 50%;
+    background-color: var(--status-color);
+    box-shadow: 0 0 5px 1px var(--status-color);
+  }
+
+  // TODO(cards-migrate-to-api): `ready`, `error`, `pending` and `in-progress` are the
+  // pre-migration state names. Drop them once every card emits the new ones.
+  &.online,
+  &.ready {
+    --status-color: var(--status-online);
+  }
+
+  &.offline,
+  &.error {
+    --status-color: var(--status-offline);
+  }
+
+  &.warning,
+  &.pending {
+    --status-color: var(--status-warning);
+  }
+
+  &.unknown {
+    --status-color: var(--status-unknown);
+  }
+
+  &.busy,
+  &.in-progress {
+    --status-color: var(--status-busy);
+
+    &::before {
+      animation: status-pulse 1s alternate infinite;
+    }
+  }
+}
+
+@keyframes status-pulse {
+  from {
+    opacity: 0.55;
+    box-shadow: 0 0 0 0 var(--status-color);
+  }
+  to {
+    opacity: 1;
+    box-shadow: 0 0 6px 2px var(--status-color);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .status.busy::before,
+  .status.in-progress::before {
+    animation: none;
   }
 }

--- a/src/assets/themes/classic.scss
+++ b/src/assets/themes/classic.scss
@@ -42,4 +42,18 @@
   --highlight-orange: #ff8a08;
   --highlight-green: #22a699;
   --highlight-purple: #711db0;
+
+  --status-online: #94e185;
+  --status-offline: #d65c68;
+  --status-warning: #e8bb7d;
+  --status-busy: #8fe87d;
+  --status-unknown: #9a9a9a;
+
+  --badge-text: #ffffff;
+  --badge-info: #4fb5d6;
+  --badge-success: #2ac194;
+  --badge-warning: #d08d2e;
+  --badge-danger: #d6455d;
+  --badge-accent: #8a3ffc;
+  --badge-neutral: #6b7280;
 }

--- a/src/assets/themes/neon.scss
+++ b/src/assets/themes/neon.scss
@@ -85,7 +85,7 @@
 
   *[class^="highlight-"],
   *[class*=" highlight-"] {
-    .card:hover {
+    .card-wrapper:hover .card {
       border: 1px solid var(--highlight-color);
     }
   }

--- a/src/assets/themes/walkxcode.scss
+++ b/src/assets/themes/walkxcode.scss
@@ -68,12 +68,12 @@
       border-radius: 0;
     }
 
-    .column div:first-of-type .card {
+    .column > div:first-of-type .card {
       border-top-left-radius: var(--border-radius);
       border-top-right-radius: var(--border-radius);
     }
 
-    .column div:last-child .card {
+    .column > div:last-child .card {
       border-bottom-left-radius: var(--border-radius);
       border-bottom-right-radius: var(--border-radius);
     }

--- a/src/components/GroupHeader.vue
+++ b/src/components/GroupHeader.vue
@@ -1,7 +1,7 @@
 <template>
   <h2 :class="group.class">
     <i v-if="group.icon" :class="['fa-fw', group.icon]"></i>
-    <div v-else-if="group.logo" class="group-logo media-left">
+    <div v-else-if="group.logo" class="group-logo">
       <figure class="image is-48x48">
         <img :src="group.logo" :alt="`${group.name} logo`" />
       </figure>

--- a/src/components/services/Generic.vue
+++ b/src/components/services/Generic.vue
@@ -1,100 +1,145 @@
 <template>
+  <!-- Takes the `item.class` fallthrough, which themes match as an ancestor. -->
   <div>
-    <div class="card" :style="`background-color:${item.background};`">
-      <a :href="item.url" :target="item.target" rel="noreferrer">
-        <div class="card-content">
-          <div :class="mediaClass">
-            <slot name="icon">
-              <div v-if="item.logo" class="media-left">
-                <figure class="image is-48x48">
-                  <img :src="item.logo" :alt="`${item.name} logo`" />
-                </figure>
-              </div>
-              <div v-if="item.icon" class="media-left">
-                <figure class="image is-48x48">
-                  <i style="font-size: 32px" :class="['fa-fw', item.icon]"></i>
-                </figure>
+    <div class="card-wrapper">
+      <div class="card" :style="cardStyle">
+        <div
+          class="card-content"
+          :class="{
+            'has-icon': $slots.icon || item.logo || item.icon,
+            'has-lane': !!item.quick,
+          }"
+        >
+          <a
+            class="card-link"
+            :href="item.url"
+            :target="item.target"
+            :aria-label="item.url ? item.name : null"
+            rel="noreferrer"
+          ></a>
+          <slot name="icon">
+            <div v-if="item.icon" class="card-icon">
+              <figure class="image">
+                <i :class="['fa-fw', item.icon]"></i>
+              </figure>
+            </div>
+            <div v-else-if="item.logo" class="card-icon">
+              <figure class="image">
+                <img :src="item.logo" :alt="`${item.name} logo`" />
+              </figure>
+            </div>
+          </slot>
+          <div class="card-body">
+            <!-- TODO(cards-migrate-to-api): drop #content once every card is migrated. -->
+            <slot name="content">
+              <p class="title">{{ item.name }}</p>
+              <div
+                v-if="item.subtitle || $slots.subtitle || subtitle"
+                class="subtitle"
+              >
+                <template v-if="item.subtitle">{{ item.subtitle }}</template>
+                <slot v-else name="subtitle">{{ subtitle }}</slot>
               </div>
             </slot>
-            <div class="media-content">
-              <slot name="content">
-                <p class="title">{{ item.name }}</p>
-                <p v-if="item.quick" class="quicklinks">
-                  <a
-                    v-for="(link, linkIndex) in item.quick"
-                    :key="linkIndex"
-                    :style="`background-color:${link.color};`"
-                    :href="link.url"
-                    :target="link.target"
-                    rel="noreferrer"
-                  >
-                    <span v-if="link.icon"
-                      ><i
-                        style="font-size: 12px"
-                        :class="['fa-fw', link.icon]"
-                      ></i
-                    ></span>
-                    {{ link.name }}
-                  </a>
-                </p>
-                <p v-if="item.subtitle" class="subtitle">
-                  {{ item.subtitle }}
-                </p>
-              </slot>
-            </div>
-            <slot name="indicator" class="indicator"></slot>
           </div>
-          <div v-if="item.tag" class="tag" :class="item.tagstyle">
-            <strong class="tag-text">#{{ item.tag }}</strong>
+          <div v-if="$slots.badges || visibleBadges.length" class="card-badges">
+            <slot name="badges">
+              <!-- A link, or it would swallow the card click. -->
+              <a
+                v-for="badge in visibleBadges"
+                :key="badge.key"
+                class="badge"
+                :class="badge.tone"
+                :title="badge.label"
+                :href="item.url"
+                :target="item.target"
+                tabindex="-1"
+                rel="noreferrer"
+              >
+                {{ badge.text }}
+              </a>
+            </slot>
+          </div>
+          <div
+            v-if="$slots.aside || $slots.indicator || status"
+            class="card-aside"
+          >
+            <slot name="aside">
+              <!-- TODO(cards-migrate-to-api): drop #indicator once every card is migrated. -->
+              <slot name="indicator">
+                <div v-if="status" class="status" :class="status.state">
+                  {{ status.label }}
+                </div>
+              </slot>
+            </slot>
+          </div>
+          <div v-if="item.quick || item.tag" class="card-lane">
+            <p v-if="item.quick" class="quicklinks">
+              <a
+                v-for="(link, linkIndex) in item.quick"
+                :key="linkIndex"
+                :style="link.color ? `background-color:${link.color};` : null"
+                :href="link.url"
+                :target="link.target"
+                rel="noreferrer"
+              >
+                <span v-if="link.icon"
+                  ><i
+                    style="font-size: 12px"
+                    :class="['fa-fw', link.icon]"
+                  ></i></span
+                >{{ link.name }}
+              </a>
+            </p>
+            <div v-if="item.tag" class="tag-slot">
+              <a
+                class="tag"
+                :class="item.tagstyle"
+                :href="item.url"
+                :target="item.target"
+                tabindex="-1"
+                aria-hidden="true"
+                rel="noreferrer"
+              >
+                <strong class="tag-text">#{{ item.tag }}</strong>
+              </a>
+            </div>
           </div>
         </div>
-      </a>
+      </div>
     </div>
   </div>
 </template>
 
 <script>
+import { capCount } from "@/utils/format.js";
+
+const isEmpty = (badge) =>
+  badge.value === "" ||
+  badge.value === null ||
+  badge.value === undefined ||
+  (badge.value === 0 && !badge.showZero);
+
 export default {
   name: "Generic",
   props: {
     item: Object,
+    subtitle: String,
+    status: Object,
+    badges: Array,
   },
   computed: {
-    mediaClass: function () {
-      return { media: true, "no-subtitle": !this.item.subtitle };
+    cardStyle() {
+      return this.item.background
+        ? { backgroundColor: this.item.background }
+        : null;
+    },
+    visibleBadges() {
+      const hidden = this.item.hide || [];
+      return (this.badges ?? [])
+        .filter((badge) => !hidden.includes(badge.key) && !isEmpty(badge))
+        .map((badge) => ({ ...badge, text: capCount(badge.value) }));
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.media-left {
-  .image {
-    display: flex;
-    align-items: center;
-  }
-
-  img {
-    max-height: 100%;
-    object-fit: contain;
-  }
-}
-
-a[href=""] {
-  pointer-events: none;
-  cursor: default;
-}
-
-.quicklinks {
-  float: right;
-  a {
-    font-size: 0.75rem;
-    padding: 3px 6px;
-    margin-left: 6px;
-    border-radius: 100px;
-    background-color: var(--background);
-    z-index: 9999;
-    pointer-events: all;
-  }
-}
-</style>

--- a/src/components/services/OpenWeather.vue
+++ b/src/components/services/OpenWeather.vue
@@ -1,47 +1,25 @@
 <template>
-  <div :class="{ 'component-error': error }">
-    <div class="card" :class="item.class">
-      <a
-        :href="`https://openweathermap.org/city/${id}`"
-        :target="item.target"
-        rel="noreferrer"
-      >
-        <div class="card-content">
-          <div class="media">
-            <div v-if="icon" class="media-left" :class="item.background">
-              <figure class="image is-48x48">
-                <img
-                  :src="`https://openweathermap.org/img/wn/${icon}@2x.png`"
-                  :alt="conditions"
-                  :title="conditions"
-                />
-              </figure>
-            </div>
-            <div class="media-content">
-              <div>
-                <p class="title is-4">{{ name }}</p>
-                <p v-if="error" class="subtitle is-6">
-                  Fail to load weather information
-                </p>
-                <p v-else class="subtitle is-6">
-                  <span>
-                    {{ temperature }}
-                  </span>
-                  <span class="location-time">
-                    {{ locationTime }}
-                  </span>
-                </p>
-              </div>
-            </div>
-            <div v-if="error" name="indicator" class="indicator">⚠️</div>
-          </div>
-          <div v-if="item.tag" class="tag" :class="item.tagstyle">
-            <strong class="tag-text">#{{ item.tag }}</strong>
-          </div>
-        </div>
-      </a>
-    </div>
-  </div>
+  <Generic :item="weatherItem" :class="{ 'component-error': error }">
+    <template v-if="icon" #icon>
+      <div class="card-icon" :class="item.background">
+        <figure class="image">
+          <img
+            :src="`https://openweathermap.org/img/wn/${icon}@2x.png`"
+            :alt="conditions"
+            :title="conditions"
+          />
+        </figure>
+      </div>
+    </template>
+    <template #subtitle>
+      <template v-if="error">Fail to load weather information</template>
+      <template v-else>
+        <span>{{ temperature }}</span>
+        <span class="location-time">{{ locationTime }}</span>
+      </template>
+    </template>
+    <template v-if="error" #aside>⚠️</template>
+  </Generic>
 </template>
 
 <script>
@@ -60,6 +38,13 @@ export default {
     timezoneOffset: 0,
   }),
   computed: {
+    weatherItem: function () {
+      const item = { ...this.item };
+      delete item.background;
+      item.name = this.name ?? this.item.name;
+      item.url = this.id ? `https://openweathermap.org/city/${this.id}` : "";
+      return item;
+    },
     temperature: function () {
       if (!this.temp) return "";
 
@@ -111,7 +96,7 @@ export default {
           this.timezoneOffset = weather.timezone;
         })
         .catch((e) => {
-          console.log(e);
+          console.error(e);
           this.name = this.item.name;
           this.error = true;
         });
@@ -133,7 +118,7 @@ export default {
 <style scoped lang="scss">
 // Add a border around the weather image.
 // Otherwise the image is not always distinguishable.
-.media-left {
+.card-icon {
   &.circle,
   &.square {
     background-color: #e4e4e4;
@@ -142,23 +127,12 @@ export default {
   &.circle {
     border-radius: 90%;
   }
-
-  img {
-    max-height: 100%;
-  }
 }
 
-.error {
-  color: #de0000;
-}
-
-// Change background color in dark mode.
-.is-dark {
-  .media-left {
-    &.circle,
-    &.square {
-      background-color: #909090;
-    }
+.dark .card-icon {
+  &.circle,
+  &.square {
+    background-color: #909090;
   }
 }
 

--- a/src/components/services/Prometheus.vue
+++ b/src/components/services/Prometheus.vue
@@ -98,16 +98,6 @@ export default {
 </script>
 
 <style scoped lang="scss">
-.media-left {
-  .image {
-    display: flex;
-    align-items: center;
-  }
-
-  img {
-    max-height: 100%;
-  }
-}
 .status {
   font-size: 0.8rem;
   color: var(--text-title);

--- a/src/mixins/service.js
+++ b/src/mixins/service.js
@@ -1,4 +1,5 @@
 import updateScheduler from "@/utils/updateScheduler.js";
+import { capCount } from "@/utils/format.js";
 
 // Header names are case-insensitive, so they are lowercased before merging and
 // each source overrides the previous one whatever its casing. Unset values are
@@ -51,10 +52,7 @@ export default {
     isValueShown(key) {
       return !(this.item.hide || []).includes(key);
     },
-    // Long counts blow out a small pill.
-    capCount(value, max = 99) {
-      return typeof value === "number" && value > max ? `${max}+` : value;
-    },
+    capCount,
     fetch: function (path, init, json = true) {
       let options = {};
 

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -1,0 +1,5 @@
+// TODO(cards-migrate-to-api): the follow-up moves the rest of the card
+// formatters here, off the cards and the service mixin.
+export function capCount(value, max = 99) {
+  return typeof value === "number" && value > max ? `${max}+` : value;
+}


### PR DESCRIPTION
First of two stacked PRs. This one is mainly presentation: [`Generic.vue`](https://github.com/bastienwirtz/homer/blob/daa017d/src/components/services/Generic.vue) takes over the card layout and the styling moves into [`src/assets/components/`](https://github.com/bastienwirtz/homer/tree/daa017d/src/assets/components). The old slots keep every existing card rendering, with the one exception noted below. The second PR migrates the cards onto the new props and the shared service helpers.

## What changes

- The card becomes a grid with a fixed set of zones: icon, title, subtitle, badges, status chip, quicklinks and tag. A card no longer positions anything itself.
- **Quicklinks get their own lane** at the bottom, with a different position. They previously lived inside `Generic`'s default `#content` slot, so any card overriding that slot silently dropped them; in the lane they work on every card.
- **The card link becomes a single stretched overlay** (`.card-link`) instead of an anchor wrapping the content. The HTML parser closes the outer `<a>` at the first quicklink, which is what made a `quick` url unreachable when the card had its own url.
- **Only quicklinks claim the lane row.** A card with pills gives them a row of their own and the title and subtitle sit above it, so the text and the pills stay centred on the card as a group. A tag on its own stays pinned to the card's bottom edge as it is on `main`, claiming no row, so the text stays centred and nothing moves. When the two appear together the tag unfurls into the space left beside the pills, and hovering the tag itself expands it over them.
- Nothing that overhangs the card takes the pointer while the card is idle, which removes the hover feedback loop at the card edges.
- **An unfurling tag is clipped at the card edge** instead of running into the next column, and the text ellipsises where it is cut. The lane reaches both card edges to do the clipping, with a matching padding holding the quicklinks where they were.
- Card geometry (`--card-height`, `--card-pad`, `--card-radius`, `--card-lift`) becomes CSS custom properties, overridable from an additional stylesheet. The status and badge colours become theme tokens, settable through the existing `colors:` config.
- `icon` now takes precedence over `logo` when both are set, matching group headers and what [the configuration docs](https://github.com/bastienwirtz/homer/blob/daa017d/docs/customservices.md#common-options) already promise. They previously rendered side by side.
- **[`OpenWeather`](https://github.com/bastienwirtz/homer/blob/daa017d/src/components/services/OpenWeather.vue) moves onto `Generic`.** It was the only card still building its own `.card` markup, so it was also the only one the new layout could not reach. It is a card change in an otherwise presentational PR, but leaving it behind would have meant shipping a card with no hover lift and a tag that never unfurls. Going through `Generic` also makes it honour `quick:` and a configured `subtitle:`, both of which it silently dropped before, the second against [what the docs already promise](https://github.com/bastienwirtz/homer/blob/daa017d/docs/customservices.md#L90).
- `Generic` gains `subtitle`, `status` and `badges` props plus `icon` / `subtitle` / `aside` / `badges` slots. Only `OpenWeather` uses them here; the second PR migrates the rest.
- New `src/utils/format.js` holds `capCount`, which caps a badge count at `99+`. It is a pure function rather than a mixin method, so `Generic` can use it without pulling in the service mixin it has no other use for. The mixin still exposes it for cards that have not migrated.

Fixes #1077. Fixes #997.

Also addresses part of #1025: the pills that "do not render at all" are the quicklinks bug above. Not closing it, since neither the compact cards nor the list-only item type it also asks for are in scope.

## Compatibility

`Generic` still accepts the old `#content` and `#indicator` slots, so every card that uses them keeps rendering. Everything held open for those cards carries a `TODO(cards-migrate-to-api)` marker and goes in the [follow-up](https://github.com/bastienwirtz/homer/pull/1081):

- the `#content` and `#indicator` slots themselves
- `--status-color: transparent` and the `ready` / `error` / `pending` / `in-progress` aliases in `status.scss`, while cards still emit their own state names
- the dot spacing as a `margin-inline-end` on `::before` rather than a `gap` on `.status`, so the scoped `margin-right` those cards ship overrides it instead of stacking with it
- `z-index` on `.card-aside`

One thing does change before the second PR lands: **the status chip is not clickable.** `.card-aside` has to sit above the `.card-link` overlay so unmigrated indicators keep their `title` tooltips, which are the only labels on the notification counts, and that costs the click through it. On `main` the chip opened the service. The follow-up drops the `z-index` once those counts become badges, which keep their tooltips without blocking the click.

Two consequences of the `.card-link` overlay are permanent, and worth a decision:

- Card text is no longer selectable.
- Native `title` tooltips on elements under the overlay no longer appear. This matters for `Glances`, whose `:title` is the only thing naming its bare stat icons, and for the weather description on `OpenWeather`'s icon. `.card-body [title] { position: relative; z-index: 2 }` brings the body ones back, at the cost of those spans no longer forwarding the card click.

### For users with a custom stylesheet

The card markup changed, so some selectors stop matching. The affected ones are listed in [troubleshooting](https://github.com/bastienwirtz/homer/blob/daa017d/docs/troubleshooting.md). `.card:hover` still fires, so hover rules keyed on the card itself keep working.

Tags with a `tagstyle: is-*` class also pick up Bulma's `a.tag:hover` shade now that the tag is an anchor; tags without one are unaffected.

## Please merge both PRs in the same release

On its own this looks half-migrated: the new chrome with cards still using their own status words, colours and pill placement. The split exists so the CSS can be reviewed on its own, not so the two can ship separately. Merging this one alone publishes nothing in any case, since `dockerhub.yml` and `release.yml` both trigger on `v*` tags rather than on `main`.

## Testing

- `pnpm lint` and `pnpm build` clean.
- Rendered against a config covering every smart card plus the chrome cases: quicklinks, long tags, tag-only, no tag, no subtitle, no icon, logo instead of icon, both logo and icon, and long titles that have to ellipsis.
- Checked the states cards still emit themselves against the aliases: `ready`, `error` and `pending` keep their colour and `in-progress` keeps its pulse, so no card's dot changes.
- Checked side by side with `main` in both light and dark, in the default grid layout and `layout: columns`, and across the classic, walkxcode and neon themes.
- Checked the community themes listed in [the configuration docs](https://github.com/bastienwirtz/homer/blob/daa017d/docs/configuration.md) against `main` and this branch. They all still look right, with two exceptions that already behave the same way on `main`: the Dracula theme does not apply at all, and Homer Theme v2 is wonky. Both look like abandonware rather than anything this branch changes.
- Diffed the compiled CSS against `main`. Outside the card, two like-for-like moves: `.group-logo` picks up the `margin-inline-end` the group header used to get from `.media-left`, and `main`'s `.card:hover` rule is gone, which restores the error tint on a hovered `.component-error` card. The new custom properties are the only other additions, and no existing rule reads them.

One thing left alone on purpose: `--card-shadow` is documented as the card shadow but a later rule in `base.scss` has always overridden it, on `main` too. Letting it through would deepen card shadows in every dark theme, so it belongs in its own, separate PR.
