### PR TITLE
feat(cards): move every card onto the shared API

### DIFF
--- a/.schema/config-schema.json
+++ b/.schema/config-schema.json
@@ -316,6 +316,36 @@
           "items": {
             "$ref": "#/definitions/QuickLink"
           }
+        },
+        "endpoint": {
+          "type": "string",
+          "description": "Smart cards only: alternative base URL used to fetch service data when it differs from the card url"
+        },
+        "headers": {
+          "$ref": "#/definitions/Headers",
+          "description": "Smart cards only: per-item headers, layered over (and overriding) proxy.headers"
+        },
+        "useCredentials": {
+          "type": "boolean",
+          "description": "Smart cards only: override the global proxy.useCredentials configuration"
+        },
+        "successCodes": {
+          "type": "array",
+          "description": "Smart cards only: HTTP status codes to treat as a success instead of the default 2xx",
+          "items": {
+            "type": "integer"
+          }
+        },
+        "updateIntervalMs": {
+          "type": ["integer", "boolean"],
+          "description": "Smart cards only: refresh interval in milliseconds, overriding the global one. Set to 0 or false to disable"
+        },
+        "hide": {
+          "type": "array",
+          "description": "Smart cards only: badge keys, plus any card-specific field keys, to remove from this card (see docs/customservices.md)",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "title": "Item"
@@ -393,6 +423,10 @@
         }
       ],
       "description": "footer Line content. HTML is supported. Set false if you want to hide it."
+    },
+    "updateIntervalMs": {
+      "type": ["integer", "boolean"],
+      "description": "Default refresh interval in milliseconds for every smart card that supports it, minimum 1000. Remove or set to 0 to disable. Can be overriden per item"
     },
     "columns": {
       "type": "string",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,15 +22,16 @@ Homer is a static Vue.js 3 PWA dashboard that loads configuration from YAML file
 - **Entry Point**: `src/main.js` mounts the Vue app
 - **Root Component**: `src/App.vue` handles layout, configuration loading, and routing
 - **Configuration System**: YAML-based with runtime merging of defaults (`src/assets/defaults.yml`) and user config (`/assets/config.yml`)
-- **Service Components**: 53 specialized integrations in `src/components/services/` that extend a Generic component pattern
+- **Service Components**: 58 specialized integrations in `src/components/services/` that extend a Generic component pattern
 
 ### Service Integration Pattern
 
 All service components follow this architecture:
 
-- Extend `Generic.vue` using Vue slots (`<template #indicator>`, `<template #content>`, `<template #icon>`)
-- Use the `service.js` mixin (`src/mixins/service.js`) for common API functionality
+- Render a single `Generic.vue` as the template root and feed it the `subtitle`, `status` and `badges` props, using a slot (`icon`, `subtitle`, `aside`, `badges`) only for richer content. `Generic` owns the card layout and `pnpm lint` enforces it.
+- Use the `service.js` mixin (`src/mixins/service.js`) for common API functionality. It supplies the `item` prop, calls your `fetchData()` on create and on the refresh schedule, and owns error state through `load()` and `serverError`.
 - Use a custom `fetch` method provided by the service mixin to seamlessly support proxy configuration, custom headers, and credentials.
+- Keep display formatting out of the mixin. `capCount`, `displayRate`, `displaySize` and `displayDuration` are pure functions in `src/utils/format.js`, importable by anything, including components that are not cards. Anything needing `this` (the item config, the proxy, the lifecycle) belongs on the mixin instead.
 - Never call the native `fetch` in a service component unless you have a specific reason not to. See `OpenWeather` (third-party public API) or `Rtorrent` (XML-RPC on a separate host) for use case where the service fetch is not suitable.
 - Pass the service's own headers (an API key, an `Authorization` header, ...) as the `init.headers` argument of `this.fetch(path, init, json)`. They layer over the user's `proxy.headers` and item `headers` rather than replacing them, so a card must never build its headers from `proxy` or `item.headers` itself. Names are compared case-insensitively, and the card value wins on conflict.
 
@@ -40,12 +41,14 @@ Services support automatic data refreshing using a centralized scheduler system 
 
 #### Global Configuration
 
-`autoUpdate: 30000` - Set default interval for all services (30 seconds)
+`updateIntervalMs: 30000` - Set default interval for all services (30 seconds)
 
 #### Service Configuration
-- **Service-specific interval**: `updateInterval: 10000` - Override global default
-- **Disable per service**: `autoUpdateInterval: false` - Disable for specific service
-- **Use global default**: Omit `autoUpdateInterval` to use global setting
+- **Service-specific interval**: `updateIntervalMs: 10000` - Override global default
+- **Disable per service**: `updateIntervalMs: false` (or `0`) - Disable for specific service
+- **Use global default**: Omit `updateIntervalMs` to use global setting
+
+The mixin still accepts `checkInterval`, `downloadInterval`, `rateInterval`, `torrentInterval` and `updateInterval`, logging a deprecation warning for each.
 
 ### Configuration & Routing
 

--- a/docs/customservices.md
+++ b/docs/customservices.md
@@ -85,9 +85,54 @@ Available services are located in `src/components/`:
   endpoint: https://my-service-api.url # Optional: alternative base URL used to fetch service data when necessary.
   useCredentials: false # Optional: Override global proxy.useCredentials configuration.
   headers: # Optional: Per-item headers, layered over (and overriding) proxy.headers. A card setting the same header wins over both.
+  hide: [] # Optional: List of keys to remove from this card, badges and card-specific fields alike (see each card below for the keys it offers).
 ```
 
 If a subtitle is provided, (using the `subtitle` configuration key), **it will override (hide)** any custom information displayed on the subtitle line by the custom integration.
+
+Every smart card uses the same layout: icon, name and subtitle, a **status chip** on the right, **badges** along the top, and the `quick` links and `tag` sharing the bottom. A card only shows the parts it has data for.
+
+- **Status chip**: green is healthy, red down, amber needs attention, pulsing green busy, grey unknown. Nothing shows until the first request settles.
+- **Badges**: blue activity, green healthy totals, amber warnings, red errors, purple a secondary count, grey a plain total. Zero is hidden, counts above 99 read `99+`, and `?` means the API was unreachable. Hover one for its meaning.
+
+<details>
+<summary>Keys for the <code>hide</code> option</summary>
+
+Mostly badge keys; a few cards route their own fields through `hide` too.
+
+| card | keys |
+| --- | --- |
+| AdGuard Home, Docuseal, Emby / Jellyfin, Gatus, Gitea, Gotify, Home Assistant, Matrix, Nextcloud, OctoPrint, OliveTin, OpenHAB, PeaNUT, Pi-hole, Ping, Prometheus, Traefik, TrueNAS Scale, Uptime Kuma, Vaultwarden, Wallabag | no badges, these cards show a status chip |
+| Docker Socket Proxy | `running`, `stopped`, `errors`, `serverError` |
+| FreshRSS | `subscriptions`, `unread`, `serverError` |
+| Glances | `serverError` |
+| Healthchecks | `up`, `down`, `grace`, `serverError` |
+| HyperHDR | `running`, `stopped` |
+| Immich | `users`, `photos`, `videos`, `usage`, `serverError` |
+| Jellystat | `streams`, `serverError` |
+| LibrisLog | `reading`, `want-to-read`, `serverError` |
+| Lidarr | `activity`, `missing`, `warnings`, `errors`, `serverError` |
+| Mealie | `serverError` |
+| Medusa | `news`, `warnings`, `errors`, `serverError` |
+| Miniflux | `unread`, `serverError` |
+| Mylar | `wanted`, `upcoming`, `serverError` |
+| NetAlertx, PiAlert | `total`, `connected`, `newdevices`, `downalert`, `serverError` |
+| Paperless-ng | `serverError` |
+| Plex | `streams`, `series`, `movies`, `warnings`, `errors`, `serverError` |
+| Portainer | `running`, `dead`, `misc` |
+| Prowlarr | `warnings`, `errors`, `serverError` |
+| Proxmox | the subtitle fields `vms`, `vms_total`, `lxcs`, `lxcs_total`, `disk`, `mem`, `cpu`, plus `serverError` |
+| Radarr, Readarr, Sonarr | `activity`, `missing`, `warnings`, `errors`, `serverError` |
+| SABnzbd | `downloads`, `serverError` |
+| Scrutiny | `passed`, `failed`, `unknown`, `serverError` |
+| Seerr | `media`, `pending`, `processing`, `issues`, `serverError`, plus the subtitle icons `updateAvailable` and `restartRequired` |
+| Speedtest Tracker | `serverError` |
+| Tautulli | `streams`, `serverError` |
+| Tdarr | `queue`, `errored`, `serverError` |
+| Transmission, qBittorrent, rTorrent | `torrents`, `serverError` |
+| WUD | `running`, `update`, `serverError` |
+
+</details>
 
 > [!TIP]
 > **Auto refresh of the card data**: Some cards support periodic update (see indication in detail below). It can be enabled or disabled globally for all service, or individually for each service using the `updateIntervalMs` configuration option.

--- a/docs/development.md
+++ b/docs/development.md
@@ -12,11 +12,22 @@ pnpm dev
 Custom services are small VueJs component (see `src/components/services/`) that add little features to a classic, "static", dashboard item. It should be very simple.
 A dashboard can contain a lot of items, so performance is very important. 
 
-The [`Generic`](https://github.com/bastienwirtz/homer/blob/main/src/components/services/Generic.vue) service provides a typical card layout which
-you can extend to add specific features. Unless you want a completely different design, extended the generic service is the recommended way. It gives you 3 [slots](https://vuejs.org/v2/guide/components-slots.html#Named-Slots) to extend: `icon`, `content` and `indicator`. 
-Each one is **optional**, and will display the usual information if omitted. Content given to `icon` must be a `.card-icon` element: the card is a grid, and anything else lands outside the icon zone.
+Each service must bind the `item` [property](https://vuejs.org/v2/guide/components-props.html) to the [`Generic`](https://github.com/bastienwirtz/homer/blob/main/src/components/services/Generic.vue) component, which owns the card layout.
 
-Each service must implement the `item` [property](https://vuejs.org/v2/guide/components-props.html) and bind it the Generic component if used.
+```Vue
+<Generic :item="item" :subtitle="rttLabel" :status="reachabilityStatus()" :badges="badges" />
+```
+
+- **`subtitle`** (string): the subtitle line. A config `subtitle` wins over it.
+- **`status`** (`{ state, label }`): the chip on the right. `state` is `online`, `offline`, `warning`, `busy` or `unknown`; `label` is optional.
+- **`badges`** (`[{ key, label, value, tone }]`): the counters along the top. `tone` is `info`, `success`, `warning`, `danger`, `accent` or `neutral`; `label` is the tooltip. Empty values, zeros (unless `showZero: true`) and any `key` in the item's `hide` are dropped, and counts cap at `99+`.
+
+The `icon`, `subtitle`, `aside` and `badges` slots take richer content, each replacing its zone.
+
+A card must surface an API failure exactly once: through its status chip if it has one, otherwise with a `connectionBadge()`.
+
+> [!IMPORTANT]
+> `pnpm lint` enforces this: a single `<Generic>` root, known slots, known `tone` / `state` values, no redeclared `item` prop, no `created()` that only wires `autoUpdateMethod`, a declared `serverError`, and no card restyling the shared chrome. Name a lookup table `_STATE` or `_TONE` in SCREAMING_CASE to have its values checked too.
 
 ### Fetching data
 
@@ -26,25 +37,30 @@ Any service consuming an API must use the [`service`](https://github.com/bastien
 - **Headers**: pass the service ones (an API key, an `Authorization` header, ...) as `init.headers`. The mixin layers them over the user's `proxy.headers` and item `headers`, so never read those yourself. If both set the same header, the service value wins.
 - **Credentials**: `proxy.useCredentials` and its per-item override are applied for you.
 - **Response**: returned as parsed JSON, or as text when `json` is `false`.
-- **Refresh**: assign the method to re-run to `this.autoUpdateMethod`, the mixin schedules it using `updateIntervalMs`.
-- **Formatting**: `capCount(value, max)` lives in [`@/utils/format.js`](https://github.com/bastienwirtz/homer/blob/main/src/utils/format.js), not on the mixin. It is a pure function, so import it where you need it, including from components that are not cards. Anything needing `this` (the item config, the proxy, the lifecycle) belongs on the mixin instead.
+- **Loading and refresh**: name the loading method `fetchData()`. The mixin runs it on create and on the `updateIntervalMs` schedule. To pick a method at runtime, set `this.autoUpdateMethod` in the card's own `created()` (see `PiHole`).
+- **Errors**: wrap the requests in `this.load(...)`, which logs any failure and sets `this.serverError`. Declare `serverError: null` in `data`; `null` means "not loaded yet".
+- **Card helpers**: `reachabilityStatus()` and `connectionBadge()` build the chip and error pill from `serverError`; `versionSubtitle`, `requireConfig("apikey")` and `isValueShown(key)` complete the mixin.
+- **Formatting**: `capCount(value, max)`, `displayRate(bytesPerSecond)`, `displaySize(bytes)` and `displayDuration(seconds)` live in [`@/utils/format.js`](https://github.com/bastienwirtz/homer/blob/main/src/utils/format.js), not on the mixin. They are pure functions, so import them where you need them. A template cannot see an import, so a card calling one from its markup exposes it through `methods` (see `OctoPrint`).
 
 > [!NOTE]
-> Some services like `OpenWeather` and `Rtorrent` bypass the mixin, respectively for a third-party public API and an XML-RPC host. Don't use them as an example for a new service.
+> Some services cannot use `this.fetch`: `OpenWeather` talks to a third-party public API and `Rtorrent` to an XML-RPC host. `Rtorrent` still uses the mixin for everything else, so follow it if you need a custom transport. `OpenWeather` uses none of it and is not a model for anything.
 
 ### Skeleton
 
 ```Vue
 <template>
-  <Generic :item="item">
+  <Generic :item="item" :subtitle="subtitle" :badges="badges">
     <template #icon>
-      <!-- left area containing the icon -->
+      <!-- left area, the item logo or icon by default -->
     </template>
-    <template #content>
-      <!-- main area containing the title, subtitle, ... -->
+    <template #subtitle>
+      <!-- subtitle line, for content richer than the `subtitle` prop -->
     </template>
-    <template #indicator>
-      <!-- top right area, empty by default -->
+    <template #aside>
+      <!-- right area, the `status` chip by default -->
+    </template>
+    <template #badges>
+      <!-- top band, the `badges` counters by default -->
     </template>
   </Generic>
 </template>
@@ -59,23 +75,31 @@ export default {
   components: {
     Generic,
   },
-  props: {
-    item: Object,
-  },
   data: () => ({
     stats: null,
+    serverError: null,
   }),
-  created() {
-    this.autoUpdateMethod = this.fetchStatus;
-    this.fetchStatus();
+  computed: {
+    subtitle() {
+      return this.stats && `${this.stats.total} things`;
+    },
+    badges() {
+      return [
+        { key: "errors", label: "Error", value: this.stats?.errors, tone: "danger" },
+        this.connectionBadge(),
+      ];
+    },
   },
   methods: {
-    fetchStatus: async function () {
+    fetchData() {
       const headers = this.item.apikey
         ? { "X-Api-Key": this.item.apikey }
         : {};
-      this.stats = await this.fetch("/api/stats", { headers }).catch((e) =>
-        console.error(e),
+
+      return this.load(
+        this.fetch("/api/stats", { headers }).then((stats) => {
+          this.stats = stats;
+        }),
       );
     },
   },

--- a/eslint-rules/card-contract.js
+++ b/eslint-rules/card-contract.js
@@ -1,0 +1,340 @@
+const SLOTS = ["icon", "subtitle", "aside", "badges"];
+
+const TONES = ["info", "success", "warning", "danger", "accent", "neutral"];
+const STATES = ["online", "offline", "warning", "busy", "unknown"];
+
+const VOCABULARIES = {
+  tone: { values: TONES, owner: "assets/components/badges.scss" },
+  state: { values: STATES, owner: "assets/components/status.scss" },
+};
+
+// Suffixes that opt a SCREAMING_CASE lookup table into a vocabulary.
+const MAP_SUFFIXES = { _STATE: "state", _TONE: "tone" };
+
+// Vue applies computed after methods, so redefining one of these silently
+// replaces the mixin helper.
+const MIXIN_NAMES = [
+  "load",
+  "fetch",
+  "requireConfig",
+  "connectionBadge",
+  "reachabilityStatus",
+  "versionSubtitle",
+  "isValueShown",
+  "initAutoUpdate",
+  "getUpdateInterval",
+];
+
+const FORBIDDEN_STYLE = [
+  {
+    pattern: /\.status\b/,
+    what: "`.status`, owned by assets/components/status.scss",
+  },
+  { pattern: /\.notifs?\b/, what: "`.notif`, replaced by the `badges` prop" },
+  {
+    pattern: /\.badge\b/,
+    what: "`.badge`, owned by assets/components/badges.scss",
+  },
+  {
+    pattern: /\.card-(content|body|lane|badges|aside)\b/,
+    what: "a card layout class, owned by assets/components/base.scss",
+  },
+  {
+    pattern: /\.(quicklinks|tag)\b/,
+    what: "`.quicklinks` / `.tag`, owned by assets/components/base.scss",
+  },
+  { pattern: /position\s*:\s*(absolute|fixed)/, what: "absolute positioning" },
+  { pattern: /\bfloat\s*:/, what: "`float`" },
+];
+
+function slotName(node) {
+  for (const attr of node.startTag.attributes) {
+    if (
+      attr.directive &&
+      attr.key.name.name === "slot" &&
+      attr.key.argument?.type === "VIdentifier"
+    ) {
+      return attr.key.argument.name;
+    }
+  }
+  return null;
+}
+
+function* elements(node) {
+  for (const child of node.children ?? []) {
+    if (child.type === "VElement") {
+      yield child;
+      yield* elements(child);
+    }
+  }
+}
+
+function keyName(property) {
+  if (property.type !== "Property") {
+    return null;
+  }
+  return property.key.type === "Identifier"
+    ? property.key.name
+    : property.key.type === "Literal"
+      ? String(property.key.value)
+      : null;
+}
+
+function optionValue(component, name) {
+  return component.properties.find((p) => keyName(p) === name)?.value ?? null;
+}
+
+function optionKeys(component, name) {
+  const value = optionValue(component, name);
+  return value?.type === "ObjectExpression"
+    ? value.properties.map(keyName).filter(Boolean)
+    : [];
+}
+
+// data() comes as `() => ({...})` or `function () { return {...} }`.
+function dataKeys(component) {
+  const value = optionValue(component, "data");
+  if (
+    !value ||
+    (value.type !== "ArrowFunctionExpression" &&
+      value.type !== "FunctionExpression")
+  ) {
+    return [];
+  }
+  let object = value.body;
+  if (object.type === "BlockStatement") {
+    object = object.body.find((s) => s.type === "ReturnStatement")?.argument;
+  }
+  return object?.type === "ObjectExpression"
+    ? object.properties.map(keyName).filter(Boolean)
+    : [];
+}
+
+function usesServiceMixin(component) {
+  const mixins = optionValue(component, "mixins");
+  return (
+    mixins?.type === "ArrayExpression" &&
+    mixins.elements.some(
+      (e) => e?.type === "Identifier" && e.name === "service",
+    )
+  );
+}
+
+function isPureWiring(created) {
+  const body =
+    created?.type === "FunctionExpression" ? (created.body?.body ?? []) : [];
+  if (body.length !== 2) {
+    return false;
+  }
+  const [assign, call] = body;
+  return (
+    assign.type === "ExpressionStatement" &&
+    assign.expression.type === "AssignmentExpression" &&
+    assign.expression.left.property?.name === "autoUpdateMethod" &&
+    call.type === "ExpressionStatement" &&
+    call.expression.type === "CallExpression"
+  );
+}
+
+export default {
+  meta: {
+    type: "problem",
+    docs: { description: "enforce the Homer service card anatomy" },
+    schema: [],
+  },
+  create(context) {
+    const fragment = context.sourceCode.parserServices?.getDocumentFragment?.();
+    if (!fragment) {
+      return {};
+    }
+
+    return {
+      Property(node) {
+        const name =
+          node.key.type === "Identifier"
+            ? node.key.name
+            : node.key.type === "Literal"
+              ? node.key.value
+              : null;
+        const vocabulary = VOCABULARIES[name];
+
+        if (
+          !vocabulary ||
+          node.value.type !== "Literal" ||
+          typeof node.value.value !== "string" ||
+          vocabulary.values.includes(node.value.value)
+        ) {
+          return;
+        }
+
+        context.report({
+          node: node.value,
+          message: `Unknown ${name} "${node.value.value}". ${vocabulary.owner} defines ${vocabulary.values.join(", ")}; anything else renders without its colour.`,
+        });
+      },
+
+      // Lookup tables are keyed by upstream names, so the check above misses them.
+      VariableDeclarator(node) {
+        if (
+          node.id.type !== "Identifier" ||
+          node.init?.type !== "ObjectExpression" ||
+          node.id.name !== node.id.name.toUpperCase()
+        ) {
+          return;
+        }
+
+        const suffix = Object.keys(MAP_SUFFIXES).find((end) =>
+          node.id.name.endsWith(end),
+        );
+        if (!suffix) {
+          return;
+        }
+
+        const name = MAP_SUFFIXES[suffix];
+        const vocabulary = VOCABULARIES[name];
+
+        for (const { value } of node.init.properties) {
+          if (
+            value?.type === "Literal" &&
+            typeof value.value === "string" &&
+            !vocabulary.values.includes(value.value)
+          ) {
+            context.report({
+              node: value,
+              message: `Unknown ${name} "${value.value}" in ${node.id.name}. ${vocabulary.owner} defines ${vocabulary.values.join(", ")}; anything else renders without its colour.`,
+            });
+          }
+        }
+      },
+
+      ExportDefaultDeclaration(node) {
+        const component = node.declaration;
+        if (
+          component?.type !== "ObjectExpression" ||
+          !usesServiceMixin(component)
+        ) {
+          return;
+        }
+
+        const text = context.sourceCode.getText();
+        const data = dataKeys(component);
+        const computed = optionKeys(component, "computed");
+
+        if (optionKeys(component, "props").includes("item")) {
+          context.report({
+            node: optionValue(component, "props"),
+            message:
+              'The service mixin already declares the "item" prop; redeclaring it here duplicates the contract.',
+          });
+        }
+
+        for (const option of ["data", "computed", "methods"]) {
+          const keys = option === "data" ? data : optionKeys(component, option);
+          for (const shadowed of keys.filter((k) => MIXIN_NAMES.includes(k))) {
+            context.report({
+              node: optionValue(component, option) ?? component,
+              message: `"${shadowed}" in ${option}() shadows the service mixin's own ${shadowed}. Vue applies computed after methods, so the mixin helper becomes unreachable — rename this one.`,
+            });
+          }
+        }
+
+        const created = optionValue(component, "created");
+        if (created && isPureWiring(created)) {
+          context.report({
+            node: created,
+            message:
+              "Name the loading method fetchData() and delete created(): the mixin calls fetchData on create and on the refresh schedule. Keep created() only to choose a method at runtime.",
+          });
+        }
+
+        const showsServerError =
+          /\b(connectionBadge|reachabilityStatus)\(/.test(text);
+        const touchesServerError =
+          showsServerError ||
+          /\bthis\.(load|requireConfig)\(/.test(text) ||
+          /\bthis\.serverError\b/.test(text);
+        const ownsServerError =
+          data.includes("serverError") || computed.includes("serverError");
+
+        if (touchesServerError && !ownsServerError) {
+          context.report({
+            node: component,
+            message:
+              'This card reads or writes serverError — through connectionBadge(), reachabilityStatus(), load() or requireConfig() — but never declares it. Add "serverError: null" to data(): assigning an undeclared field is not reactive, so the chip and badge would never appear.',
+          });
+        }
+
+        if (/\bthis\.fetch\(/.test(text) && !showsServerError) {
+          const template = fragment.children.find(
+            (block) => block.type === "VElement" && block.name === "template",
+          );
+          const templateText = template
+            ? context.sourceCode.getText(template)
+            : "";
+          // A card that renders a list has no single card to hang a badge on.
+          const rendersList = /v-for=/.test(templateText);
+          // A chip nothing can move off its healthy value surfaces nothing.
+          const ownStatus =
+            /:status=/.test(templateText) &&
+            /(\.catch\(|\bcatch\s*\()/.test(text);
+
+          if (!ownStatus && !rendersList) {
+            context.report({
+              node: component,
+              message:
+                "This card calls an API but surfaces no failure. Add this.connectionBadge() to its badges, or a :status chip driven from a catch; otherwise an unreachable service looks identical to an idle one.",
+            });
+          }
+        }
+      },
+
+      Program() {
+        for (const block of fragment.children) {
+          if (block.type !== "VElement") {
+            continue;
+          }
+
+          if (block.name === "template") {
+            const [root, ...extra] = [...(block.children ?? [])].filter(
+              (child) => child.type === "VElement",
+            );
+
+            if (!root || root.rawName !== "Generic" || extra.length) {
+              context.report({
+                node: root ?? block,
+                message:
+                  "A service card must render a single <Generic> as its template root.",
+              });
+              continue;
+            }
+
+            for (const node of elements(root)) {
+              const name = slotName(node);
+              if (name && !SLOTS.includes(name)) {
+                context.report({
+                  node,
+                  message: `Unknown slot "#${name}". Generic offers ${SLOTS.map((s) => `#${s}`).join(", ")}; counts go through the "badges" prop and the chip through "status".`,
+                });
+              }
+            }
+          }
+
+          if (block.name === "style") {
+            const css = (block.children ?? [])
+              .map((child) => child.value ?? "")
+              .join("");
+
+            for (const { pattern, what } of FORBIDDEN_STYLE) {
+              if (pattern.test(css)) {
+                context.report({
+                  node: block,
+                  message: `A service card must not define ${what}. Card chrome lives in the shared stylesheets so every card stays aligned.`,
+                });
+              }
+            }
+          }
+        }
+      },
+    };
+  },
+};

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,7 @@ import globals from 'globals'
 import js from '@eslint/js'
 import pluginVue from 'eslint-plugin-vue'
 import skipFormatting from 'eslint-config-prettier/flat'
+import cardContract from './eslint-rules/card-contract.js'
 
 export default defineConfig([
   {
@@ -26,7 +27,14 @@ export default defineConfig([
     rules: {
       "vue/multi-word-component-names": "off",
       "vue/require-default-prop": "off",
-      "vue/no-v-html": "off", 
+      "vue/no-v-html": "off",
     },
+  },
+  {
+    name: 'app/card-anatomy',
+    files: ['src/components/services/*.vue'],
+    ignores: ['src/components/services/Generic.vue'],
+    plugins: { homer: { rules: { 'card-contract': cardContract } } },
+    rules: { 'homer/card-contract': 'error' },
   },
 ])

--- a/src/assets/components/base.scss
+++ b/src/assets/components/base.scss
@@ -356,9 +356,6 @@
 
       .card-aside {
         grid-area: aside;
-        // TODO(cards-migrate-to-api): keeps unmigrated indicators above `.card-link` so
-        // their `title` shows, at the cost of the click. Drop with the last card.
-        z-index: 3;
         display: flex;
         align-items: center;
         gap: 0.5rem;

--- a/src/assets/components/status.scss
+++ b/src/assets/components/status.scss
@@ -1,8 +1,9 @@
 .status {
-  --status-color: transparent;
+  --status-color: var(--status-unknown);
 
   display: inline-flex;
   align-items: center;
+  gap: 0.625rem;
   font-size: 0.8rem;
   white-space: nowrap;
   color: var(--text-title);
@@ -12,28 +13,20 @@
     flex-shrink: 0;
     width: 8px;
     height: 8px;
-    // TODO(cards-migrate-to-api): a `gap` on `.status` once no card ships its own
-    // margin here, which is unlayered and would stack rather than override.
-    margin-inline-end: 0.625rem;
     border-radius: 50%;
     background-color: var(--status-color);
     box-shadow: 0 0 5px 1px var(--status-color);
   }
 
-  // TODO(cards-migrate-to-api): `ready`, `error`, `pending` and `in-progress` are the
-  // pre-migration state names. Drop them once every card emits the new ones.
-  &.online,
-  &.ready {
+  &.online {
     --status-color: var(--status-online);
   }
 
-  &.offline,
-  &.error {
+  &.offline {
     --status-color: var(--status-offline);
   }
 
-  &.warning,
-  &.pending {
+  &.warning {
     --status-color: var(--status-warning);
   }
 
@@ -41,8 +34,7 @@
     --status-color: var(--status-unknown);
   }
 
-  &.busy,
-  &.in-progress {
+  &.busy {
     --status-color: var(--status-busy);
 
     &::before {
@@ -63,8 +55,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .status.busy::before,
-  .status.in-progress::before {
+  .status.busy::before {
     animation: none;
   }
 }

--- a/src/components/services/AdGuardHome.vue
+++ b/src/components/services/AdGuardHome.vue
@@ -1,36 +1,26 @@
 <template>
-  <Generic :item="item">
-    <template #content>
-      <p class="title is-4">{{ item.name }}</p>
-      <p class="subtitle is-6">
-        <template v-if="item.subtitle">
-          {{ item.subtitle }}
-        </template>
-        <template v-else-if="stats">
-          {{ percentage }}&percnt; blocked
-        </template>
-      </p>
-    </template>
-    <template #indicator>
-      <div class="status" :class="protection">
-        {{ protection }}
-      </div>
-    </template>
-  </Generic>
+  <Generic
+    :item="item"
+    :subtitle="stats && `${percentage}% blocked`"
+    :status="protection"
+  />
 </template>
 
 <script>
 import service from "@/mixins/service.js";
 
+const PROTECTION = {
+  enabled: { state: "online", label: "enabled" },
+  disabled: { state: "warning", label: "disabled" },
+  unknown: { state: "unknown", label: "unknown" },
+};
+
 export default {
   name: "AdGuardHome",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => {
     return {
-      status: null,
+      serverStatus: null,
       stats: null,
     };
   },
@@ -45,69 +35,30 @@ export default {
       return "";
     },
     protection: function () {
-      if (this.status) {
-        return this.status.protection_enabled ? "enabled" : "disabled";
-      } else return "unknown";
+      if (!this.serverStatus) {
+        return PROTECTION.unknown;
+      }
+      return this.serverStatus.protection_enabled
+        ? PROTECTION.enabled
+        : PROTECTION.disabled;
     },
   },
-  created: function () {
-    // Set up auto-update method for the scheduler
-    this.autoUpdateMethod = this.fetchStatus;
-
-    // Initial data fetch
-    this.fetchStatus();
-  },
   methods: {
-    fetchStatus: async function () {
+    fetchData: async function () {
       this.fetch("/control/status")
         .then((status) => {
-          this.status = status;
+          this.serverStatus = status;
         })
-        .catch((e) => console.log(e));
+        .catch((e) => console.error(e));
 
       if (!this.item.subtitle) {
         this.fetch("/control/stats")
           .then((stats) => {
             this.stats = stats;
           })
-          .catch((e) => console.log(e));
+          .catch((e) => console.error(e));
       }
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.status {
-  font-size: 0.8rem;
-  color: var(--text-title);
-
-  &.enabled:before {
-    background-color: #94e185;
-    border-color: #78d965;
-    box-shadow: 0px 0px 4px 1px #94e185;
-  }
-
-  &.disabled:before {
-    background-color: #c9404d;
-    border-color: #c42c3b;
-    box-shadow: 0px 0px 4px 1px #c9404d;
-  }
-
-  &.unknown:before {
-    background-color: #c9c740;
-    border-color: #ccc935;
-    box-shadow: 0px 0px 4px 1px #c9c740;
-  }
-
-  &:before {
-    content: " ";
-    display: inline-block;
-    width: 7px;
-    height: 7px;
-    margin-right: 10px;
-    border: 1px solid #000;
-    border-radius: 7px;
-  }
-}
-</style>

--- a/src/components/services/CopyToClipboard.vue
+++ b/src/components/services/CopyToClipboard.vue
@@ -1,14 +1,14 @@
 <template>
   <Generic :item="item">
-    <template #indicator>
-      <div class="status">
-        <i
-          class="fa-regular fa-copy fa-xl"
-          :class="{ scale: animate }"
-          @click="copy()"
-          @animationend="animate = false"
-        ></i>
-      </div>
+    <template #aside>
+      <button
+        type="button"
+        title="Copy to clipboard"
+        @click="copy()"
+        @animationend="animate = false"
+      >
+        <i class="fa-regular fa-copy fa-xl" :class="{ scale: animate }"></i>
+      </button>
     </template>
   </Generic>
 </template>
@@ -19,9 +19,6 @@ import service from "@/mixins/service.js";
 export default {
   name: "CopyToClipboard",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => ({
     animate: false,
   }),
@@ -35,6 +32,14 @@ export default {
 </script>
 
 <style scoped lang="scss">
+button {
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  color: inherit;
+}
+
 .scale {
   -webkit-animation: scale-up 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94) both;
   animation: scale-up 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94) both;

--- a/src/components/services/DockerSocketProxy.vue
+++ b/src/components/services/DockerSocketProxy.vue
@@ -1,34 +1,5 @@
 <template>
-  <Generic :item="item">
-    <template #indicator>
-      <div class="notifs">
-        <strong
-          v-if="running > 0"
-          class="notif running"
-          title="Running Containers"
-        >
-          {{ running }}
-        </strong>
-        <strong
-          v-if="stopped > 0"
-          class="notif stopped"
-          title="Stopped Containers"
-        >
-          {{ stopped }}
-        </strong>
-        <strong v-if="errors > 0" class="notif errors" title="Error">
-          {{ errors }}
-        </strong>
-        <strong
-          v-if="serverError"
-          class="notif errors"
-          title="Connection error to Docker Socket Proxy API"
-        >
-          Unavailable
-        </strong>
-      </div>
-    </template>
-  </Generic>
+  <Generic :item="item" :badges="badges" />
 </template>
 
 <script>
@@ -36,74 +7,47 @@ import service from "@/mixins/service.js";
 export default {
   name: "DockerSocketProxy",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => {
     return {
       running: null,
       stopped: null,
       errors: null,
-      serverError: false,
+      serverError: null,
     };
   },
-  created: function () {
-    // Set up auto-update method for the scheduler
-    this.autoUpdateMethod = this.fetchData;
-
-    // Initial data fetch
-    this.fetchData();
+  computed: {
+    badges() {
+      return [
+        {
+          key: "running",
+          label: "Running Containers",
+          value: this.running,
+          tone: "success",
+        },
+        {
+          key: "stopped",
+          label: "Stopped Containers",
+          value: this.stopped,
+          tone: "neutral",
+        },
+        { key: "errors", label: "Error", value: this.errors, tone: "danger" },
+        this.connectionBadge(),
+      ];
+    },
   },
   methods: {
     fetchData: function () {
-      const handleError = (e) => {
-        console.error(e);
-        this.serverError = true;
-      };
-
-      // Fetch all containers (including stopped) from Docker Socket Proxy
-      this.fetch("/containers/json?all=true") // Docker endpoint for container statuses
-        .then((containers) => {
+      return this.load(
+        this.fetch("/containers/json?all=true").then((containers) => {
           this.running = containers.filter(
             (container) => container.State === "running",
           ).length;
           this.stopped = containers.filter(
             (container) => container.State === "exited",
           ).length;
-        })
-        .catch(handleError);
+        }),
+      );
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.notifs {
-  position: absolute;
-  color: white;
-  font-family: sans-serif;
-  top: 0.3em;
-  right: 0.5em;
-
-  .notif {
-    display: inline-block;
-    padding: 0.2em 0.35em;
-    border-radius: 0.25em;
-    position: relative;
-    margin-left: 0.3em;
-    font-size: 0.8em;
-
-    &.running {
-      background-color: #4fb5d6;
-    }
-
-    &.stopped {
-      background-color: #d08d2e;
-    }
-
-    &.errors {
-      background-color: #e51111;
-    }
-  }
-}
-</style>

--- a/src/components/services/Docuseal.vue
+++ b/src/components/services/Docuseal.vue
@@ -1,22 +1,9 @@
 <template>
-  <Generic :item="item">
-    <template #content>
-      <p class="title is-4">{{ item.name }}</p>
-      <p class="subtitle is-6">
-        <template v-if="item.subtitle">
-          {{ item.subtitle }}
-        </template>
-        <template v-else-if="versionstring">
-          Version {{ versionstring }}
-        </template>
-      </p>
-    </template>
-    <template #indicator>
-      <div v-if="status" class="status" :class="status">
-        {{ status }}
-      </div>
-    </template>
-  </Generic>
+  <Generic
+    :item="item"
+    :subtitle="versionSubtitle"
+    :status="reachabilityStatus()"
+  />
 </template>
 
 <script>
@@ -25,62 +12,21 @@ import service from "@/mixins/service.js";
 export default {
   name: "Docuseal",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => ({
-    status: null,
+    serverError: null,
     versionstring: null,
   }),
-  created() {
-    this.fetchStatus();
-  },
   methods: {
-    fetchStatus: async function () {
+    fetchData: function () {
       const params = {
         cache: "no-cache",
       };
-      this.fetch("/version", params, false)
-        .then((response) => {
-          this.status = "online";
+      return this.load(
+        this.fetch("/version", params, false).then((response) => {
           this.versionstring = response;
-        })
-        .catch((e) => {
-          this.status = "offline";
-          console.log(e);
-        });
+        }),
+      );
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.status {
-  font-size: 0.8rem;
-  color: var(--text-title);
-  white-space: nowrap;
-  margin-left: 0.25rem;
-
-  &.online:before {
-    background-color: #94e185;
-    border-color: #78d965;
-    box-shadow: 0 0 5px 1px #94e185;
-  }
-
-  &.offline:before {
-    background-color: #c9404d;
-    border-color: #c42c3b;
-    box-shadow: 0 0 5px 1px #c9404d;
-  }
-
-  &:before {
-    content: " ";
-    display: inline-block;
-    width: 7px;
-    height: 7px;
-    margin-right: 10px;
-    border: 1px solid #000;
-    border-radius: 7px;
-  }
-}
-</style>

--- a/src/components/services/Emby.vue
+++ b/src/components/services/Emby.vue
@@ -1,22 +1,5 @@
 <template>
-  <Generic :item="item">
-    <template #content>
-      <p class="title is-4">{{ item.name }}</p>
-      <p class="subtitle is-6">
-        <template v-if="item.subtitle">
-          {{ item.subtitle }}
-        </template>
-        <template v-else>
-          {{ embyCount }}
-        </template>
-      </p>
-    </template>
-    <template #indicator>
-      <div v-if="status" class="status" :class="status">
-        {{ status }}
-      </div>
-    </template>
-  </Generic>
+  <Generic :item="item" :subtitle="embyCount" :status="status" />
 </template>
 
 <script>
@@ -25,11 +8,8 @@ import service from "@/mixins/service.js";
 export default {
   name: "Emby",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => ({
-    status: "",
+    status: null,
     albumCount: 0,
     songCount: 0,
     movieCount: 0,
@@ -47,15 +27,8 @@ export default {
       else return `wrong library type 💀`;
     },
   },
-  created() {
-    // Set up auto-update method for the scheduler
-    this.autoUpdateMethod = this.fetchAll;
-
-    // Initial data fetch
-    this.fetchAll();
-  },
   methods: {
-    fetchAll: async function () {
+    fetchData: async function () {
       const serverInfo = await this.fetchServerStatus();
 
       if (!this.item.subtitle) {
@@ -66,12 +39,12 @@ export default {
       return this.fetch("/System/info/public")
         .then((response) => {
           if (!response.Id) throw new Error();
-          this.status = "running";
+          this.status = { state: "online", label: "running" };
           return response;
         })
         .catch((e) => {
-          console.log(e);
-          this.status = "dead";
+          console.error(e);
+          this.status = { state: "offline", label: "dead" };
           return null;
         });
     },
@@ -91,7 +64,7 @@ export default {
       const headers = this.authHeaders(serverInfo);
 
       const data = await this.fetch("/items/counts", { headers }).catch((e) => {
-        console.log(e);
+        console.error(e);
       });
 
       if (!data) {
@@ -107,32 +80,3 @@ export default {
   },
 };
 </script>
-
-<style scoped lang="scss">
-.status {
-  font-size: 0.8rem;
-  color: var(--text-title);
-
-  &.running:before {
-    background-color: #94e185;
-    border-color: #78d965;
-    box-shadow: 0 0 5px 1px #94e185;
-  }
-
-  &.dead:before {
-    background-color: #c9404d;
-    border-color: #c42c3b;
-    box-shadow: 0 0 5px 1px #c9404d;
-  }
-
-  &:before {
-    content: " ";
-    display: inline-block;
-    width: 7px;
-    height: 7px;
-    margin-right: 10px;
-    border: 1px solid #000;
-    border-radius: 7px;
-  }
-}
-</style>

--- a/src/components/services/FreshRSS.vue
+++ b/src/components/services/FreshRSS.vue
@@ -1,26 +1,5 @@
 <template>
-  <Generic :item="item">
-    <template #indicator>
-      <div class="notifs">
-        <strong
-          v-if="subscriptions > 0"
-          class="notif subscriptions"
-          title="Subscriptions"
-        >
-          {{ subscriptions }}
-        </strong>
-        <strong v-if="unread > 0" class="notif unread" title="Unread">
-          {{ unread }}
-        </strong>
-        <strong
-          v-if="serverError"
-          class="notif errors"
-          title="Connection error to the FreshRSS API, check url username and password in config.yml"
-          >?</strong
-        >
-      </div>
-    </template>
-  </Generic>
+  <Generic :item="item" :badges="badges" />
 </template>
 
 <script>
@@ -29,89 +8,67 @@ import service from "@/mixins/service.js";
 export default {
   name: "FreshRSS",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => {
     return {
       subscriptions: 0,
       unread: 0,
-      serverError: false,
+      serverError: null,
     };
   },
-  created: function () {
-    // Set up auto-update method for the scheduler
-    this.autoUpdateMethod = this.fetchConfig;
-
-    // Initial data fetch
-    this.fetchConfig();
+  computed: {
+    badges() {
+      return [
+        {
+          key: "subscriptions",
+          label: "Subscriptions",
+          value: this.subscriptions,
+          tone: "info",
+        },
+        { key: "unread", label: "Unread", value: this.unread, tone: "warning" },
+        this.connectionBadge(),
+      ];
+    },
   },
   methods: {
-    fetchConfig: async function () {
+    fetchData: async function () {
       if (!this.auth) {
-        const match = await this.fetch(
-          `/api/greader.php/accounts/ClientLogin?Email=${this.item.username}&Passwd=${this.item.password}`,
-          { method: "GET", cache: "no-cache" },
-          false,
-        ).then((body) => {
-          return body.match(/Auth=(([([a-z0-9]+)\/([([a-z0-9]+))/i);
-        });
-        if (match !== null) this.auth = match[1];
+        await this.load(
+          this.fetch(
+            `/api/greader.php/accounts/ClientLogin?Email=${this.item.username}&Passwd=${this.item.password}`,
+            { method: "GET", cache: "no-cache" },
+            false,
+          ).then((body) => {
+            const match = body.match(/Auth=(([([a-z0-9]+)\/([([a-z0-9]+))/i);
+            if (!match) {
+              throw new Error("FreshRSS login returned no auth token");
+            }
+            this.auth = match[1];
+          }),
+        );
+
+        if (this.serverError) {
+          return;
+        }
       }
 
       const headers = {
         Authorization: `GoogleLogin auth=${this.auth}`,
       };
 
-      this.fetch(
-        `/api/greader.php/reader/api/0/subscription/list?output=json`,
-        { headers },
-      )
-        .then((subscription) => {
+      return this.load(
+        this.fetch(
+          `/api/greader.php/reader/api/0/subscription/list?output=json`,
+          { headers },
+        ).then((subscription) => {
           this.subscriptions = subscription.subscriptions.length;
-        })
-        .catch((e) => {
-          console.error(e);
-          this.serverError = true;
-        });
-      this.fetch(`/api/greader.php/reader/api/0/unread-count?output=json`, {
-        headers,
-      })
-        .then((unreadcount) => {
+        }),
+        this.fetch(`/api/greader.php/reader/api/0/unread-count?output=json`, {
+          headers,
+        }).then((unreadcount) => {
           this.unread = unreadcount.max;
-        })
-        .catch((e) => {
-          console.error(e);
-          this.serverError = true;
-        });
+        }),
+      );
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.notifs {
-  position: absolute;
-  color: white;
-  font-family: sans-serif;
-  top: 0.3em;
-  right: 0.5em;
-
-  .notif {
-    display: inline-block;
-    padding: 0.2em 0.35em;
-    border-radius: 0.25em;
-    position: relative;
-    margin-left: 0.3em;
-    font-size: 0.8em;
-
-    &.subscriptions {
-      background-color: #4fb5d6;
-    }
-
-    &.unread {
-      background-color: #d08d2e;
-    }
-  }
-}
-</style>

--- a/src/components/services/Gatus.vue
+++ b/src/components/services/Gatus.vue
@@ -1,22 +1,11 @@
 <template>
-  <Generic :item="item">
-    <template #content>
-      <p class="title is-4">{{ item.name }}</p>
-      <p class="subtitle is-6">
-        <template v-if="item.subtitle">
-          {{ item.subtitle }}
-        </template>
-        <i class="fa-solid fa-signal"></i> {{ up }}/{{ total }}
-        <template v-if="avgRespTime > 0">
-          <span class="separator"> | </span>
-          <i class="fa-solid fa-stopwatch"></i> {{ avgRespTime }} ms avg.
-        </template>
-      </p>
-    </template>
-    <template #indicator>
-      <div v-if="status !== false" class="status" :class="status">
-        {{ percentageGood }}&percnt;
-      </div>
+  <Generic :item="item" :status="status">
+    <template #subtitle>
+      <i class="fa-solid fa-signal"></i> {{ up }}/{{ total }}
+      <template v-if="avgRespTime > 0">
+        <span class="mx-1"> | </span>
+        <i class="fa-solid fa-stopwatch"></i> {{ avgRespTime }} ms avg.
+      </template>
     </template>
   </Generic>
 </template>
@@ -27,32 +16,32 @@ import service from "@/mixins/service.js";
 export default {
   name: "Gatus",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => ({
     up: 0,
     down: 0,
     total: 0,
     avgRespTime: NaN,
     percentageGood: NaN,
-    status: false,
-    statusMessage: false,
+    state: null,
+    serverError: null,
   }),
-  created() {
-    // Set up auto-update method for the scheduler
-    this.autoUpdateMethod = this.fetchStatus;
-
-    // Initial data fetch
-    this.fetchStatus();
+  computed: {
+    status: function () {
+      if (this.serverError) {
+        return this.reachabilityStatus();
+      }
+      return (
+        this.state && { state: this.state, label: `${this.percentageGood}%` }
+      );
+    },
   },
   methods: {
-    fetchStatus: async function () {
-      this.fetch("/api/v1/endpoints/statuses", {
-        method: "GET",
-        cache: "no-cache",
-      })
-        .then((response) => {
+    fetchData: function () {
+      return this.load(
+        this.fetch("/api/v1/endpoints/statuses", {
+          method: "GET",
+          cache: "no-cache",
+        }).then((response) => {
           // Apply filtering by groups, if defined
           if (this.item.groups) {
             response = response?.filter((job) => {
@@ -104,50 +93,17 @@ export default {
 
           // Status flag
           if (this.up == 0 && this.down == 0) {
-            this.status = false;
+            this.state = null;
           } else if (this.down == this.total) {
-            this.status = "bad";
+            this.state = "offline";
           } else if (this.up == this.total) {
-            this.status = "good";
+            this.state = "online";
           } else {
-            this.status = "warn";
+            this.state = "warning";
           }
-        })
-        .catch((e) => {
-          console.error(e);
-        });
+        }),
+      );
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.status {
-  font-size: 0.8rem;
-  color: var(--text-title);
-  &.good:before {
-    background-color: #94e185;
-    border-color: #78d965;
-    box-shadow: 0 0 5px 1px #94e185;
-  }
-  &.warn:before {
-    background-color: #f8a306;
-    border-color: #e1b35e;
-    box-shadow: 0 0 5px 1px #f8a306;
-  }
-  &.bad:before {
-    background-color: #c9404d;
-    border-color: #c42c3b;
-    box-shadow: 0 0 5px 1px #c9404d;
-  }
-  &:before {
-    content: " ";
-    display: inline-block;
-    width: 7px;
-    height: 7px;
-    margin-right: 10px;
-    border: 1px solid #000;
-    border-radius: 7px;
-  }
-}
-</style>

--- a/src/components/services/Generic.vue
+++ b/src/components/services/Generic.vue
@@ -30,17 +30,14 @@
             </div>
           </slot>
           <div class="card-body">
-            <!-- TODO(cards-migrate-to-api): drop #content once every card is migrated. -->
-            <slot name="content">
-              <p class="title">{{ item.name }}</p>
-              <div
-                v-if="item.subtitle || $slots.subtitle || subtitle"
-                class="subtitle"
-              >
-                <template v-if="item.subtitle">{{ item.subtitle }}</template>
-                <slot v-else name="subtitle">{{ subtitle }}</slot>
-              </div>
-            </slot>
+            <p class="title">{{ item.name }}</p>
+            <div
+              v-if="item.subtitle || $slots.subtitle || subtitle"
+              class="subtitle"
+            >
+              <template v-if="item.subtitle">{{ item.subtitle }}</template>
+              <slot v-else name="subtitle">{{ subtitle }}</slot>
+            </div>
           </div>
           <div v-if="$slots.badges || visibleBadges.length" class="card-badges">
             <slot name="badges">
@@ -60,17 +57,11 @@
               </a>
             </slot>
           </div>
-          <div
-            v-if="$slots.aside || $slots.indicator || status"
-            class="card-aside"
-          >
+          <div v-if="$slots.aside || status" class="card-aside">
             <slot name="aside">
-              <!-- TODO(cards-migrate-to-api): drop #indicator once every card is migrated. -->
-              <slot name="indicator">
-                <div v-if="status" class="status" :class="status.state">
-                  {{ status.label }}
-                </div>
-              </slot>
+              <div v-if="status" class="status" :class="status.state">
+                {{ status.label }}
+              </div>
             </slot>
           </div>
           <div v-if="item.quick || item.tag" class="card-lane">

--- a/src/components/services/Gitea.vue
+++ b/src/components/services/Gitea.vue
@@ -1,22 +1,9 @@
 <template>
-  <Generic :item="item">
-    <template #content>
-      <p class="title is-4">{{ item.name }}</p>
-      <p class="subtitle is-6">
-        <template v-if="item.subtitle">
-          {{ item.subtitle }}
-        </template>
-        <template v-else-if="versionstring">
-          Version {{ versionstring }}
-        </template>
-      </p>
-    </template>
-    <template #indicator>
-      <div v-if="status" class="status" :class="status">
-        {{ status }}
-      </div>
-    </template>
-  </Generic>
+  <Generic
+    :item="item"
+    :subtitle="versionSubtitle"
+    :status="reachabilityStatus()"
+  />
 </template>
 
 <script>
@@ -25,64 +12,18 @@ import service from "@/mixins/service.js";
 export default {
   name: "Gitea",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => ({
-    fetchOk: null,
+    serverError: null,
     versionstring: null,
   }),
-  computed: {
-    status: function () {
-      return this.fetchOk ? "online" : "offline";
-    },
-  },
-  created() {
-    this.fetchStatus();
-  },
   methods: {
-    fetchStatus: async function () {
-      this.fetch("/swagger.v1.json")
-        .then((response) => {
-          this.fetchOk = true;
+    fetchData: function () {
+      return this.load(
+        this.fetch("/swagger.v1.json").then((response) => {
           this.versionstring = response.info.version;
-        })
-        .catch((e) => {
-          this.fetchOk = false;
-          console.log(e);
-        });
+        }),
+      );
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.status {
-  font-size: 0.8rem;
-  color: var(--text-title);
-  white-space: nowrap;
-  margin-left: 0.25rem;
-
-  &.online:before {
-    background-color: #94e185;
-    border-color: #78d965;
-    box-shadow: 0 0 5px 1px #94e185;
-  }
-
-  &.offline:before {
-    background-color: #c9404d;
-    border-color: #c42c3b;
-    box-shadow: 0 0 5px 1px #c9404d;
-  }
-
-  &:before {
-    content: " ";
-    display: inline-block;
-    width: 7px;
-    height: 7px;
-    margin-right: 10px;
-    border: 1px solid #000;
-    border-radius: 7px;
-  }
-}
-</style>

--- a/src/components/services/Glances.vue
+++ b/src/components/services/Glances.vue
@@ -1,16 +1,13 @@
 <template>
-  <Generic :item="item">
-    <template #content>
-      <p class="title is-4">{{ item.name }}</p>
-      <p class="subtitle is-6">
-        <template v-for="(statItem, index) in item.stats" :key="statItem">
-          <span v-if="stats[statItem]" :title="stats[statItem].label">
-            <i :class="stats[statItem].icon"></i> {{ stats[statItem].value }}
-            {{ stats[statItem].unit }}
-            <span v-if="index != item.stats.length - 1"> / </span>
-          </span>
-        </template>
-      </p>
+  <Generic :item="item" :badges="badges">
+    <template #subtitle>
+      <template v-for="(statItem, index) in item.stats" :key="statItem">
+        <span v-if="stats[statItem]" :title="stats[statItem].label">
+          <i :class="stats[statItem].icon"></i> {{ stats[statItem].value }}
+          {{ stats[statItem].unit }}
+          <span v-if="index != item.stats.length - 1"> / </span>
+        </span>
+      </template>
     </template>
   </Generic>
 </template>
@@ -21,24 +18,19 @@ import service from "@/mixins/service.js";
 export default {
   name: "Glances",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => ({
     stats: [],
-    error: null,
+    serverError: null,
   }),
-  created() {
-    // Set up auto-update method for the scheduler
-    this.autoUpdateMethod = this.fetchStat;
-
-    // Initial data fetch
-    this.fetchStat();
+  computed: {
+    badges() {
+      return [this.connectionBadge()];
+    },
   },
   methods: {
-    fetchStat: async function () {
-      this.fetch(`/api/4/quicklook`)
-        .then((response) => {
+    fetchData: function () {
+      return this.load(
+        this.fetch(`/api/4/quicklook`).then((response) => {
           this.stats["load"] = {
             value: response.load,
             label: "System load",
@@ -63,11 +55,8 @@ export default {
             icon: "fa-solid fa-file-arrow-down",
             unit: "%",
           };
-        })
-        .catch((e) => {
-          console.log(e);
-          this.error = "Unable to get metrics";
-        });
+        }),
+      );
     },
   },
 };

--- a/src/components/services/Gotify.vue
+++ b/src/components/services/Gotify.vue
@@ -1,108 +1,59 @@
 <template>
-  <Generic :item="item">
-    <template #content>
-      <p class="title is-4">{{ item.name }}</p>
-      <p class="subtitle is-6">
-        <template v-if="messages > 0">
-          <template v-if="messages > 100">100+</template>
-          <template v-else>{{ messages }}</template>
-          <template v-if="messages === 1"> message</template>
-          <template v-else> messages</template>
-        </template>
-      </p>
-    </template>
-    <template #indicator>
-      <div v-if="status" class="status" :class="status"></div>
-    </template>
-  </Generic>
+  <Generic :item="item" :subtitle="messageCount" :status="status" />
 </template>
 
 <script>
 import service from "@/mixins/service.js";
+import { capCount } from "@/utils/format.js";
 
 export default {
   name: "Gotify",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => ({
     health: {},
     messages: 0,
+    serverError: null,
   }),
   computed: {
+    messageCount: function () {
+      if (!this.messages) {
+        return null;
+      }
+      const count = capCount(this.messages);
+      return `${count} message${this.messages === 1 ? "" : "s"}`;
+    },
     status: function () {
+      if (this.serverError || !this.health?.health) {
+        return this.reachabilityStatus();
+      }
       const statuses = [this.health.health, this.health.database];
 
       if (statuses.includes("red")) {
-        return "red";
+        return { state: "offline" };
       } else if (statuses.includes("orange")) {
-        return "orange";
+        return { state: "warning" };
       }
 
-      return "green";
+      return { state: "online" };
     },
-  },
-  created() {
-    // Set up auto-update method for the scheduler
-    this.autoUpdateMethod = this.fetchAll;
-
-    // Initial data fetch
-    this.fetchAll();
   },
   methods: {
-    fetchAll: async function () {
-      this.fetchStatus();
-      this.fetchMessages();
-    },
-    fetchStatus: async function () {
-      await this.fetch(`/health`)
-        .catch((e) => console.log(e))
-        .then((resp) => (this.health = resp));
-    },
-    fetchMessages: async function () {
-      const headers = {
-        "X-Gotify-Key": this.item.apikey,
-      };
-      await this.fetch(`/message?limit=100`, { headers })
-        .catch((e) => console.log(e))
-        .then((resp) => (this.messages = resp.messages.length));
+    fetchData: function () {
+      const headers = { "X-Gotify-Key": this.item.apikey };
+
+      return this.load(
+        this.fetch(`/health`).then((health) => {
+          this.health = health;
+        }),
+        // Needs a client token, and only feeds the subtitle, so a missing key
+        // must not make the whole card look unreachable.
+        this.fetch(`/message?limit=100`, { headers })
+          .then((messages) => {
+            this.messages = messages.messages.length;
+          })
+          .catch((e) => console.warn("Gotify messages unavailable:", e)),
+      );
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.status {
-  font-size: 0.8rem;
-  color: var(--text-title);
-
-  &.green:before {
-    background-color: #94e185;
-    border-color: #78d965;
-    box-shadow: 0 0 5px 1px #94e185;
-  }
-
-  &.orange:before {
-    background-color: #ee863e;
-    border-color: #e77322;
-    box-shadow: 0 0 5px 1px #ee863e;
-  }
-
-  &.red:before {
-    background-color: #c9404d;
-    border-color: #c42c3b;
-    box-shadow: 0 0 5px 1px #c9404d;
-  }
-
-  &:before {
-    content: " ";
-    display: inline-block;
-    width: 7px;
-    height: 7px;
-    margin-right: 10px;
-    border: 1px solid #000;
-    border-radius: 7px;
-  }
-}
-</style>

--- a/src/components/services/Healthchecks.vue
+++ b/src/components/services/Healthchecks.vue
@@ -1,19 +1,5 @@
 <template>
-  <Generic :item="item">
-    <template #indicator>
-      <div class="notifs">
-        <strong v-if="up > 0" class="notif up" title="Up">
-          {{ up }}
-        </strong>
-        <strong v-if="down > 0" class="notif down" title="Down">
-          {{ down }}
-        </strong>
-        <strong v-if="grace > 0" class="notif grace" title="Grace">
-          {{ grace }}
-        </strong>
-      </div>
-    </template>
-  </Generic>
+  <Generic :item="item" :badges="badges" />
 </template>
 
 <script>
@@ -22,52 +8,38 @@ import service from "@/mixins/service.js";
 export default {
   name: "Healthchecks",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => ({
     api: null,
+    serverError: null,
   }),
   computed: {
-    up: function () {
-      if (!this.api) {
-        return "";
-      }
-      return this.api.checks?.filter((check) => {
-        return check.status.toLowerCase() === "up";
-      }).length;
+    badges() {
+      return [
+        { key: "up", label: "Up", value: this.count("up"), tone: "success" },
+        {
+          key: "down",
+          label: "Down",
+          value: this.count("down"),
+          tone: "danger",
+        },
+        {
+          key: "grace",
+          label: "Grace",
+          value: this.count("grace"),
+          tone: "warning",
+        },
+        this.connectionBadge(),
+      ];
     },
-    down: function () {
-      if (!this.api) {
-        return "";
-      }
-      return this.api.checks?.filter((check) => {
-        return check.status.toLowerCase() === "down";
-      }).length;
-    },
-    grace: function () {
-      if (!this.api) {
-        return "";
-      }
-      return this.api.checks?.filter((check) => {
-        return check.status.toLowerCase() === "grace";
-      }).length;
-    },
-  },
-  created() {
-    // Set up auto-update method for the scheduler
-    this.autoUpdateMethod = this.fetchStatus;
-
-    // Initial data fetch
-    this.fetchStatus();
   },
   methods: {
-    fetchStatus: async function () {
-      const apikey = this.item.apikey;
-      if (!apikey) {
-        console.error(
-          "apikey is not present in config.yml for the Healthchecks entry!",
-        );
+    count(status) {
+      return this.api?.checks?.filter(
+        (check) => check.status.toLowerCase() === status,
+      ).length;
+    },
+    fetchData: async function () {
+      if (!this.requireConfig("apikey")) {
         return;
       }
 
@@ -75,41 +47,12 @@ export default {
         "X-Api-Key": this.item.apikey,
       };
 
-      this.api = await this.fetch("/api/v1/checks/", { headers }).catch((e) => {
-        console.error(e);
-      });
+      return this.load(
+        this.fetch("/api/v1/checks/", { headers }).then((api) => {
+          this.api = api;
+        }),
+      );
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.notifs {
-  position: absolute;
-  color: white;
-  font-family: sans-serif;
-  top: 0.3em;
-  right: 0.5em;
-
-  .notif {
-    display: inline-block;
-    padding: 0.2em 0.35em;
-    border-radius: 0.25em;
-    position: relative;
-    margin-left: 0.3em;
-    font-size: 0.8em;
-
-    &.up {
-      background-color: #4fd671;
-    }
-
-    &.down {
-      background-color: #e51111;
-    }
-
-    &.grace {
-      background-color: #cdd02e;
-    }
-  }
-}
-</style>

--- a/src/components/services/HomeAssistant.vue
+++ b/src/components/services/HomeAssistant.vue
@@ -1,22 +1,5 @@
 <template>
-  <Generic :item="item">
-    <template #content>
-      <p class="title is-4">{{ item.name }}</p>
-      <p class="subtitle is-6">
-        <template v-if="item.subtitle">
-          {{ item.subtitle }}
-        </template>
-        <template v-else>
-          {{ details }}
-        </template>
-      </p>
-    </template>
-    <template #indicator>
-      <div v-if="status" class="status" :class="status">
-        {{ status }}
-      </div>
-    </template>
-  </Generic>
+  <Generic :item="item" :subtitle="details" :status="status" />
 </template>
 
 <script>
@@ -25,11 +8,8 @@ import service from "@/mixins/service.js";
 export default {
   name: "HomeAssistant",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => ({
-    status: "",
+    status: null,
     version: "",
     entities: 0,
     location_name: "",
@@ -69,28 +49,30 @@ export default {
       return details.join(separator);
     },
   },
-  created() {
-    this.fetchServerStatus().then(() => {
-      if (!this.item.subtitle && this.status !== "dead") {
+  methods: {
+    fetchData: function () {
+      return this.fetchServerStatus().then(() => {
+        if (this.item.subtitle || this.status?.state === "offline") {
+          return;
+        }
         if (this.item.items) this.items = this.item.items;
         if (this.item.separator) this.separator = this.item.separator;
 
-        this.fetchServerStats();
-      }
-    });
-  },
-  methods: {
+        return this.fetchServerStats();
+      });
+    },
     fetchServerStatus: async function () {
       const headers = this.headers;
 
       return this.fetch("/api/", { headers })
         .then((response) => {
-          if (response && response.message) this.status = "running";
+          if (response && response.message)
+            this.status = { state: "online", label: "running" };
           else throw new Error();
         })
         .catch((e) => {
-          console.log(e);
-          this.status = "dead";
+          console.error(e);
+          this.status = { state: "offline", label: "dead" };
         });
     },
     fetchServerStats: async function () {
@@ -105,8 +87,8 @@ export default {
           } else throw new Error();
         })
         .catch((e) => {
-          console.log(e);
-          this.status = "dead";
+          console.error(e);
+          this.status = { state: "offline", label: "dead" };
         });
 
       this.fetch("/api/states", { headers })
@@ -116,39 +98,10 @@ export default {
           } else throw new Error();
         })
         .catch((e) => {
-          console.log(e);
-          this.status = "dead";
+          console.error(e);
+          this.status = { state: "offline", label: "dead" };
         });
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.status {
-  font-size: 0.8rem;
-  color: var(--text-title);
-
-  &.running:before {
-    background-color: #94e185;
-    border-color: #78d965;
-    box-shadow: 0 0 5px 1px #94e185;
-  }
-
-  &.dead:before {
-    background-color: #c9404d;
-    border-color: #c42c3b;
-    box-shadow: 0 0 5px 1px #c9404d;
-  }
-
-  &:before {
-    content: " ";
-    display: inline-block;
-    width: 7px;
-    height: 7px;
-    margin-right: 10px;
-    border: 1px solid #000;
-    border-radius: 7px;
-  }
-}
-</style>

--- a/src/components/services/HyperHDR.vue
+++ b/src/components/services/HyperHDR.vue
@@ -1,30 +1,10 @@
 <template>
-  <Generic :item="item">
-    <template #content>
-      <p class="title is-4">{{ item.name }}</p>
-      <p class="subtitle is-6">
-        <template v-if="item.subtitle">
-          {{ item.subtitle }}
-        </template>
-        <template v-else-if="currentInstance">
-          Current instance: {{ currentInstance }}
-        </template>
-      </p>
-    </template>
-    <template #indicator>
-      <div class="notifs">
-        <strong v-if="running > 0" class="notif running" title="Running">
-          {{ running }}
-        </strong>
-        <strong v-if="stopped > 0" class="notif stopped" title="Stopped">
-          {{ stopped }}
-        </strong>
-      </div>
-      <div v-if="status" class="status" :class="status">
-        {{ status }}
-      </div>
-    </template>
-  </Generic>
+  <Generic
+    :item="item"
+    :subtitle="currentInstance && `Current instance: ${currentInstance}`"
+    :status="reachabilityStatus()"
+    :badges="badges"
+  />
 </template>
 <script>
 import service from "@/mixins/service.js";
@@ -34,12 +14,9 @@ const ENDPPOINT_SERVER_INFO = "/json-rpc?request=";
 export default {
   name: "HyperHDR",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => ({
     serverInfo: null,
-    error: false,
+    serverError: null,
   }),
   computed: {
     instances: function () {
@@ -49,9 +26,8 @@ export default {
 
     currentInstance: function () {
       const instanceId = this.serverInfo?.info?.currentInstance;
-      return this.instances.find(
-        (instance) => instance.instance === instanceId
-      )?.friendly_name;
+      return this.instances.find((instance) => instance.instance === instanceId)
+        ?.friendly_name;
     },
 
     running: function () {
@@ -59,11 +35,10 @@ export default {
         return 0;
       }
 
-      return this.instances.filter(
-        (instance) => instance.running === true
-      ).length;
+      return this.instances.filter((instance) => instance.running === true)
+        .length;
     },
-    
+
     stopped: function () {
       if (!this.instances) {
         return 0;
@@ -72,15 +47,25 @@ export default {
       return this.instances.length - this.running;
     },
 
-    status: function () {
-      return !this.error ? "online" : "offline";
+    badges() {
+      return [
+        {
+          key: "running",
+          label: "Running",
+          value: this.running,
+          tone: "success",
+        },
+        {
+          key: "stopped",
+          label: "Stopped",
+          value: this.stopped,
+          tone: "neutral",
+        },
+      ];
     },
   },
-  created() {
-    this.fetchStatus();
-  },
   methods: {
-    fetchStatus: async function () {
+    fetchData: async function () {
       const headers = {};
 
       const command = {
@@ -88,45 +73,15 @@ export default {
       };
 
       const requestUrl = `${ENDPPOINT_SERVER_INFO}${encodeURIComponent(
-        JSON.stringify(command)
+        JSON.stringify(command),
       )}`;
 
-      try {
-        const response = await this.fetch(requestUrl, { headers });
-        this.error = false;
-        this.serverInfo = response;
-      } catch (e) {
-        this.error = true;
-        console.error(e);
-      }
+      return this.load(
+        this.fetch(requestUrl, { headers }).then((response) => {
+          this.serverInfo = response;
+        }),
+      );
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.notifs {
-  position: absolute;
-  color: white;
-  font-family: sans-serif;
-  top: 0.3em;
-  right: 0.5em;
-
-  .notif {
-    display: inline-block;
-    padding: 0.2em 0.35em;
-    border-radius: 0.25em;
-    position: relative;
-    margin-left: 0.3em;
-    font-size: 0.8em;
-
-    &.running {
-      background-color: #4fd671;
-    }
-
-    &.stopped {
-      background-color: #e51111;
-    }
-  }
-}
-</style>

--- a/src/components/services/Immich.vue
+++ b/src/components/services/Immich.vue
@@ -1,124 +1,54 @@
 <template>
-  <Generic :item="item">
-    <template #indicator>
-      <div class="notifs">
-        <strong v-if="users > 0" class="notif users" title="Users">
-          {{ users }}
-        </strong>
-        <strong v-if="photos > 0" class="notif photos" title="Photos">
-          {{ photos }}
-        </strong>
-        <strong v-if="videos > 0" class="notif videos" title="Videos">
-          {{ videos }}
-        </strong>
-        <strong v-if="usage > 0" class="notif usage" title="Usage">
-          {{ humanizeSize }}
-        </strong>
-        <strong
-          v-if="serverError"
-          class="notif errors"
-          title="Connection error to Immich API, check your url and apikey in config.yml"
-          >?</strong
-        >
-      </div>
-    </template>
-  </Generic>
+  <Generic :item="item" :badges="badges" />
 </template>
 
 <script>
 import service from "@/mixins/service.js";
+import { displaySize } from "@/utils/format.js";
 
 export default {
   name: "Immich",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => {
     return {
       users: null,
       photos: null,
       videos: null,
       usage: null,
-      serverError: false,
+      serverError: null,
     };
   },
   computed: {
-    humanizeSize: function () {
-      let bytes = this.usage;
-      if (Math.abs(bytes) < 1024) return bytes + " B";
-
-      const units = ["KiB", "MiB", "GiB", "TiB"];
-      let u = -1;
-      do {
-        bytes /= 1024;
-        ++u;
-      } while (
-        Math.round(Math.abs(bytes) * 100) / 100 >= 1024 &&
-        u < units.length - 1
-      );
-
-      return bytes.toFixed(2) + " " + units[u];
+    badges() {
+      return [
+        { key: "users", label: "Users", value: this.users, tone: "success" },
+        { key: "photos", label: "Photos", value: this.photos, tone: "info" },
+        { key: "videos", label: "Videos", value: this.videos, tone: "warning" },
+        {
+          key: "usage",
+          label: "Usage",
+          value: this.usage ? displaySize(this.usage) : null,
+          tone: "neutral",
+        },
+        this.connectionBadge(),
+      ];
     },
   },
-  created: function () {
-    // Set up auto-update method for the scheduler
-    this.autoUpdateMethod = this.fetchConfig;
-
-    // Initial data fetch
-    this.fetchConfig();
-  },
   methods: {
-    fetchConfig: function () {
+    fetchData: function () {
       const headers = {
         "x-api-key": this.item.apikey,
       };
 
-      this.fetch(`/api/server/statistics`, { headers })
-        .then((stats) => {
+      return this.load(
+        this.fetch(`/api/server/statistics`, { headers }).then((stats) => {
           this.photos = stats.photos;
           this.videos = stats.videos;
           this.usage = stats.usage;
           this.users = stats.usageByUser.length;
-        })
-        .catch((e) => {
-          console.error(e);
-          this.serverError = true;
-        });
+        }),
+      );
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.notifs {
-  position: absolute;
-  color: white;
-  font-family: sans-serif;
-  top: 0.3em;
-  right: 0.5em;
-  .notif {
-    display: inline-block;
-    padding: 0.2em 0.35em;
-    border-radius: 0.25em;
-    position: relative;
-    margin-left: 0.3em;
-    font-size: 0.8em;
-    &.photos {
-      background-color: #4fb5d6;
-    }
-
-    &.videos {
-      background-color: #d08d2e;
-    }
-
-    &.usage {
-      background-color: #e51111;
-    }
-
-    &.users {
-      background-color: #8dd475;
-    }
-  }
-}
-</style>

--- a/src/components/services/Jellystat.vue
+++ b/src/components/services/Jellystat.vue
@@ -1,98 +1,43 @@
 <template>
-  <Generic :item="item">
-    <template #indicator>
-      <div class="notifs">
-        <strong
-          v-if="streams > 0"
-          class="notif playing"
-          :title="`${streams} active stream${streams > 1 ? 's' : ''}`"
-        >
-          {{ streams }}
-        </strong>
-        <i
-          v-if="error"
-          class="notif error fa-solid fa-triangle-exclamation"
-          title="Unable to fetch current status"
-        ></i>
-      </div>
-    </template>
-  </Generic>
+  <Generic :item="item" :badges="badges" />
 </template>
 <script>
 import service from "@/mixins/service.js";
 
 export default {
-  name: "Jellyfin",
+  name: "Jellystat",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => ({
     stats: null,
-    error: false,
+    serverError: null,
   }),
   computed: {
     streams: function () {
-      if (!this.stats) {
-        return "";
-      }
-      let nb_streams = 0;
-      for (let stream of this.stats) {
-        if ("NowPlayingItem" in stream) nb_streams++;
-      }
-      return nb_streams;
+      return this.stats?.filter((stream) => "NowPlayingItem" in stream).length;
+    },
+    badges() {
+      return [
+        {
+          key: "streams",
+          label: "Active streams",
+          value: this.streams,
+          tone: "success",
+        },
+        this.connectionBadge(),
+      ];
     },
   },
-  created() {
-    // Set up auto-update method for the scheduler
-    this.autoUpdateMethod = this.fetchStatus;
-
-    // Initial data fetch
-    this.fetchStatus();
-  },
   methods: {
-    fetchStatus: async function () {
+    fetchData: function () {
       const headers = {
         Authorization: `bearer ${this.item.apikey}`,
       };
-      try {
-        const response = await this.fetch("/proxy/getSessions", { headers });
-        this.error = false;
-        this.stats = response;
-      } catch (e) {
-        this.error = true;
-        console.error(e);
-      }
+      return this.load(
+        this.fetch("/proxy/getSessions", { headers }).then((response) => {
+          this.stats = response;
+        }),
+      );
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.notifs {
-  position: absolute;
-  color: white;
-  font-family: sans-serif;
-  top: 0.3em;
-  right: 0.5em;
-
-  .notif {
-    display: inline-block;
-    padding: 0.2em 0.35em;
-    border-radius: 0.25em;
-    position: relative;
-    margin-left: 0.3em;
-    font-size: 0.8em;
-
-    &.playing {
-      background-color: #28a9a3;
-    }
-
-    &.error {
-      border-radius: 50%;
-      aspect-ratio: 1;
-      background-color: #e51111;
-    }
-  }
-}
-</style>

--- a/src/components/services/LibrisLog.vue
+++ b/src/components/services/LibrisLog.vue
@@ -1,38 +1,5 @@
 <template>
-  <Generic :item="item">
-    <template #content>
-      <p class="title is-4">{{ item.name }}</p>
-      <p class="subtitle is-6">
-        <template v-if="item.subtitle">{{ item.subtitle }}</template>
-        <template v-else-if="statsText">{{ statsText }}</template>
-      </p>
-    </template>
-    <template #indicator>
-      <div class="notifs">
-        <strong
-          v-if="stats && stats.books_reading > 0"
-          class="notif reading"
-          title="Currently reading"
-        >
-          {{ stats.books_reading }}
-        </strong>
-        <strong
-          v-if="stats && stats.books_want_to_read > 0"
-          class="notif want-to-read"
-          title="Want to read"
-        >
-          {{ stats.books_want_to_read }}
-        </strong>
-        <strong
-          v-if="serverError"
-          class="notif errors"
-          title="Connection error to LibrisLog API, check url and apikey in config.yml"
-        >
-          ?
-        </strong>
-      </div>
-    </template>
-  </Generic>
+  <Generic :item="item" :subtitle="statsText" :badges="badges" />
 </template>
 
 <script>
@@ -41,68 +8,44 @@ import service from "@/mixins/service.js";
 export default {
   name: "LibrisLog",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => ({
     stats: null,
-    serverError: false,
+    serverError: null,
   }),
   computed: {
     statsText() {
       if (!this.stats) return null;
       return `${this.stats.books_read} / ${this.stats.total_books} books read`;
     },
-  },
-  created() {
-    this.autoUpdateMethod = this.fetchStats;
-    this.fetchStats();
+    badges() {
+      return [
+        {
+          key: "reading",
+          label: "Currently reading",
+          value: this.stats?.books_reading,
+          tone: "info",
+        },
+        {
+          key: "want-to-read",
+          label: "Want to read",
+          value: this.stats?.books_want_to_read,
+          tone: "accent",
+        },
+        this.connectionBadge(),
+      ];
+    },
   },
   methods: {
-    fetchStats() {
+    fetchData() {
       const headers = {
         "X-API-Key": this.item.apikey,
       };
-      this.fetch("/api/books/stats", { headers })
-        .then((data) => {
+      return this.load(
+        this.fetch("/api/books/stats", { headers }).then((data) => {
           this.stats = data;
-        })
-        .catch((e) => {
-          console.error(e);
-          this.serverError = true;
-        });
+        }),
+      );
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.notifs {
-  position: absolute;
-  color: white;
-  font-family: sans-serif;
-  top: 0.3em;
-  right: 0.5em;
-
-  .notif {
-    display: inline-block;
-    padding: 0.2em 0.35em;
-    border-radius: 0.25em;
-    position: relative;
-    margin-left: 0.3em;
-    font-size: 0.8em;
-
-    &.reading {
-      background-color: #4fb5d6;
-    }
-
-    &.want-to-read {
-      background-color: #9d00ff;
-    }
-
-    &.errors {
-      background-color: #e51111;
-    }
-  }
-}
-</style>

--- a/src/components/services/Lidarr.vue
+++ b/src/components/services/Lidarr.vue
@@ -1,28 +1,5 @@
 <template>
-  <Generic :item="item">
-    <template #indicator>
-      <div class="notifs">
-        <strong v-if="activity > 0" class="notif activity" title="Activity">
-          {{ activity }}
-        </strong>
-        <strong v-if="missing > 0" class="notif missing" title="Missing">
-          {{ missing }}
-        </strong>
-        <strong v-if="warnings > 0" class="notif warnings" title="Warning">
-          {{ warnings }}
-        </strong>
-        <strong v-if="errors > 0" class="notif errors" title="Error">
-          {{ errors }}
-        </strong>
-        <strong
-          v-if="serverError"
-          class="notif errors"
-          title="Connection error to Lidarr API, check url and apikey in config.yml"
-          >?</strong
-        >
-      </div>
-    </template>
-  </Generic>
+  <Generic :item="item" :badges="badges" />
 </template>
 
 <script>
@@ -31,91 +8,69 @@ import service from "@/mixins/service.js";
 export default {
   name: "Lidarr",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => {
     return {
       activity: null,
       missing: null,
       warnings: null,
       errors: null,
-      serverError: false,
+      serverError: null,
     };
   },
-  created() {
-    // Set up auto-update method for the scheduler
-    this.autoUpdateMethod = this.fetchConfig;
-
-    // Initial data fetch
-    this.fetchConfig();
+  computed: {
+    badges() {
+      return [
+        {
+          key: "activity",
+          label: "Activity",
+          value: this.activity,
+          tone: "info",
+        },
+        {
+          key: "missing",
+          label: "Missing",
+          value: this.missing,
+          tone: "accent",
+        },
+        {
+          key: "warnings",
+          label: "Warning",
+          value: this.warnings,
+          tone: "warning",
+        },
+        { key: "errors", label: "Error", value: this.errors, tone: "danger" },
+        this.connectionBadge(),
+      ];
+    },
   },
   methods: {
-    fetchConfig: function () {
-      const handleError = (e) => {
-        console.error(e);
-        this.serverError = true;
-      };
-      this.fetch(`/api/v1/health?apikey=${this.item.apikey}`)
-        .then((health) => {
-          this.warnings = 0;
-          this.errors = 0;
-          for (var i = 0; i < health.length; i++) {
-            if (health[i].type == "warning") {
-              this.warnings++;
-            } else if (health[i].type == "error") {
-              this.errors++;
+    fetchData: function () {
+      return this.load(
+        this.fetch(`/api/v1/health?apikey=${this.item.apikey}`).then(
+          (health) => {
+            this.warnings = 0;
+            this.errors = 0;
+            for (var i = 0; i < health.length; i++) {
+              if (health[i].type == "warning") {
+                this.warnings++;
+              } else if (health[i].type == "error") {
+                this.errors++;
+              }
             }
-          }
-        })
-        .catch(handleError);
-      this.fetch(`/api/v1/queue/status?apikey=${this.item.apikey}`)
-        .then((queue) => {
-          this.activity = queue.totalCount;
-        })
-        .catch(handleError);
-      this.fetch(`/api/v1/wanted/missing?apikey=${this.item.apikey}`)
-        .then((queue) => {
-          this.missing = queue.totalRecords;
-        })
-        .catch(handleError);
+          },
+        ),
+        this.fetch(`/api/v1/queue/status?apikey=${this.item.apikey}`).then(
+          (queue) => {
+            this.activity = queue.totalCount;
+          },
+        ),
+        this.fetch(`/api/v1/wanted/missing?apikey=${this.item.apikey}`).then(
+          (queue) => {
+            this.missing = queue.totalRecords;
+          },
+        ),
+      );
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.notifs {
-  position: absolute;
-  color: white;
-  font-family: sans-serif;
-  top: 0.3em;
-  right: 0.5em;
-  .notif {
-    display: inline-block;
-    padding-right: 0.35em;
-    padding-left: 0.35em;
-    padding-top: 0.2em;
-    padding-bottom: 0.2em;
-    border-radius: 0.25em;
-    position: relative;
-    margin-left: 0.3em;
-    font-size: 0.8em;
-    &.activity {
-      background-color: #4fb5d6;
-    }
-
-    &.missing {
-      background-color: #9d00ff;
-    }
-
-    &.warnings {
-      background-color: #d08d2e;
-    }
-
-    &.errors {
-      background-color: #e51111;
-    }
-  }
-}
-</style>

--- a/src/components/services/Linkding.vue
+++ b/src/components/services/Linkding.vue
@@ -13,9 +13,6 @@ export default {
     Generic,
   },
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => ({
     bookmarks: [],
   }),
@@ -25,15 +22,8 @@ export default {
       return Math.min(Math.max(limit, 1), 15);
     },
   },
-  created() {
-    // Set up auto-update method for the scheduler
-    this.autoUpdateMethod = this.fetchBookmarks;
-
-    // Initial data fetch
-    this.fetchBookmarks();
-  },
   methods: {
-    fetchBookmarks: async function () {
+    fetchData: async function () {
       const headers = {
         Authorization: `Token ${this.item.token}`,
         Accept: "application/json",
@@ -59,7 +49,7 @@ export default {
           }));
         })
         .catch((e) => {
-          console.log(e);
+          console.error(e);
         });
     },
   },

--- a/src/components/services/Matrix.vue
+++ b/src/components/services/Matrix.vue
@@ -1,22 +1,9 @@
 <template>
-  <Generic :item="item">
-    <template #content>
-      <p class="title is-4">{{ item.name }}</p>
-      <p class="subtitle is-6">
-        <template v-if="item.subtitle">
-          {{ item.subtitle }}
-        </template>
-        <template v-else-if="versionstring">
-          Version {{ versionstring }}
-        </template>
-      </p>
-    </template>
-    <template #indicator>
-      <div v-if="status" class="status" :class="status">
-        {{ status }}
-      </div>
-    </template>
-  </Generic>
+  <Generic
+    :item="item"
+    :subtitle="versionSubtitle"
+    :status="reachabilityStatus()"
+  />
 </template>
 
 <script>
@@ -25,64 +12,18 @@ import service from "@/mixins/service.js";
 export default {
   name: "Matrix",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => ({
-    fetchOk: null,
+    serverError: null,
     versionstring: null,
   }),
-  computed: {
-    status: function () {
-      return this.fetchOk ? "online" : "offline";
-    },
-  },
-  created() {
-    this.fetchStatus();
-  },
   methods: {
-    fetchStatus: async function () {
-      this.fetch("_matrix/federation/v1/version")
-        .then((response) => {
-          this.fetchOk = true;
+    fetchData: function () {
+      return this.load(
+        this.fetch("_matrix/federation/v1/version").then((response) => {
           this.versionstring = response.server.version;
-        })
-        .catch((e) => {
-          this.fetchOk = false;
-          console.log(e);
-        });
+        }),
+      );
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.status {
-  font-size: 0.8rem;
-  color: var(--text-title);
-  white-space: nowrap;
-  margin-left: 0.25rem;
-
-  &.online:before {
-    background-color: #94e185;
-    border-color: #78d965;
-    box-shadow: 0 0 5px 1px #94e185;
-  }
-
-  &.offline:before {
-    background-color: #c9404d;
-    border-color: #c42c3b;
-    box-shadow: 0 0 5px 1px #c9404d;
-  }
-
-  &:before {
-    content: " ";
-    display: inline-block;
-    width: 7px;
-    height: 7px;
-    margin-right: 10px;
-    border: 1px solid #000;
-    border-radius: 7px;
-  }
-}
-</style>

--- a/src/components/services/Mealie.vue
+++ b/src/components/services/Mealie.vue
@@ -1,20 +1,5 @@
 <template>
-  <Generic :item="item">
-    <template #content>
-      <p class="title is-4">{{ item.name }}</p>
-      <p class="subtitle is-6">
-        <template v-if="item.subtitle">
-          {{ item.subtitle }}
-        </template>
-        <template v-else-if="mealtext">
-          {{ mealtext }}
-        </template>
-        <template v-else-if="statsText">
-          {{ statsText }}
-        </template>
-      </p>
-    </template>
-  </Generic>
+  <Generic :item="item" :subtitle="mealtext || statsText" :badges="badges" />
 </template>
 
 <script>
@@ -23,14 +8,15 @@ import service from "@/mixins/service.js";
 export default {
   name: "Mealie",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => ({
     stats: null,
     meal: null,
+    serverError: null,
   }),
   computed: {
+    badges() {
+      return [this.connectionBadge()];
+    },
     mealtext: function () {
       if (this.meal && this.meal.length > 0) {
         return `Today: ${this.meal[0].recipe.name}`;
@@ -44,11 +30,8 @@ export default {
       return null;
     },
   },
-  created() {
-    this.fetchStatus();
-  },
   methods: {
-    fetchStatus: async function () {
+    fetchData: async function () {
       const headers = {
         Authorization: "Bearer " + this.item.apikey,
         Accept: "application/json",
@@ -56,12 +39,17 @@ export default {
 
       if (this.item.subtitle != null) return;
 
-      this.meal = await this.fetch("/api/groups/mealplans/today", {
-        headers,
-      }).catch((e) => console.log(e));
-      this.stats = await this.fetch("/api/admin/about/statistics", {
-        headers,
-      }).catch((e) => console.log(e));
+      return this.load(
+        this.fetch("/api/groups/mealplans/today", { headers }).then((meal) => {
+          this.meal = meal;
+        }),
+        // Admin-only, so a non-admin key must not sink the whole card.
+        this.fetch("/api/admin/about/statistics", { headers })
+          .then((stats) => {
+            this.stats = stats;
+          })
+          .catch((e) => console.warn("Mealie statistics unavailable:", e)),
+      );
     },
   },
 };

--- a/src/components/services/Medusa.vue
+++ b/src/components/services/Medusa.vue
@@ -1,34 +1,5 @@
 <template>
-  <Generic :item="item">
-    <template #indicator>
-      <div class="notifs">
-        <strong
-          v-if="config !== null && config.system.news.unread > 0"
-          class="notif news"
-          title="News"
-          >{{ config.system.news.unread }}</strong
-        >
-        <strong
-          v-if="config !== null && config.main.logs.numWarnings > 0"
-          class="notif warnings"
-          title="Warning"
-          >{{ config.main.logs.numWarnings }}</strong
-        >
-        <strong
-          v-if="config !== null && config.main.logs.numErrors > 0"
-          class="notif errors"
-          title="Error"
-          >{{ config.main.logs.numErrors }}</strong
-        >
-        <strong
-          v-if="serverError"
-          class="notif errors"
-          title="Connection error to Medusa API, check url and apikey in config.yml"
-          >?</strong
-        >
-      </div>
-    </template>
-  </Generic>
+  <Generic :item="item" :badges="badges" />
 </template>
 
 <script>
@@ -37,66 +8,47 @@ import service from "@/mixins/service.js";
 export default {
   name: "Medusa",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => {
     return {
-      config: null,
-      serverError: false,
+      stats: null,
+      serverError: null,
     };
   },
-  created: function () {
-    // Set up auto-update method for the scheduler
-    this.autoUpdateMethod = this.fetchConfig;
-
-    // Initial data fetch
-    this.fetchConfig();
+  computed: {
+    badges() {
+      return [
+        {
+          key: "news",
+          label: "News",
+          value: this.stats?.system?.news?.unread,
+          tone: "neutral",
+        },
+        {
+          key: "warnings",
+          label: "Warning",
+          value: this.stats?.main?.logs?.numWarnings,
+          tone: "warning",
+        },
+        {
+          key: "errors",
+          label: "Error",
+          value: this.stats?.main?.logs?.numErrors,
+          tone: "danger",
+        },
+        this.connectionBadge(),
+      ];
+    },
   },
   methods: {
-    fetchConfig: function () {
-      this.fetch("/api/v2/config", {
-        headers: { "X-Api-Key": this.item.apikey },
-      })
-        .then((conf) => {
-          this.config = conf;
-        })
-        .catch((e) => {
-          console.log(e);
-          this.serverError = true;
-        });
+    fetchData: function () {
+      return this.load(
+        this.fetch("/api/v2/config", {
+          headers: { "X-Api-Key": this.item.apikey },
+        }).then((conf) => {
+          this.stats = conf;
+        }),
+      );
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.notifs {
-  position: absolute;
-  color: white;
-  font-family: sans-serif;
-  top: 0.3em;
-  right: 0.5em;
-  .notif {
-    padding-right: 0.35em;
-    padding-left: 0.35em;
-    padding-top: 0.2em;
-    padding-bottom: 0.2em;
-    border-radius: 0.25em;
-    position: relative;
-    margin-left: 0.3em;
-    font-size: 0.8em;
-    &.news {
-      background-color: #777777;
-    }
-
-    &.warnings {
-      background-color: #d08d2e;
-    }
-
-    &.errors {
-      background-color: #e51111;
-    }
-  }
-}
-</style>

--- a/src/components/services/Miniflux.vue
+++ b/src/components/services/Miniflux.vue
@@ -1,36 +1,12 @@
 <template>
-  <Generic :item="item">
-    <template #content>
-      <p class="title is-4">{{ item.name }}</p>
-      <p class="subtitle is-6">
-        <template v-if="item.subtitle"> {{ item.subtitle }} </template>
-        <template v-else-if="unreadEntries">
-          <template v-if="unreadFeeds < 2">
-            {{ unreadEntries }} unread
-          </template>
-          <template v-else>
-            {{ unreadEntries }} unread in {{ unreadFeeds }} feeds
-          </template>
-        </template>
-      </p>
-    </template>
-    <template #indicator>
-      <i v-if="loading" class="fa fa-circle-notch fa-spin"></i>
-      <div v-else-if="style == 'status'" class="status" :class="statusClass">
-        {{ status }}
-      </div>
-      <div v-else class="notifs">
-        <strong v-if="unreadEntries > 0" class="notif unread" title="Unread">
-          {{ unreadEntries }}
-        </strong>
-        <strong
-          v-if="!isHealthy"
-          class="notif errors"
-          title="Connection error to Miniflux API, check url and apikey in config.yml"
-        >
-          ?
-        </strong>
-      </div>
+  <Generic
+    :item="item"
+    :subtitle="unreadText"
+    :status="status"
+    :badges="badges"
+  >
+    <template v-if="loading" #aside>
+      <i class="fa fa-circle-notch fa-spin"></i>
     </template>
   </Generic>
 </template>
@@ -41,120 +17,68 @@ import service from "@/mixins/service.js";
 export default {
   name: "Miniflux",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => ({
     unreadEntries: 0,
     unreadFeeds: 0,
-    isHealthy: false,
+    serverError: null,
     loading: true,
-    style: "status",
   }),
   computed: {
-    status: function () {
-      if (!this.isHealthy) {
-        return "Error";
+    style: function () {
+      return this.item.style ?? "status";
+    },
+    unreadText: function () {
+      if (!this.unreadEntries) {
+        return null;
       }
-      return this.unreadEntries > 0 ? "Unread" : "Online";
+      return this.unreadFeeds < 2
+        ? `${this.unreadEntries} unread`
+        : `${this.unreadEntries} unread in ${this.unreadFeeds} feeds`;
     },
-    statusClass: function () {
-      return this.status.toLowerCase();
+    status: function () {
+      if (this.loading || this.style !== "status") {
+        return null;
+      }
+      if (this.serverError) {
+        return { state: "offline", label: "error" };
+      }
+      return this.unreadEntries > 0
+        ? { state: "warning", label: "unread" }
+        : { state: "online", label: "online" };
     },
-  },
-  created() {
-    // Set up auto-update method for the scheduler
-    this.autoUpdateMethod = this.fetchStatus;
-
-    // Initial data fetch
-    this.fetchStatus();
+    badges: function () {
+      if (this.loading || this.style === "status") {
+        return [];
+      }
+      return [
+        {
+          key: "unread",
+          label: "Unread",
+          value: this.unreadEntries,
+          tone: "warning",
+        },
+        this.connectionBadge(),
+      ];
+    },
   },
   methods: {
-    fetchStatus: async function () {
+    fetchData: async function () {
       const headers = {
         "X-Auth-Token": this.item.apikey,
       };
 
-      let counters;
-      try {
-        counters = await this.fetch("/v1/feeds/counters", { headers });
-        this.isHealthy = true;
-      } catch (e) {
-        console.log(e);
-      } finally {
-        this.loading = false;
-      }
-
-      if (!this.isHealthy) {
-        return;
-      }
-
-      const unreads = Object.values(counters.unreads || {});
-      this.unreadFeeds = unreads.length;
-      this.unreadEntries = unreads.reduce((accumulator, value) => {
-        return accumulator + value;
-      }, 0);
+      await this.load(
+        this.fetch("/v1/feeds/counters", { headers }).then((counters) => {
+          const unreads = Object.values(counters.unreads || {});
+          this.unreadFeeds = unreads.length;
+          this.unreadEntries = unreads.reduce(
+            (accumulator, value) => accumulator + value,
+            0,
+          );
+        }),
+      );
+      this.loading = false;
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.status {
-  font-size: 0.8rem;
-  color: var(--text-title);
-
-  &.online:before {
-    background-color: #94e185;
-    border-color: #78d965;
-    box-shadow: 0 0 5px 1px #94e185;
-  }
-
-  &.unread:before {
-    background-color: #1774ff;
-    border-color: #1774ff;
-    box-shadow: 0 0 5px 1px #1774ff;
-  }
-
-  &.error:before {
-    background-color: #c9404d;
-    border-color: #c42c3b;
-    box-shadow: 0 0 5px 1px #c9404d;
-  }
-
-  &:before {
-    content: " ";
-    display: inline-block;
-    width: 7px;
-    height: 7px;
-    margin-right: 10px;
-    border: 1px solid #000;
-    border-radius: 7px;
-  }
-}
-
-.notifs {
-  position: absolute;
-  color: white;
-  font-family: sans-serif;
-  top: 0.3em;
-  right: 0.5em;
-
-  .notif {
-    display: inline-block;
-    padding: 0.2em 0.35em;
-    border-radius: 0.25em;
-    position: relative;
-    margin-left: 0.3em;
-    font-size: 0.8em;
-
-    &.unread {
-      background-color: #4fb5d6;
-    }
-
-    &.errors {
-      background-color: #e51111;
-    }
-  }
-}
-</style>

--- a/src/components/services/Mylar.vue
+++ b/src/components/services/Mylar.vue
@@ -1,23 +1,5 @@
 <template>
-  <Generic :item="item">
-    <template #indicator>
-      <div class="notifs">
-        <strong v-if="wanted > 0" class="notif wanted" title="Wanted">
-          {{ wanted }}
-        </strong>
-        <strong v-if="upcoming > 0" class="notif upcoming" title="Upcoming">
-          {{ upcoming }}
-        </strong>
-        <strong
-          v-if="serverError"
-          class="notif errors"
-          title="Connection error to Mylar API, check url and apikey in config.yml"
-        >
-          ?
-        </strong>
-      </div>
-    </template>
-  </Generic>
+  <Generic :item="item" :badges="badges" />
 </template>
 
 <script>
@@ -26,77 +8,42 @@ import service from "@/mixins/service.js";
 export default {
   name: "Mylar",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => {
     return {
       upcoming: null,
       wanted: null,
-      warnings: null,
-      errors: null,
-      serverError: false,
+      serverError: null,
     };
   },
-  created: function () {
-    // Set up auto-update method for the scheduler
-    this.autoUpdateMethod = this.fetchConfig;
-
-    // Initial data fetch
-    this.fetchConfig();
+  computed: {
+    badges() {
+      return [
+        { key: "wanted", label: "Wanted", value: this.wanted, tone: "info" },
+        {
+          key: "upcoming",
+          label: "Upcoming",
+          value: this.upcoming,
+          tone: "accent",
+        },
+        this.connectionBadge(),
+      ];
+    },
   },
   methods: {
-    fetchConfig: function () {
-      const handleError = (e) => {
-        console.error(e);
-        this.serverError = true;
-      };
-      this.fetch(`/api?cmd=getUpcoming&apikey=${this.item.apikey}`)
-        .then((upcoming) => {
-          this.upcoming = upcoming.length;
-        })
-        .catch(handleError);
-      this.fetch(`/api?cmd=getWanted&apikey=${this.item.apikey}`)
-        .then((wanted) => {
-          this.wanted = wanted.issues.length + wanted.annuals.length;
-        })
-        .catch(handleError);
+    fetchData: function () {
+      return this.load(
+        this.fetch(`/api?cmd=getUpcoming&apikey=${this.item.apikey}`).then(
+          (upcoming) => {
+            this.upcoming = upcoming.length;
+          },
+        ),
+        this.fetch(`/api?cmd=getWanted&apikey=${this.item.apikey}`).then(
+          (wanted) => {
+            this.wanted = wanted.issues.length + wanted.annuals.length;
+          },
+        ),
+      );
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.notifs {
-  position: absolute;
-  color: white;
-  font-family: sans-serif;
-  top: 0.3em;
-  right: 0.5em;
-
-  .notif {
-    display: inline-block;
-    padding: 0.2em 0.35em;
-    border-radius: 0.25em;
-    position: relative;
-    margin-left: 0.3em;
-    font-size: 0.8em;
-
-    &.wanted {
-      background-color: #4fb5d6;
-    }
-
-    &.upcoming {
-      background-color: #9d00ff;
-    }
-
-    &.warnings {
-      background-color: #d08d2e;
-    }
-
-    &.errors {
-      background-color: #e51111;
-    }
-  }
-}
-</style>

--- a/src/components/services/NetAlertx.vue
+++ b/src/components/services/NetAlertx.vue
@@ -1,28 +1,5 @@
 <template>
-  <Generic :item="item">
-    <template #indicator>
-      <div class="notifs">
-        <strong class="notif total" title="Total Devices">
-          {{ total }}
-        </strong>
-        <strong class="notif connected" title="Connected Devices">
-          {{ connected }}
-        </strong>
-        <strong class="notif newdevices" title="New Devices">
-          {{ newdevices }}
-        </strong>
-        <strong class="notif alert" title="Down Alerts">
-          {{ downalert }}
-        </strong>
-        <strong
-          v-if="serverError"
-          class="notif alert"
-          title="Connection error to NetAlertx server, check the url in config.yml"
-          >?</strong
-        >
-      </div>
-    </template>
-  </Generic>
+  <Generic :item="item" :badges="badges" />
 </template>
 
 <script>
@@ -31,75 +8,63 @@ import service from "@/mixins/service.js";
 export default {
   name: "NetAlertx",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => {
     return {
       total: 0,
       connected: 0,
       newdevices: 0,
       downalert: 0,
-      serverError: false,
+      serverError: null,
     };
   },
-  created() {
-    // Set up auto-update method for the scheduler
-    this.autoUpdateMethod = this.fetchStatus;
-
-    // Initial data fetch
-    this.fetchStatus();
+  computed: {
+    badges() {
+      return [
+        {
+          key: "total",
+          label: "Total Devices",
+          value: this.total,
+          tone: "neutral",
+          showZero: true,
+        },
+        {
+          key: "connected",
+          label: "Connected Devices",
+          value: this.connected,
+          tone: "success",
+          showZero: true,
+        },
+        {
+          key: "newdevices",
+          label: "New Devices",
+          value: this.newdevices,
+          tone: "info",
+          showZero: true,
+        },
+        {
+          key: "downalert",
+          label: "Down Alerts",
+          value: this.downalert,
+          tone: "danger",
+          showZero: true,
+        },
+        this.connectionBadge(),
+      ];
+    },
   },
   methods: {
-    fetchStatus: async function () {
-      this.fetch("/devices/totals", { headers: { Authorization: `Bearer ${this.item.apikey}` } })
-        .then((response) => {
+    fetchData: function () {
+      return this.load(
+        this.fetch("/devices/totals", {
+          headers: { Authorization: `Bearer ${this.item.apikey}` },
+        }).then((response) => {
           this.total = response.total || response[0] || 0;
           this.connected = response.connected || response[1] || 0;
           this.newdevices = response.new || response[3] || 0;
           this.downalert = response.down || response[4] || 0;
-          this.serverError = false;
-        })
-        .catch((e) => {
-          console.log(e);
-          this.serverError = true;
-        });
+        }),
+      );
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.notifs {
-  position: absolute;
-  color: white;
-  font-family: sans-serif;
-  top: 0.3em;
-  right: 0.5em;
-
-  .notif {
-    display: inline-block;
-    padding: 0.2em 0.35em;
-    border-radius: 0.25em;
-    position: relative;
-    margin-left: 0.3em;
-    font-size: 0.8em;
-
-    &.total {
-      background-color: #4fb5d6;
-    }
-
-    &.connected {
-      background-color: #4fd671;
-    }
-
-    &.newdevices {
-      background-color: #d08d2e;
-    }
-
-    &.alert {
-      background-color: #e51111;
-    }
-  }
-}
-</style>

--- a/src/components/services/Nextcloud.vue
+++ b/src/components/services/Nextcloud.vue
@@ -1,17 +1,5 @@
 <template>
-  <Generic :item="item">
-    <template #content>
-      <p class="title is-4">{{ item.name }}</p>
-      <p class="subtitle is-6">
-        <template v-if="versionstring"> Version {{ versionstring }} </template>
-      </p>
-    </template>
-    <template #indicator>
-      <div v-if="status" class="status" :class="status">
-        {{ status }}
-      </div>
-    </template>
-  </Generic>
+  <Generic :item="item" :subtitle="versionSubtitle" :status="status" />
 </template>
 
 <script>
@@ -20,75 +8,28 @@ import service from "@/mixins/service.js";
 export default {
   name: "Nextcloud",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => ({
-    fetchOk: null,
+    serverError: null,
     versionstring: null,
     maintenance: null,
   }),
   computed: {
     status: function () {
-      if (!this.fetchOk) {
-        return "offline";
+      if (this.serverError || !this.maintenance) {
+        return this.reachabilityStatus();
       }
-      return this.maintenance ? "maintenance" : "online";
+      return { state: "warning", label: "maintenance" };
     },
   },
-  created() {
-    this.fetchStatus();
-  },
   methods: {
-    fetchStatus: async function () {
-      this.fetch("/status.php")
-        .then((response) => {
-          this.fetchOk = true;
+    fetchData: function () {
+      return this.load(
+        this.fetch("/status.php").then((response) => {
           this.versionstring = response.versionstring;
           this.maintenance = response.maintenance;
-        })
-        .catch((e) => {
-          this.fetchOk = false;
-          console.log(e);
-        });
+        }),
+      );
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.status {
-  font-size: 0.8rem;
-  color: var(--text-title);
-  white-space: nowrap;
-  margin-left: 0.25rem;
-
-  &.online:before {
-    background-color: #94e185;
-    border-color: #78d965;
-    box-shadow: 0 0 5px 1px #94e185;
-  }
-
-  &.maintenance:before {
-    background-color: #f8a306;
-    border-color: #e1b35e;
-    box-shadow: 0 0 5px 1px #f8a306;
-  }
-
-  &.offline:before {
-    background-color: #c9404d;
-    border-color: #c42c3b;
-    box-shadow: 0 0 5px 1px #c9404d;
-  }
-
-  &:before {
-    content: " ";
-    display: inline-block;
-    width: 7px;
-    height: 7px;
-    margin-right: 10px;
-    border: 1px solid #000;
-    border-radius: 7px;
-  }
-}
-</style>

--- a/src/components/services/OctoPrint.vue
+++ b/src/components/services/OctoPrint.vue
@@ -1,63 +1,56 @@
 <template>
-  <Generic :item="item" :title="state">
-    <template #content>
-      <p class="title is-4">{{ item.name }}</p>
-      <p class="subtitle is-6">
-        <template v-if="item.subtitle && !state">
-          {{ item.subtitle }}
-        </template>
-        <template
-          v-if="!error && display == 'text' && statusClass == 'in-progress'"
+  <Generic :item="item" :title="state" :status="status">
+    <template #subtitle>
+      <template v-if="!error && display == 'text' && printing">
+        <i class="fa-solid fa-gear mr-1"></i>
+        <b v-if="completion">{{ completion.toFixed() }}%</b>
+        <span class="mx-1"> | </span>
+        <span v-if="printTime" :title="`${displayDuration(printTimeLeft)} left`">
+          <i class="fa-solid fa-stopwatch mr-1"></i>
+          {{ displayDuration(printTime) }}
+        </span>
+      </template>
+      <template v-if="!error && display == 'text' && state == 'Operational'">
+        <i class="fa-solid fa-temperature-half mr-1"></i>
+        <b v-if="printer.temperature.bed"
+          >{{ printer.temperature.bed.actual.toFixed() }} C</b
         >
-          <i class="fa-solid fa-gear mr-1"></i>
-          <b v-if="completion">{{ completion.toFixed() }}%</b>
-          <span class="separator mx-1"> | </span>
-          <span v-if="printTime" :title="`${formatTime(printTimeLeft)} left`">
-            <i class="fa-solid fa-stopwatch mr-1"></i>
-            {{ formatTime(printTime) }}
-          </span>
-        </template>
-        <template v-if="!error && display == 'text' && statusClass == 'ready'">
-          <i class="fa-solid fa-temperature-half mr-1"></i>
-          <b v-if="printer.temperature.bed"
-            >{{ printer.temperature.bed.actual.toFixed() }} C</b
-          >
-          <span class="separator mx-1"> | </span>
-          <b v-if="printer.temperature.tool0"
-            >{{ printer.temperature.tool0.actual.toFixed() }} C</b
-          >
-        </template>
-        <template v-if="!error && display == 'bar'">
-          <progress
-            v-if="completion"
-            class="progress is-primary"
-            :value="completion"
-            max="100"
-            :title="`${state} - ${completion.toFixed()}%, ${formatTime(
-              printTimeLeft,
-            )} left`"
-          >
-            {{ completion }}%
-          </progress>
-        </template>
-        <span v-if="error" :title="error">{{ error }}</span>
-      </p>
-    </template>
-    <template #indicator>
-      <i :class="['status', statusClass]" :title="state"></i>
+        <span class="mx-1"> | </span>
+        <b v-if="printer.temperature.tool0"
+          >{{ printer.temperature.tool0.actual.toFixed() }} C</b
+        >
+      </template>
+      <template v-if="!error && display == 'bar'">
+        <progress
+          v-if="completion"
+          class="progress is-primary"
+          :value="completion"
+          max="100"
+          :title="`${state} - ${completion.toFixed()}%, ${displayDuration(
+            printTimeLeft,
+          )} left`"
+        >
+          {{ completion }}%
+        </progress>
+      </template>
+      <span v-if="error" :title="error">{{ error }}</span>
     </template>
   </Generic>
 </template>
 
 <script>
 import service from "@/mixins/service.js";
+import { displayDuration } from "@/utils/format.js";
+
+const PRINTER_STATE = {
+  Operational: "online",
+  Offline: "offline",
+  Printing: "busy",
+};
 
 export default {
   name: "OctoPrint",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => ({
     printTime: null,
     printTimeLeft: null,
@@ -67,30 +60,21 @@ export default {
     error: null,
   }),
   computed: {
-    statusClass: function () {
-      switch (this.state) {
-        case "Operational":
-          return "ready";
-        case "Offline":
-          return "offline";
-        case "Printing":
-          return "in-progress";
-        default:
-          return "pending";
+    display: function () {
+      return this.item.display == "bar" ? this.item.display : "text";
+    },
+    printing: function () {
+      return this.state === "Printing";
+    },
+    status: function () {
+      if (!this.state) {
+        return null;
       }
+      return { state: PRINTER_STATE[this.state] ?? "warning", label: null };
     },
   },
-  created() {
-    this.display = this.item.display == "bar" ? this.item.display : "text";
-
-    // Set up auto-update method for the scheduler
-    this.autoUpdateMethod = this.fetchAll;
-
-    // Initial data fetch
-    this.fetchAll();
-  },
   methods: {
-    fetchAll: async function () {
+    fetchData: async function () {
       this.fetchPrinterStatus();
       this.fetchStatus();
     },
@@ -119,37 +103,12 @@ export default {
         console.error(e);
       }
     },
-    formatTime: function (seconds) {
-      const days = Math.floor(seconds / 86400);
-      let remainingSeconds = seconds % 86400;
-      const hours = Math.floor(remainingSeconds / 3600);
-      remainingSeconds %= 3600;
-      const minutes = Math.floor(remainingSeconds / 60);
-      const secs = remainingSeconds % 60;
-
-      const formattedHrs = hours.toString().padStart(2, "0");
-      const formattedMins = minutes.toString().padStart(2, "0");
-      const formattedSecs = secs.toString().padStart(2, "0");
-
-      if (days > 0) {
-        return `${days}d ${formattedHrs}h ${formattedMins}m`;
-      } else if (hours > 0) {
-        return `${formattedHrs}h ${formattedMins}m ${formattedSecs}s`;
-      } else if (minutes > 0) {
-        return `${formattedMins}m ${formattedSecs}s`;
-      } else {
-        return `${secs} seconds`;
-      }
-    },
+    displayDuration,
   },
 };
 </script>
 
 <style scoped lang="scss">
-.fa-triangle-exclamation::before {
-  color: #d65c68;
-}
-
 .progress {
   height: 8px;
   width: 90%;

--- a/src/components/services/Olivetin.vue
+++ b/src/components/services/Olivetin.vue
@@ -1,22 +1,9 @@
 <template>
-  <Generic :item="item">
-    <template #content>
-      <p class="title is-4">{{ item.name }}</p>
-      <p class="subtitle is-6">
-        <template v-if="item.subtitle">
-          {{ item.subtitle }}
-        </template>
-        <template v-else-if="versionstring">
-          Version {{ versionstring }}
-        </template>
-      </p>
-    </template>
-    <template #indicator>
-      <div v-if="status" class="status" :class="status">
-        {{ status }}
-      </div>
-    </template>
-  </Generic>
+  <Generic
+    :item="item"
+    :subtitle="versionSubtitle"
+    :status="reachabilityStatus()"
+  />
 </template>
 
 <script>
@@ -25,59 +12,18 @@ import service from "@/mixins/service.js";
 export default {
   name: "Olivetin",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => ({
-    status: null,
+    serverError: null,
     versionstring: null,
   }),
-  created() {
-    this.fetchStatus();
-  },
   methods: {
-    fetchStatus: async function () {
-      this.fetch("/webUiSettings.json")
-        .then((response) => {
-          this.status = "online";
+    fetchData: function () {
+      return this.load(
+        this.fetch("/webUiSettings.json").then((response) => {
           this.versionstring = response.CurrentVersion;
-        })
-        .catch((e) => {
-          this.status = "offline";
-          console.log(e);
-        });
+        }),
+      );
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.status {
-  font-size: 0.8rem;
-  color: var(--text-title);
-  white-space: nowrap;
-  margin-left: 0.25rem;
-
-  &.online:before {
-    background-color: #94e185;
-    border-color: #78d965;
-    box-shadow: 0 0 5px 1px #94e185;
-  }
-
-  &.offline:before {
-    background-color: #c9404d;
-    border-color: #c42c3b;
-    box-shadow: 0 0 5px 1px #c9404d;
-  }
-
-  &:before {
-    content: " ";
-    display: inline-block;
-    width: 7px;
-    height: 7px;
-    margin-right: 10px;
-    border: 1px solid #000;
-    border-radius: 7px;
-  }
-}
-</style>

--- a/src/components/services/OpenHAB.vue
+++ b/src/components/services/OpenHAB.vue
@@ -1,22 +1,5 @@
 <template>
-  <Generic :item="item">
-    <template #content>
-      <p class="title is-4">{{ item.name }}</p>
-      <p class="subtitle is-6">
-        <template v-if="item.subtitle">
-          {{ item.subtitle }}
-        </template>
-        <template v-else>
-          {{ details }}
-        </template>
-      </p>
-    </template>
-    <template #indicator>
-      <div v-if="status" class="status" :class="status">
-        {{ status }}
-      </div>
-    </template>
-  </Generic>
+  <Generic :item="item" :subtitle="details" :status="status" />
 </template>
 
 <script>
@@ -25,11 +8,8 @@ import service from "@/mixins/service.js";
 export default {
   name: "OpenHAB",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => ({
-    status: "",
+    status: null,
     things: {
       count: 0,
       online: 0,
@@ -62,24 +42,26 @@ export default {
       return details.join(", ");
     },
   },
-  created() {
-    this.fetchServerStatus();
-
-    if (!this.item.subtitle && this.status !== "dead") {
-      this.fetchServerStats();
-    }
-  },
   methods: {
+    fetchData: function () {
+      return this.fetchServerStatus().then(() => {
+        if (this.item.subtitle || this.status?.state === "offline") {
+          return;
+        }
+        return this.fetchServerStats();
+      });
+    },
     fetchServerStatus: async function () {
       const headers = this.headers;
-      this.fetch("/rest/systeminfo", { headers })
+      return this.fetch("/rest/systeminfo", { headers })
         .then((response) => {
-          if (response && response.systemInfo) this.status = "running";
+          if (response && response.systemInfo)
+            this.status = { state: "online", label: "running" };
           else throw new Error();
         })
         .catch((e) => {
-          console.log(e);
-          this.status = "dead";
+          console.error(e);
+          this.status = { state: "offline", label: "dead" };
         });
     },
     fetchServerStats: async function () {
@@ -89,7 +71,7 @@ export default {
         const data = await this.fetch("/rest/things?summary=true", {
           headers,
         }).catch((e) => {
-          console.log(e);
+          console.error(e);
         });
 
         this.things.count = data.length;
@@ -100,7 +82,7 @@ export default {
 
       if (this.item.items) {
         const data = await this.fetch("/rest/items", { headers }).catch((e) => {
-          console.log(e);
+          console.error(e);
         });
 
         this.items.count = data.length;
@@ -109,32 +91,3 @@ export default {
   },
 };
 </script>
-
-<style scoped lang="scss">
-.status {
-  font-size: 0.8rem;
-  color: var(--text-title);
-
-  &.running:before {
-    background-color: #94e185;
-    border-color: #78d965;
-    box-shadow: 0 0 5px 1px #94e185;
-  }
-
-  &.dead:before {
-    background-color: #c9404d;
-    border-color: #c42c3b;
-    box-shadow: 0 0 5px 1px #c9404d;
-  }
-
-  &:before {
-    content: " ";
-    display: inline-block;
-    width: 7px;
-    height: 7px;
-    margin-right: 10px;
-    border: 1px solid #000;
-    border-radius: 7px;
-  }
-}
-</style>

--- a/src/components/services/PaperlessNG.vue
+++ b/src/components/services/PaperlessNG.vue
@@ -1,17 +1,9 @@
 <template>
-  <Generic :item="item">
-    <template #content>
-      <p class="title is-4">{{ item.name }}</p>
-      <p class="subtitle is-6">
-        <template v-if="item.subtitle">
-          {{ item.subtitle }}
-        </template>
-        <template v-else-if="api">
-          happily storing {{ api.count }} documents
-        </template>
-      </p>
-    </template>
-  </Generic>
+  <Generic
+    :item="item"
+    :subtitle="api && `happily storing ${api.count} documents`"
+    :badges="badges"
+  />
 </template>
 
 <script>
@@ -20,31 +12,32 @@ import service from "@/mixins/service.js";
 export default {
   name: "Paperless",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => ({
     api: null,
+    serverError: null,
   }),
-  created() {
-    this.fetchStatus();
+  computed: {
+    badges() {
+      return [this.connectionBadge()];
+    },
   },
   methods: {
-    fetchStatus: async function () {
+    fetchData: async function () {
       if (this.item.subtitle != null) return;
 
-      const apikey = this.item.apikey;
-      if (!apikey) {
-        console.error(
-          "apikey is not present in config.yml for the paperless entry!",
-        );
+      if (!this.requireConfig("apikey")) {
         return;
       }
-      this.api = await this.fetch("/api/documents/", {
-        headers: {
-          Authorization: "Token " + this.item.apikey,
-        },
-      }).catch((e) => console.log(e));
+
+      return this.load(
+        this.fetch("/api/documents/", {
+          headers: {
+            Authorization: "Token " + this.item.apikey,
+          },
+        }).then((api) => {
+          this.api = api;
+        }),
+      );
     },
   },
 };

--- a/src/components/services/PeaNUT.vue
+++ b/src/components/services/PeaNUT.vue
@@ -1,20 +1,9 @@
 <template>
-  <Generic :item="item">
-    <template #content>
-      <p class="title is-4">{{ item.name }}</p>
-      <p class="subtitle is-6">
-        <template v-if="item.subtitle">
-          {{ item.subtitle }}
-        </template>
-        <template v-else-if="load"> {{ load }}&percnt; UPS Load </template>
-      </p>
-    </template>
-    <template #indicator>
-      <div v-if="ups_status" class="status" :class="status_class">
-        {{ status_text }}
-      </div>
-    </template>
-  </Generic>
+  <Generic
+    :item="item"
+    :subtitle="upsLoad && `${upsLoad}% UPS Load`"
+    :status="status"
+  />
 </template>
 
 <script>
@@ -23,52 +12,39 @@ import service from "@/mixins/service.js";
 export default {
   name: "PeaNUT",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => ({
+    serverError: null,
     ups_status: "",
     ups_load: 0,
   }),
   computed: {
-    status_text: function () {
+    status: function () {
       const status = this.ups_status;
-      if (status.includes("LB"))     return "low battery";
-      if (status.includes("OB"))     return "on battery";
-      if (status.includes("OL"))     return "online";
-      return "unknown";
+      if (this.serverError || !status) return this.reachabilityStatus();
+      if (status.includes("LB"))
+        return { state: "offline", label: "low battery" };
+      if (status.includes("OB"))
+        return { state: "warning", label: "on battery" };
+      if (status.includes("OL")) return { state: "online", label: "online" };
+      return { state: "unknown", label: "unknown" };
     },
-    status_class: function () {
-      const status = this.ups_status;
-      if (status.includes("LB"))     return "offline";
-      if (status.includes("OB"))     return "pending";
-      if (status.includes("OL"))     return "online";
-      return "unknown";
-    },
-    load: function () {
+    upsLoad: function () {
       if (this.ups_load) {
         return this.ups_load.toFixed(1);
       }
       return "";
     },
   },
-  created() {
-    // Set up auto-update method for the scheduler
-    this.autoUpdateMethod = this.fetchStatus;
-
-    // Initial data fetch
-    this.fetchStatus();
-  },
   methods: {
-    fetchStatus: async function () {
+    fetchData: function () {
       const device = this.item.device || "";
 
-      const result = await this.fetch(`/api/v1/devices/${device}`).catch((e) =>
-        console.log(e),
+      return this.load(
+        this.fetch(`/api/v1/devices/${device}`).then((result) => {
+          this.ups_status = result["ups.status"] || "";
+          this.ups_load = result["ups.load"] || 0;
+        }),
       );
-
-      this.ups_status = result["ups.status"] || "";
-      this.ups_load = result["ups.load"] || 0;
     },
   },
 };

--- a/src/components/services/PiAlert.vue
+++ b/src/components/services/PiAlert.vue
@@ -1,28 +1,5 @@
 <template>
-  <Generic :item="item">
-    <template #indicator>
-      <div class="notifs">
-        <strong class="notif total" title="Total Devices">
-          {{ total }}
-        </strong>
-        <strong class="notif connected" title="Connected Devices">
-          {{ connected }}
-        </strong>
-        <strong class="notif newdevices" title="New Devices">
-          {{ newdevices }}
-        </strong>
-        <strong class="notif alert" title="Down Alerts">
-          {{ downalert }}
-        </strong>
-        <strong
-          v-if="serverError"
-          class="notif alert"
-          title="Connection error to PiAlert server, check the url in config.yml"
-          >?</strong
-        >
-      </div>
-    </template>
-  </Generic>
+  <Generic :item="item" :badges="badges" />
 </template>
 
 <script>
@@ -31,74 +8,63 @@ import service from "@/mixins/service.js";
 export default {
   name: "PiAlert",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => {
     return {
       total: 0,
       connected: 0,
       newdevices: 0,
       downalert: 0,
-      serverError: false,
+      serverError: null,
     };
   },
-  created() {
-    // Set up auto-update method for the scheduler
-    this.autoUpdateMethod = this.fetchStatus;
-
-    // Initial data fetch
-    this.fetchStatus();
+  computed: {
+    badges() {
+      return [
+        {
+          key: "total",
+          label: "Total Devices",
+          value: this.total,
+          tone: "neutral",
+          showZero: true,
+        },
+        {
+          key: "connected",
+          label: "Connected Devices",
+          value: this.connected,
+          tone: "success",
+          showZero: true,
+        },
+        {
+          key: "newdevices",
+          label: "New Devices",
+          value: this.newdevices,
+          tone: "info",
+          showZero: true,
+        },
+        {
+          key: "downalert",
+          label: "Down Alerts",
+          value: this.downalert,
+          tone: "danger",
+          showZero: true,
+        },
+        this.connectionBadge(),
+      ];
+    },
   },
   methods: {
-    fetchStatus: async function () {
-      this.fetch("/php/server/devices.php?action=getDevicesTotals")
-        .then((response) => {
-          this.total = response[0];
-          this.connected = response[1];
-          this.newdevices = response[3];
-          this.downalert = response[4];
-        })
-        .catch((e) => {
-          console.log(e);
-          this.serverError = true;
-        });
+    fetchData: async function () {
+      return this.load(
+        this.fetch("/php/server/devices.php?action=getDevicesTotals").then(
+          (response) => {
+            this.total = response[0];
+            this.connected = response[1];
+            this.newdevices = response[3];
+            this.downalert = response[4];
+          },
+        ),
+      );
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.notifs {
-  position: absolute;
-  color: white;
-  font-family: sans-serif;
-  top: 0.3em;
-  right: 0.5em;
-
-  .notif {
-    display: inline-block;
-    padding: 0.2em 0.35em;
-    border-radius: 0.25em;
-    position: relative;
-    margin-left: 0.3em;
-    font-size: 0.8em;
-
-    &.total {
-      background-color: #4fb5d6;
-    }
-
-    &.connected {
-      background-color: #4fd671;
-    }
-
-    &.newdevices {
-      background-color: #d08d2e;
-    }
-
-    &.alert {
-      background-color: #e51111;
-    }
-  }
-}
-</style>

--- a/src/components/services/PiHole.vue
+++ b/src/components/services/PiHole.vue
@@ -1,38 +1,22 @@
 <template>
-  <Generic :item="item">
-    <template #content>
-      <p class="title is-4">{{ item.name }}</p>
-      <p class="subtitle is-6">
-        <template v-if="item.subtitle">
-          {{ item.subtitle }}
-        </template>
-        <template v-else-if="percentage">
-          {{ percentage }}&percnt; blocked
-        </template>
-      </p>
-    </template>
-    <template #indicator>
-      <div v-if="status" class="status" :class="status">
-        {{ status }}
-      </div>
-    </template>
-  </Generic>
+  <Generic :item="item" :subtitle="subtitle" :status="status" />
 </template>
 
 <script>
 import service from "@/mixins/service.js";
 
+const BLOCKING_STATE = {
+  enabled: "online",
+  disabled: "warning",
+  error: "offline",
+};
+
 export default {
   name: "PiHole",
   mixins: [service],
-  props: {
-    item: {
-      type: Object,
-      required: true,
-    },
-  },
   data: () => ({
-    status: "",
+    blocking: "",
+    errorMessage: "",
     percent_blocked: 0,
     sessionId: null,
     sessionExpiry: null,
@@ -41,6 +25,17 @@ export default {
     retryDelay: 5000,
   }),
   computed: {
+    status: function () {
+      if (!this.blocking) {
+        return null;
+      }
+      return { state: BLOCKING_STATE[this.blocking], label: this.blocking };
+    },
+    subtitle: function () {
+      return (
+        this.errorMessage || (this.percentage && `${this.percentage}% blocked`)
+      );
+    },
     percentage: function () {
       if (this.percent_blocked >= 0) {
         return this.percent_blocked.toFixed(1);
@@ -61,16 +56,16 @@ export default {
       this.autoUpdateMethod = this.fetchStatus;
     } else {
       // Set up auto-update method for the scheduler
-      this.autoUpdateMethod = this.fetchStatus_v5();
+      this.autoUpdateMethod = this.fetchStatus_v5;
     }
     // Initial data fetch
     this.autoUpdateMethod();
   },
   methods: {
-    handleError: function (error, status) {
+    handleError: function (error, state = "error") {
       console.error(error);
-      this.subtitle = error;
-      this.status = status;
+      this.errorMessage = error;
+      this.blocking = state;
     },
     loadCachedSession: function () {
       try {
@@ -160,8 +155,9 @@ export default {
           throw new Error("Invalid response format");
         }
 
-        this.status = status_response.blocking;
+        this.blocking = status_response.blocking;
         this.percent_blocked = summary_response.queries.percent_blocked;
+        this.errorMessage = "";
         this.retryCount = 0;
       } catch (e) {
         const isAuthError =
@@ -170,7 +166,7 @@ export default {
           this.removeCacheSession();
           return this.retryWithDelay();
         }
-        this.handleError(`Failed to fetch status: ${e.message || e}`, "error");
+        this.handleError(`Failed to fetch status: ${e.message || e}`);
         this.removeCacheSession();
       }
     },
@@ -178,48 +174,16 @@ export default {
       const authQueryParams = this.item.apikey
         ? `?summaryRaw&auth=${this.item.apikey}`
         : "";
-      const result = await this.fetch(`/api.php${authQueryParams}`).catch((e) =>
-        this.handleError(`Failed to fetch status: ${e}`, "error"),
-      );
+      try {
+        const result = await this.fetch(`/api.php${authQueryParams}`);
 
-      this.status = result.status;
-      this.percent_blocked = result.ads_percentage_today;
+        this.blocking = result.status;
+        this.percent_blocked = result.ads_percentage_today;
+        this.errorMessage = "";
+      } catch (e) {
+        this.handleError(`Failed to fetch status: ${e}`);
+      }
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.status {
-  font-size: 0.8rem;
-  color: var(--text-title);
-
-  &.enabled:before {
-    background-color: #94e185;
-    border-color: #78d965;
-    box-shadow: 0 0 5px 1px #94e185;
-  }
-
-  &.disabled:before {
-    background-color: #f5a623;
-    border-color: #e59400;
-    box-shadow: 0 0 5px 1px #f5a623;
-  }
-
-  &.error:before {
-    background-color: #c9404d;
-    border-color: #c42c3b;
-    box-shadow: 0 0 5px 1px #c9404d;
-  }
-
-  &:before {
-    content: " ";
-    display: inline-block;
-    width: 7px;
-    height: 7px;
-    margin-right: 10px;
-    border: 1px solid #000;
-    border-radius: 7px;
-  }
-}
-</style>

--- a/src/components/services/Ping.vue
+++ b/src/components/services/Ping.vue
@@ -1,22 +1,5 @@
 <template>
-  <Generic :item="item">
-    <template #indicator>
-      <div v-if="status" class="status" :class="status">
-        {{ status }}
-      </div>
-    </template>
-    <template #content>
-      <p class="title is-4">{{ item.name }}</p>
-      <p class="subtitle is-6">
-        <template v-if="item.subtitle">
-          {{ item.subtitle }}
-        </template>
-        <template v-else>
-          {{ rttLabel }}
-        </template>
-      </p>
-    </template>
-  </Generic>
+  <Generic :item="item" :subtitle="rttLabel" :status="reachabilityStatus()" />
 </template>
 
 <script>
@@ -25,30 +8,20 @@ import service from "@/mixins/service.js";
 export default {
   name: "Ping",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => ({
-    status: null,
+    serverError: null,
     rtt: null,
   }),
   computed: {
     rttLabel: function () {
-      if (this.status === "online") {
-        return `${this.rtt}ms`;
+      if (this.serverError === null) {
+        return null;
       }
-      return "unavailable";
+      return !this.serverError ? `${this.rtt}ms` : "unavailable";
     },
   },
-  created() {
-    // Set up auto-update method for the scheduler
-    this.autoUpdateMethod = this.fetchStatus;
-
-    // Initial data fetch
-    this.fetchStatus();
-  },
   methods: {
-    fetchStatus: async function () {
+    fetchData: async function () {
       const method =
         typeof this.item.method === "string"
           ? this.item.method.toUpperCase()
@@ -69,46 +42,15 @@ export default {
 
       this.fetch("/", params, false)
         .then(() => {
-          this.status = "online";
+          this.serverError = false;
           const endTime = performance.now();
           this.rtt = Math.round(endTime - startTime);
         })
         .catch(() => {
-          this.status = "offline";
+          this.serverError = true;
           this.rtt = null; // Reset rtt on failure
         });
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.status {
-  font-size: 0.8rem;
-  color: var(--text-title);
-  white-space: nowrap;
-  margin-left: 0.25rem;
-
-  &.online:before {
-    background-color: #94e185;
-    border-color: #78d965;
-    box-shadow: 0 0 5px 1px #94e185;
-  }
-
-  &.offline:before {
-    background-color: #c9404d;
-    border-color: #c42c3b;
-    box-shadow: 0 0 5px 1px #c9404d;
-  }
-
-  &:before {
-    content: " ";
-    display: inline-block;
-    width: 7px;
-    height: 7px;
-    margin-right: 10px;
-    border: 1px solid #000;
-    border-radius: 7px;
-  }
-}
-</style>

--- a/src/components/services/Plex.vue
+++ b/src/components/services/Plex.vue
@@ -1,36 +1,5 @@
 <template>
-  <Generic :item="item">
-    <template #indicator>
-      <div class="notifs">
-        <strong
-          v-if="streams > 0"
-          class="notif activity"
-          title="Active Streams"
-        >
-          {{ streams }}
-        </strong>
-        <strong v-if="series > 0" class="notif series" title="Total Series">
-          {{ series }}
-        </strong>
-        <strong v-if="movies > 0" class="notif movies" title="Total Movies">
-          {{ movies }}
-        </strong>
-        <strong v-if="warnings > 0" class="notif warnings" title="Warning">
-          {{ warnings }}
-        </strong>
-        <strong v-if="errors > 0" class="notif errors" title="Error">
-          {{ errors }}
-        </strong>
-        <strong
-          v-if="serverError"
-          class="notif errors"
-          title="Connection error to Plex API, check url and token in config.yml"
-        >
-          ?
-        </strong>
-      </div>
-    </template>
-  </Generic>
+  <Generic :item="item" :badges="badges" />
 </template>
 
 <script>
@@ -38,9 +7,6 @@ import service from "@/mixins/service.js";
 export default {
   name: "Plex",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => {
     return {
       streams: null,
@@ -48,32 +14,59 @@ export default {
       movies: null,
       warnings: null,
       errors: null,
-      serverError: false,
+      serverError: null,
     };
   },
-  created: function () {
-    // Set up auto-update method for the scheduler
-    this.autoUpdateMethod = this.fetchData;
-
-    // Initial data fetch
-    this.fetchData();
+  computed: {
+    badges() {
+      return [
+        {
+          key: "streams",
+          label: "Active Streams",
+          value: this.streams,
+          tone: "info",
+        },
+        {
+          key: "series",
+          label: "Total Series",
+          value: this.series,
+          tone: "accent",
+        },
+        {
+          key: "movies",
+          label: "Total Movies",
+          value: this.movies,
+          tone: "success",
+        },
+        {
+          key: "warnings",
+          label: "Warning",
+          value: this.warnings,
+          tone: "warning",
+        },
+        { key: "errors", label: "Error", value: this.errors, tone: "danger" },
+        this.connectionBadge(),
+      ];
+    },
   },
   methods: {
     fetchData: function () {
-      const handleError = (e) => {
-        console.error(e);
-        this.serverError = true;
-      };
-      this.fetch(`/status/sessions?X-Plex-Token=${this.item.token}`, {}, false)
-        .then((str) => {
+      return this.load(
+        this.fetch(
+          `/status/sessions?X-Plex-Token=${this.item.token}`,
+          {},
+          false,
+        ).then((str) => {
           const parser = new DOMParser();
           const xml = parser.parseFromString(str, "application/xml");
           const metadata = xml.getElementsByTagName("MediaContainer")[0];
-          this.streams = metadata ? metadata.getAttribute("size") || 0 : 0;
-        })
-        .catch(handleError);
-      this.fetch(`/library/sections?X-Plex-Token=${this.item.token}`, {}, false)
-        .then((str) => {
+          this.streams = metadata ? Number(metadata.getAttribute("size")) : 0;
+        }),
+        this.fetch(
+          `/library/sections?X-Plex-Token=${this.item.token}`,
+          {},
+          false,
+        ).then((str) => {
           const parser = new DOMParser();
           const xml = parser.parseFromString(str, "application/xml");
           const directories = xml.getElementsByTagName("Directory");
@@ -87,79 +80,41 @@ export default {
             }
           }
           let seriesCount = 0;
-          Promise.all(
-            seriesDirIds.map((seriesDirId) =>
-              this.fetch(
-                `/library/sections/${seriesDirId}/all?X-Plex-Token=${this.item.token}`,
-                {},
-                false,
-              )
-                .then((str) => {
+          let movieCount = 0;
+
+          return Promise.all([
+            Promise.all(
+              seriesDirIds.map((seriesDirId) =>
+                this.fetch(
+                  `/library/sections/${seriesDirId}/all?X-Plex-Token=${this.item.token}`,
+                  {},
+                  false,
+                ).then((str) => {
                   const xml = parser.parseFromString(str, "application/xml");
                   seriesCount += xml.getElementsByTagName("Directory").length;
-                })
-                .catch(handleError),
-            ),
-          )
-            .then(() => {
+                }),
+              ),
+            ).then(() => {
               this.series = seriesCount;
-            })
-            .catch(handleError);
-
-          let movieCount = 0;
-          Promise.all(
-            movieDirIds.map((movieDirId) =>
-              this.fetch(
-                `/library/sections/${movieDirId}/all?X-Plex-Token=${this.item.token}`,
-                {},
-                false,
-              )
-                .then((str) => {
+            }),
+            Promise.all(
+              movieDirIds.map((movieDirId) =>
+                this.fetch(
+                  `/library/sections/${movieDirId}/all?X-Plex-Token=${this.item.token}`,
+                  {},
+                  false,
+                ).then((str) => {
                   const xml = parser.parseFromString(str, "application/xml");
                   movieCount += xml.getElementsByTagName("Video").length;
-                })
-                .catch(handleError),
-            ),
-          ).then(() => {
-            this.movies = movieCount;
-          });
-        })
-        .catch(handleError);
+                }),
+              ),
+            ).then(() => {
+              this.movies = movieCount;
+            }),
+          ]);
+        }),
+      );
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.notifs {
-  position: absolute;
-  color: white;
-  font-family: sans-serif;
-  top: 0.3em;
-  right: 0.5em;
-
-  .notif {
-    display: inline-block;
-    padding: 0.2em 0.35em;
-    border-radius: 0.25em;
-    position: relative;
-    margin-left: 0.3em;
-    font-size: 0.8em;
-    &.activity {
-      background-color: #4fb5d6;
-    }
-    &.series {
-      background-color: #ffa500;
-    }
-    &.movies {
-      background-color: #008000;
-    }
-    &.warnings {
-      background-color: #d08d2e;
-    }
-    &.errors {
-      background-color: #e51111;
-    }
-  }
-}
-</style>

--- a/src/components/services/Portainer.vue
+++ b/src/components/services/Portainer.vue
@@ -1,37 +1,10 @@
 <template>
-  <Generic :item="item">
-    <template #content>
-      <p class="title is-4">{{ item.name }}</p>
-      <p class="subtitle is-6">
-        <template v-if="item.subtitle">
-          {{ item.subtitle }}
-        </template>
-        <template v-else-if="versionstring">
-          Version {{ versionstring }}
-        </template>
-      </p>
-    </template>
-    <template #indicator>
-      <div class="notifs">
-        <strong v-if="running > 0" class="notif running" title="Running">
-          {{ running }}
-        </strong>
-        <strong v-if="dead > 0" class="notif dead" title="Dead">
-          {{ dead }}
-        </strong>
-        <strong
-          v-if="misc > 0"
-          class="notif misc"
-          title="Other (creating, paused, exited, etc.)"
-        >
-          {{ misc }}
-        </strong>
-      </div>
-      <div v-if="status" class="status" :class="status">
-        {{ status }}
-      </div>
-    </template>
-  </Generic>
+  <Generic
+    :item="item"
+    :subtitle="versionSubtitle"
+    :status="reachabilityStatus()"
+    :badges="badges"
+  />
 </template>
 
 <script>
@@ -40,13 +13,9 @@ import service from "@/mixins/service.js";
 export default {
   name: "Portainer",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => ({
-    endpoints: null,
     containers: null,
-    fetchOk: null,
+    serverError: null,
     versionstring: null,
   }),
   computed: {
@@ -77,126 +46,64 @@ export default {
         );
       }).length;
     },
-    status: function () {
-      return this.fetchOk ? "online" : "offline";
+    badges() {
+      return [
+        {
+          key: "running",
+          label: "Running",
+          value: this.running,
+          tone: "success",
+        },
+        { key: "dead", label: "Dead", value: this.dead, tone: "danger" },
+        {
+          key: "misc",
+          label: "Other (creating, paused, exited, etc.)",
+          value: this.misc,
+          tone: "neutral",
+        },
+      ];
     },
-  },
-  created() {
-    // Set up auto-update method for the scheduler
-    this.autoUpdateMethod = this.fetchStatus;
-
-    // Initial data fetch
-    this.fetchStatus();
-    this.fetchVersion();
   },
   methods: {
-    fetchStatus: async function () {
+    fetchData: function () {
       const headers = {
         "X-Api-Key": this.item.apikey,
       };
 
-      this.endpoints = await this.fetch("/api/endpoints", { headers }).catch(
-        (e) => {
-          console.error(e);
-        },
+      return this.load(
+        this.fetch("/api/status", { headers }).then((response) => {
+          this.versionstring = response.Version;
+        }),
+        this.fetchContainers(headers),
+      );
+    },
+    fetchContainers: async function (headers) {
+      const endpoints = await this.fetch("/api/endpoints", { headers });
+      const wanted = endpoints.filter(
+        (endpoint) =>
+          !this.item.environments ||
+          this.item.environments.includes(endpoint.Name),
       );
 
-      let containers = [];
-      for (let endpoint of this.endpoints) {
-        if (
-          this.item.environments &&
-          !this.item.environments.includes(endpoint.Name)
-        ) {
-          continue;
-        }
-        const uri = `/api/endpoints/${endpoint.Id}/docker/containers/json?all=1`;
-        const endpointContainers = await this.fetch(uri, { headers }).catch(
-          (e) => {
-            console.error(e);
-          },
-        );
+      // One dead environment must not blank the others, but still reports.
+      const results = await Promise.allSettled(
+        wanted.map((endpoint) =>
+          this.fetch(
+            `/api/endpoints/${endpoint.Id}/docker/containers/json?all=1`,
+            { headers },
+          ),
+        ),
+      );
 
-        if (endpointContainers) {
-          containers = containers.concat(endpointContainers);
-        }
+      this.containers = results
+        .filter((result) => result.status === "fulfilled")
+        .flatMap((result) => result.value);
+
+      const failed = results.find((result) => result.status === "rejected");
+      if (failed) {
+        throw failed.reason;
       }
-
-      this.containers = containers;
-    },
-    fetchVersion: async function () {
-      const headers = {
-        "X-Api-Key": this.item.apikey,
-      };
-      this.fetch("/api/status", { headers })
-        .then((response) => {
-          this.fetchOk = true;
-          this.versionstring = response.Version;
-        })
-        .catch((e) => {
-          this.fetchOk = false;
-          console.error(e);
-        });
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.status {
-  font-size: 0.8rem;
-  color: var(--text-title);
-  white-space: nowrap;
-  margin-left: 0.25rem;
-
-  &.online:before {
-    background-color: #94e185;
-    border-color: #78d965;
-    box-shadow: 0 0 5px 1px #94e185;
-  }
-
-  &.offline:before {
-    background-color: #c9404d;
-    border-color: #c42c3b;
-    box-shadow: 0 0 5px 1px #c9404d;
-  }
-
-  &:before {
-    content: " ";
-    display: inline-block;
-    width: 7px;
-    height: 7px;
-    margin-right: 10px;
-    border: 1px solid #000;
-    border-radius: 7px;
-  }
-}
-
-.notifs {
-  position: absolute;
-  color: white;
-  font-family: sans-serif;
-  top: 0.3em;
-  right: 0.5em;
-
-  .notif {
-    display: inline-block;
-    padding: 0.2em 0.35em;
-    border-radius: 0.25em;
-    position: relative;
-    margin-left: 0.3em;
-    font-size: 0.8em;
-
-    &.running {
-      background-color: #4fd671;
-    }
-
-    &.dead {
-      background-color: #e51111;
-    }
-
-    &.misc {
-      background-color: #2ed0c8;
-    }
-  }
-}
-</style>

--- a/src/components/services/Prometheus.vue
+++ b/src/components/services/Prometheus.vue
@@ -1,20 +1,9 @@
 <template>
-  <Generic :item="item">
-    <template #content>
-      <p class="title is-4">{{ item.name }}</p>
-      <p class="subtitle is-6">
-        <template v-if="item.subtitle">
-          {{ item.subtitle }}
-        </template>
-        <template v-else-if="api"> {{ count }} {{ level }} alerts </template>
-      </p>
-    </template>
-    <template #indicator>
-      <div v-if="api" class="status" :class="level">
-        {{ count }}
-      </div>
-    </template>
-  </Generic>
+  <Generic
+    :item="item"
+    :subtitle="api && `${count} ${level} alerts`"
+    :status="status"
+  />
 </template>
 
 <script>
@@ -26,13 +15,17 @@ const AlertsStatus = Object.freeze({
   inactive: "inactive",
 });
 
+const ALERT_STATE = {
+  firing: "offline",
+  pending: "warning",
+  inactive: "online",
+};
+
 export default {
   name: "Prometheus",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => ({
+    serverError: null,
     api: {
       status: "",
       count: 0,
@@ -57,17 +50,20 @@ export default {
       }
       return AlertsStatus.inactive;
     },
-  },
-  created() {
-    // Set up auto-update method for the scheduler
-    this.autoUpdateMethod = this.fetchStatus;
-
-    // Initial data fetch
-    this.fetchStatus();
+    status: function () {
+      if (this.serverError) {
+        return this.reachabilityStatus();
+      }
+      return this.api && { state: ALERT_STATE[this.level], label: this.count };
+    },
   },
   methods: {
-    fetchStatus: async function () {
-      this.api = await this.fetch("api/v1/alerts").catch((e) => console.log(e));
+    fetchData: function () {
+      return this.load(
+        this.fetch("api/v1/alerts").then((api) => {
+          this.api = api;
+        }),
+      );
     },
     countFiring: function () {
       if (this.api) {
@@ -96,38 +92,3 @@ export default {
   },
 };
 </script>
-
-<style scoped lang="scss">
-.status {
-  font-size: 0.8rem;
-  color: var(--text-title);
-
-  &.firing:before {
-    background-color: #d65c68;
-    border-color: #e87d88;
-    box-shadow: 0 0 5px 1px #d65c68;
-  }
-
-  &.pending:before {
-    background-color: #e8bb7d;
-    border-color: #d6a35c;
-    box-shadow: 0 0 5px 1px #e8bb7d;
-  }
-
-  &.inactive:before {
-    background-color: #8fe87d;
-    border-color: #70d65c;
-    box-shadow: 0 0 5px 1px #8fe87d;
-  }
-
-  &:before {
-    content: " ";
-    display: inline-block;
-    width: 7px;
-    height: 7px;
-    margin-right: 10px;
-    border: 1px solid #000;
-    border-radius: 7px;
-  }
-}
-</style>

--- a/src/components/services/Prowlarr.vue
+++ b/src/components/services/Prowlarr.vue
@@ -1,23 +1,5 @@
 <template>
-  <Generic :item="item">
-    <template #indicator>
-      <div class="notifs">
-        <strong v-if="warnings > 0" class="notif warnings" title="Warning">
-          {{ warnings }}
-        </strong>
-        <strong v-if="errors > 0" class="notif errors" title="Error">
-          {{ errors }}
-        </strong>
-        <strong
-          v-if="serverError"
-          class="notif errors"
-          title="Connection error to Prowlarr API, check url and apikey in config.yml"
-        >
-          ?
-        </strong>
-      </div>
-    </template>
-  </Generic>
+  <Generic :item="item" :badges="badges" />
 </template>
 
 <script>
@@ -26,69 +8,45 @@ import service from "@/mixins/service.js";
 export default {
   name: "Prowlarr",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => {
     return {
       warnings: null,
       errors: null,
-      serverError: false,
+      serverError: null,
     };
   },
-  created() {
-    // Set up auto-update method for the scheduler
-    this.autoUpdateMethod = this.fetchConfig;
-
-    // Initial data fetch
-    this.fetchConfig();
+  computed: {
+    badges() {
+      return [
+        {
+          key: "warnings",
+          label: "Warning",
+          value: this.warnings,
+          tone: "warning",
+        },
+        { key: "errors", label: "Error", value: this.errors, tone: "danger" },
+        this.connectionBadge(),
+      ];
+    },
   },
   methods: {
-    fetchConfig: function () {
-      this.fetch(`/api/v1/health?apikey=${this.item.apikey}`)
-        .then((health) => {
-          this.warnings = 0;
-          this.errors = 0;
-          for (var i = 0; i < health.length; i++) {
-            if (health[i].type == "warning") {
-              this.warnings++;
-            } else if (health[i].type == "error") {
-              this.errors++;
+    fetchData: function () {
+      return this.load(
+        this.fetch(`/api/v1/health?apikey=${this.item.apikey}`).then(
+          (health) => {
+            this.warnings = 0;
+            this.errors = 0;
+            for (var i = 0; i < health.length; i++) {
+              if (health[i].type == "warning") {
+                this.warnings++;
+              } else if (health[i].type == "error") {
+                this.errors++;
+              }
             }
-          }
-        })
-        .catch((e) => {
-          console.error(e);
-          this.serverError = true;
-        });
+          },
+        ),
+      );
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.notifs {
-  position: absolute;
-  color: white;
-  font-family: sans-serif;
-  top: 0.3em;
-  right: 0.5em;
-
-  .notif {
-    display: inline-block;
-    padding: 0.2em 0.35em;
-    border-radius: 0.25em;
-    position: relative;
-    margin-left: 0.3em;
-    font-size: 0.8em;
-
-    &.warnings {
-      background-color: #d08d2e;
-    }
-
-    &.errors {
-      background-color: #e51111;
-    }
-  }
-}
-</style>

--- a/src/components/services/Proxmox.vue
+++ b/src/components/services/Proxmox.vue
@@ -1,75 +1,66 @@
 <template>
-  <Generic :item="item">
-    <template #content>
-      <p class="title is-4">{{ item.name }}</p>
-      <p class="subtitle is-6">
-        <template v-if="item.subtitle">
-          {{ item.subtitle }}
-        </template>
-        <template v-else-if="vms">
-          <div v-if="loading">
-            <strong>Loading...</strong>
-          </div>
-          <div v-else-if="error">
-            <strong class="danger">Error loading info</strong>
-          </div>
-          <div
-            v-else
-            class="metrics"
-            :class="{
-              'is-size-7-mobile': item.small_font_on_small_screens,
-              'is-small': item.small_font_on_desktop,
-            }"
-          >
-            <span v-if="isValueShown('vms')" class="margined"
-              >VMs:
-              <span class="is-number"
-                ><span class="has-text-weight-bold">{{ vms.running }}</span
-                ><span v-if="isValueShown('vms_total')"
-                  >/{{ vms.total }}</span
-                ></span
-              ></span
-            >
-            <span v-if="isValueShown('lxcs')" class="margined"
-              >LXCs:
-              <span class="is-number"
-                ><span class="has-text-weight-bold">{{ lxcs.running }}</span
-                ><span v-if="isValueShown('lxcs_total')"
-                  >/{{ lxcs.total }}</span
-                ></span
-              ></span
-            >
-            <span v-if="isValueShown('disk')" class="margined"
-              >Disk:
-              <span
-                class="has-text-weight-bold is-number"
-                :class="statusClass(diskUsed)"
-                >{{ diskUsed }}%</span
-              ></span
-            >
-            <span v-if="isValueShown('mem')" class="margined"
-              >Mem:
-              <span
-                class="has-text-weight-bold is-number"
-                :class="statusClass(memoryUsed)"
-                >{{ memoryUsed }}%</span
-              ></span
-            >
-            <span v-if="isValueShown('cpu')" class="margined"
-              >CPU:
-              <span
-                class="has-text-weight-bold is-number"
-                :class="statusClass(cpuUsed)"
-                >{{ cpuUsed }}%</span
-              ></span
-            >
-          </div>
-        </template>
-      </p>
+  <Generic :item="item" :badges="badges">
+    <template v-if="vms" #subtitle>
+      <div v-if="loading">
+        <strong>Loading...</strong>
+      </div>
+      <div v-else-if="serverError">
+        <strong class="danger">Error loading info</strong>
+      </div>
+      <div
+        v-else
+        class="metrics"
+        :class="{
+          'is-size-7-mobile': item.small_font_on_small_screens,
+          'is-small': item.small_font_on_desktop,
+        }"
+      >
+        <span v-if="isValueShown('vms')" class="margined"
+          >VMs:
+          <span class="is-number"
+            ><span class="has-text-weight-bold">{{ vms.running }}</span
+            ><span v-if="isValueShown('vms_total')"
+              >/{{ vms.total }}</span
+            ></span
+          ></span
+        >
+        <span v-if="isValueShown('lxcs') && lxcs.total" class="margined"
+          >LXCs:
+          <span class="is-number"
+            ><span class="has-text-weight-bold">{{ lxcs.running }}</span
+            ><span v-if="isValueShown('lxcs_total')"
+              >/{{ lxcs.total }}</span
+            ></span
+          ></span
+        >
+        <span v-if="isValueShown('disk')" class="margined"
+          >Disk:
+          <span
+            class="has-text-weight-bold is-number"
+            :class="statusClass(diskUsed)"
+            >{{ diskUsed }}%</span
+          ></span
+        >
+        <span v-if="isValueShown('mem')" class="margined"
+          >Mem:
+          <span
+            class="has-text-weight-bold is-number"
+            :class="statusClass(memoryUsed)"
+            >{{ memoryUsed }}%</span
+          ></span
+        >
+        <span v-if="isValueShown('cpu')" class="margined"
+          >CPU:
+          <span
+            class="has-text-weight-bold is-number"
+            :class="statusClass(cpuUsed)"
+            >{{ cpuUsed }}%</span
+          ></span
+        >
+      </div>
     </template>
-    <template #indicator>
-      <i v-if="loading" class="fa fa-circle-notch fa-spin fa-2xl"></i>
-      <i v-if="error" class="fa fa-exclamation-circle fa-2xl danger"></i>
+    <template v-if="loading" #aside>
+      <i class="fa fa-circle-notch fa-spin fa-2xl"></i>
     </template>
   </Generic>
 </template>
@@ -80,9 +71,6 @@ import service from "@/mixins/service.js";
 export default {
   name: "Proxmox",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => ({
     vms: {
       total: 0,
@@ -95,18 +83,13 @@ export default {
     memoryUsed: 0,
     diskUsed: 0,
     cpuUsed: 0,
-    hide: [],
-    error: false,
+    serverError: null,
     loading: true,
   }),
-  created() {
-    if (this.item.hide) this.hide = this.item.hide;
-
-    // Set up auto-update method for the scheduler
-    this.autoUpdateMethod = this.fetchStatus;
-
-    // Initial data fetch
-    this.fetchStatus();
+  computed: {
+    badges() {
+      return [this.connectionBadge()];
+    },
   },
   methods: {
     statusClass(value) {
@@ -114,7 +97,7 @@ export default {
       if (value > this.item.warning_value) return "warning";
       return "healthy";
     },
-    fetchStatus: async function () {
+    fetchData: async function () {
       try {
         const options = {
           headers: {
@@ -152,21 +135,16 @@ export default {
           );
           this.parseVMsAndLXCs(lxcs, this.lxcs);
         }
-        this.error = false;
+        this.serverError = false;
       } catch (err) {
-        console.log(err);
-        this.error = true;
+        console.error(err);
+        this.serverError = true;
       }
       this.loading = false;
     },
     parseVMsAndLXCs(items, value) {
-      value.total += items.data.length;
-      value.running += items.data.filter((i) => i.status === "running").length;
-      // if no vms, hide this value:
-      if (value.total == 0) this.hide.push("lxcs");
-    },
-    isValueShown(value) {
-      return this.hide.indexOf(value) == -1;
+      value.total = items.data.length;
+      value.running = items.data.filter((i) => i.status === "running").length;
     },
   },
 };
@@ -174,13 +152,13 @@ export default {
 
 <style scoped lang="scss">
 .healthy {
-  color: green;
+  color: var(--status-online);
 }
 .warning {
-  color: orange;
+  color: var(--status-warning);
 }
 .danger {
-  color: red;
+  color: var(--status-offline);
 }
 .metrics .margined:not(:first-child) {
   margin-left: 0.3rem;

--- a/src/components/services/Radarr.vue
+++ b/src/components/services/Radarr.vue
@@ -1,28 +1,5 @@
 <template>
-  <Generic :item="item">
-    <template #indicator>
-      <div class="notifs">
-        <strong v-if="activity > 0" class="notif activity" title="Activity">
-          {{ activity }}
-        </strong>
-        <strong v-if="missing > 0" class="notif missing" title="Missing">
-          {{ missing }}
-        </strong>
-        <strong v-if="warnings > 0" class="notif warnings" title="Warning">
-          {{ warnings }}
-        </strong>
-        <strong v-if="errors > 0" class="notif errors" title="Error">
-          {{ errors }}
-        </strong>
-        <strong
-          v-if="serverError"
-          class="notif errors"
-          title="Connection error to Radarr API, check url and apikey in config.yml"
-          >?</strong
-        >
-      </div>
-    </template>
-  </Generic>
+  <Generic :item="item" :badges="badges" />
 </template>
 
 <script>
@@ -34,125 +11,101 @@ const LEGACY_API = "/api";
 export default {
   name: "Radarr",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => {
     return {
       activity: null,
       missing: null,
       warnings: null,
       errors: null,
-      serverError: false,
+      serverError: null,
     };
   },
   computed: {
     apiPath() {
       return this.item.legacyApi ? LEGACY_API : V3_API;
     },
-  },
-  created() {
-    // Set up auto-update method for the scheduler
-    this.autoUpdateMethod = this.fetchConfig;
-
-    // Initial data fetch
-    this.fetchConfig();
+    badges() {
+      return [
+        {
+          key: "activity",
+          label: "Activity",
+          value: this.activity,
+          tone: "info",
+        },
+        {
+          key: "missing",
+          label: "Missing",
+          value: this.missing,
+          tone: "accent",
+        },
+        {
+          key: "warnings",
+          label: "Warning",
+          value: this.warnings,
+          tone: "warning",
+        },
+        { key: "errors", label: "Error", value: this.errors, tone: "danger" },
+        this.connectionBadge(),
+      ];
+    },
   },
   methods: {
-    fetchConfig: function () {
-      const handleError = (e) => {
-        console.error(e);
-        this.serverError = true;
-      };
-      this.fetch(`${this.apiPath}/health?apikey=${this.item.apikey}`)
-        .then((health) => {
-          this.warnings = 0;
-          this.errors = 0;
-          for (var i = 0; i < health.length; i++) {
-            if (health[i].type == "warning") {
-              this.warnings++;
-            } else if (health[i].type == "error") {
-              this.errors++;
-            }
-          }
-        })
-        .catch(handleError);
-      if (!this.item.legacyApi) {
-        this.fetch(`${this.apiPath}/queue/details?apikey=${this.item.apikey}`)
-          .then((queue) => {
-            for (var i = 0; i < queue.length; i++) {
-              if (queue[i].trackedDownloadStatus == "warning") {
-                this.warnings++;
-              } else if (queue[i].trackedDownloadStaus == "error") {
-                this.errors++;
-              }
-            }
-          })
-          .catch(handleError);
-      }
-      this.fetch(`${this.apiPath}/queue?apikey=${this.item.apikey}`)
-        .then((queue) => {
-          this.activity = 0;
+    fetchData: function () {
+      const apikey = this.item.apikey;
 
-          if (this.item.legacyApi) {
-            for (var i = 0; i < queue.length; i++) {
-              if (queue[i].movie) {
-                this.activity++;
-              }
-            }
-          } else {
-            this.activity = queue.totalRecords;
-          }
-        })
-        .catch(handleError);
-      if (!this.item.legacyApi) {
-        this.fetch(
-          `${this.apiPath}/wanted/missing?pageSize=1&apikey=${this.item.apikey}`,
-        )
-          .then((overview) => {
+      // Both feed warnings/errors, so they are assigned once rather than
+      // incremented from two concurrent responses.
+      const health = this.fetch(`${this.apiPath}/health?apikey=${apikey}`).then(
+        (entries) => ({
+          warnings: entries.filter((h) => h.type == "warning").length,
+          errors: entries.filter((h) => h.type == "error").length,
+        }),
+      );
+
+      const requests = [
+        this.fetch(`${this.apiPath}/queue?apikey=${apikey}`).then((queue) => {
+          this.activity = this.item.legacyApi
+            ? queue.filter((entry) => entry.movie).length
+            : queue.totalRecords;
+        }),
+      ];
+
+      if (this.item.legacyApi) {
+        requests.push(
+          health.then((counts) => {
+            this.warnings = counts.warnings;
+            this.errors = counts.errors;
+          }),
+        );
+      } else {
+        requests.push(
+          Promise.all([
+            health,
+            this.fetch(`${this.apiPath}/queue/details?apikey=${apikey}`),
+          ]).then(([counts, queue]) => {
+            this.warnings =
+              counts.warnings +
+              queue.filter((e) => e.trackedDownloadStatus == "warning").length;
+            this.errors =
+              counts.errors +
+              queue.filter((e) => e.trackedDownloadStatus == "error").length;
+          }),
+          this.fetch(
+            `${this.apiPath}/wanted/missing?pageSize=1&apikey=${apikey}`,
+          ).then((overview) =>
             this.fetch(
-              `${this.apiPath}/wanted/missing?pageSize=${overview.totalRecords}&apikey=${this.item.apikey}`,
+              `${this.apiPath}/wanted/missing?pageSize=${overview.totalRecords}&apikey=${apikey}`,
             ).then((movies) => {
               this.missing = movies.records.filter(
                 (m) => m.monitored && m.isAvailable && !m.hasFile,
               ).length;
-            });
-          })
-          .catch(handleError);
+            }),
+          ),
+        );
       }
+
+      return this.load(...requests);
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.notifs {
-  position: absolute;
-  color: white;
-  font-family: sans-serif;
-  top: 0.3em;
-  right: 0.5em;
-  .notif {
-    display: inline-block;
-    padding: 0.2em 0.35em;
-    border-radius: 0.25em;
-    position: relative;
-    margin-left: 0.3em;
-    font-size: 0.8em;
-    &.activity {
-      background-color: #4fb5d6;
-    }
-
-    &.missing {
-      background-color: #9d00ff;
-    }
-    &.warnings {
-      background-color: #d08d2e;
-    }
-
-    &.errors {
-      background-color: #e51111;
-    }
-  }
-}
-</style>

--- a/src/components/services/Readarr.vue
+++ b/src/components/services/Readarr.vue
@@ -1,28 +1,5 @@
 <template>
-  <Generic :item="item">
-    <template #indicator>
-      <div class="notifs">
-        <strong v-if="activity > 0" class="notif activity" title="Activity">
-          {{ activity }}
-        </strong>
-        <strong v-if="missing > 0" class="notif missing" title="Missing">
-          {{ missing }}
-        </strong>
-        <strong v-if="warnings > 0" class="notif warnings" title="Warning">
-          {{ warnings }}
-        </strong>
-        <strong v-if="errors > 0" class="notif errors" title="Error">
-          {{ errors }}
-        </strong>
-        <strong
-          v-if="serverError"
-          class="notif errors"
-          title="Connection error to Readarr API, check url and apikey in config.yml"
-          >?</strong
-        >
-      </div>
-    </template>
-  </Generic>
+  <Generic :item="item" :badges="badges" />
 </template>
 
 <script>
@@ -33,80 +10,60 @@ const API = "/api/v1";
 export default {
   name: "Readarr",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => {
     return {
       activity: null,
       missing: null,
       warnings: null,
       errors: null,
-      serverError: false,
+      serverError: null,
     };
   },
-  created: function () {
-    // Set up auto-update method for the scheduler
-    this.autoUpdateMethod = this.fetchConfig;
-
-    // Initial data fetch
-    this.fetchConfig();
+  computed: {
+    badges() {
+      return [
+        {
+          key: "activity",
+          label: "Activity",
+          value: this.activity,
+          tone: "info",
+        },
+        {
+          key: "missing",
+          label: "Missing",
+          value: this.missing,
+          tone: "accent",
+        },
+        {
+          key: "warnings",
+          label: "Warning",
+          value: this.warnings,
+          tone: "warning",
+        },
+        { key: "errors", label: "Error", value: this.errors, tone: "danger" },
+        this.connectionBadge(),
+      ];
+    },
   },
   methods: {
-    fetchConfig: function () {
-      const handleError = (e) => {
-        console.error(e);
-        this.serverError = true;
-      };
-      this.fetch(`${API}/health?apikey=${this.item.apikey}`)
-        .then((health) => {
-          this.warnings = health.filter((h) => h.type === "warning").length;
-          this.errors = health.filter((h) => h.type === "errors").length;
-        })
-        .catch(handleError);
-      this.fetch(`${API}/queue?apikey=${this.item.apikey}`)
-        .then((queue) => {
+    fetchData: function () {
+      return this.load(
+        this.fetch(`${API}/health?apikey=${this.item.apikey}`).then(
+          (health) => {
+            this.warnings = health.filter((h) => h.type === "warning").length;
+            this.errors = health.filter((h) => h.type === "error").length;
+          },
+        ),
+        this.fetch(`${API}/queue?apikey=${this.item.apikey}`).then((queue) => {
           this.activity = queue.totalRecords;
-        })
-        .catch(handleError);
-      this.fetch(`${API}/wanted/missing?apikey=${this.item.apikey}`)
-        .then((missing) => {
-          this.missing = missing.totalRecords;
-        })
-        .catch(handleError);
+        }),
+        this.fetch(`${API}/wanted/missing?apikey=${this.item.apikey}`).then(
+          (missing) => {
+            this.missing = missing.totalRecords;
+          },
+        ),
+      );
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.notifs {
-  position: absolute;
-  color: white;
-  font-family: sans-serif;
-  top: 0.3em;
-  right: 0.5em;
-  display: flex;
-  gap: 0.2rem;
-  .notif {
-    padding: 0.2em 0.35em;
-    border-radius: 0.25em;
-    font-size: 0.8em;
-    &.activity {
-      background-color: #4fb5d6;
-    }
-
-    &.missing {
-      background-color: #9d00ff;
-    }
-
-    &.warnings {
-      background-color: #d08d2e;
-    }
-
-    &.errors {
-      background-color: #e51111;
-    }
-  }
-}
-</style>

--- a/src/components/services/Rtorrent.vue
+++ b/src/components/services/Rtorrent.vue
@@ -1,54 +1,25 @@
 <template>
-  <Generic :item="item">
-    <template #content>
-      <p class="title is-4">{{ item.name }}</p>
-      <p class="subtitle is-6">
-        <span v-if="error" class="error">An error has occurred.</span>
-        <template v-else>
-          <span class="down">
-            <i class="fas fa-download"></i> {{ downRate }}
-          </span>
-          <span class="up"> <i class="fas fa-upload"></i> {{ upRate }} </span>
-        </template>
-      </p>
-    </template>
-    <template #indicator>
-      <span v-if="!error" class="count"
-        >{{ count }}
-        <template v-if="count === 1">torrent</template>
-        <template v-else>torrents</template>
+  <Generic :item="item" :badges="badges">
+    <template #subtitle>
+      <span class="is-family-monospace mr-3">
+        <i class="fas fa-download"></i> {{ downRate }}
+      </span>
+      <span class="is-family-monospace">
+        <i class="fas fa-upload"></i> {{ upRate }}
       </span>
     </template>
   </Generic>
 </template>
 
 <script>
-// Units to add to download and upload rates.
-const units = ["B", "kiB", "MiB", "GiB"];
-
-// Take the rate in bytes and keep dividing it by 1k until the lowest
-// value for which we have a unit is determined. Return the value with
-// up to two decimals as a string and unit/s appended.
-const displayRate = (rate) => {
-  let i = 0;
-
-  while (rate > 1000 && i < units.length) {
-    rate /= 1000;
-    i++;
-  }
-
-  return (
-    Intl.NumberFormat(undefined, { maximumFractionDigits: 2 }).format(
-      rate || 0,
-    ) + ` ${units[i]}/s`
-  );
-};
+import service from "@/mixins/service.js";
+import { displayRate } from "@/utils/format.js";
 
 export default {
   name: "RTorrent",
-  props: { item: Object },
+  mixins: [service],
   // Properties for download, upload, torrent count and errors.
-  data: () => ({ dl: null, ul: null, count: null, error: null }),
+  data: () => ({ dl: null, ul: null, count: null, serverError: null }),
   // Computed properties for the rate labels.
   computed: {
     downRate: function () {
@@ -57,36 +28,29 @@ export default {
     upRate: function () {
       return displayRate(this.ul);
     },
-  },
-  created() {
-    // Set up auto-update method for the scheduler
-    this.autoUpdateMethod = this.fetchAllData;
-
-    // Fetch the initial values.
-    this.fetchAllData();
+    badges: function () {
+      return [
+        {
+          key: "torrents",
+          label: "Torrents",
+          value: this.count,
+          tone: "neutral",
+        },
+        this.connectionBadge(),
+      ];
+    },
   },
   methods: {
-    // Combined method for scheduler - fetches both rates and count
-    fetchAllData: async function () {
-      this.fetchRates();
-      this.fetchCount();
-    },
-    // Perform two calls to the XML-RPC service and fetch download
-    // and upload rates. Values are saved to the `ul` and `dl`
-    // properties.
-    fetchRates: async function () {
-      this.getRate("throttle.global_up.rate")
-        .then((ul) => (this.ul = ul))
-        .catch(() => (this.error = true));
+    fetchData: function () {
+      if (!this.requireConfig("xmlrpc")) {
+        return;
+      }
 
-      this.getRate("throttle.global_down.rate")
-        .then((dl) => (this.dl = dl))
-        .catch(() => (this.error = true));
-    },
-    // Perform a call to the XML-RPC service to fetch the number of
-    // torrents.
-    fetchCount: async function () {
-      this.getCount().catch(() => (this.error = true));
+      return this.load(
+        this.getRate("throttle.global_up.rate").then((ul) => (this.ul = ul)),
+        this.getRate("throttle.global_down.rate").then((dl) => (this.dl = dl)),
+        this.getCount(),
+      );
     },
     // Fetch a numeric value from the XML-RPC service by requesting
     // the specified method name and parsing the XML. The response
@@ -139,16 +103,3 @@ export default {
   },
 };
 </script>
-
-<style scoped lang="scss">
-.error {
-  color: #e51111 !important;
-}
-.down {
-  margin-right: 1em;
-}
-.count {
-  color: var(--text);
-  font-size: 0.8em;
-}
-</style>

--- a/src/components/services/SABnzbd.vue
+++ b/src/components/services/SABnzbd.vue
@@ -1,70 +1,24 @@
 <template>
-  <Generic :item="item">
-    <template #indicator>
-      <div class="notifs">
-        <strong
-          v-if="downloads > 0"
-          class="notif downloading"
-          :title="`${downloads} active download${downloads > 1 ? 's' : ''}`"
-        >
-          {{ downloads }}
-        </strong>
-        <i
-          v-if="error"
-          class="notif error fa-solid fa-triangle-exclamation"
-          title="Unable to fetch current status"
-        ></i>
-      </div>
-    </template>
-    <template #content>
-      <p class="title is-4">{{ item.name }}</p>
-      <p v-if="item.subtitle" class="subtitle">
-        {{ item.subtitle }}
-      </p>
-      <template v-else>
-        <p class="subtitle is-6">
-          <span v-if="error" class="error">An error has occurred.</span>
-          <template v-else>
-            <span class="down monospace">
-              <p class="fas fa-download"></p>
-              {{ downRate }}
-            </span>
-          </template>
-        </p>
-      </template>
+  <Generic :item="item" :badges="badges">
+    <template #subtitle>
+      <span class="is-family-monospace">
+        <i class="fas fa-download"></i>
+        {{ downRate }}
+      </span>
     </template>
   </Generic>
 </template>
 
 <script>
 import service from "@/mixins/service.js";
-
-const units = ["KB", "MB", "GB"];
-
-// Function to convert rate into a human-readable format
-const displayRate = (rate) => {
-  let i = 0;
-
-  while (rate > 1000 && i < units.length) {
-    rate /= 1000;
-    i++;
-  }
-  return (
-    Intl.NumberFormat(undefined, { maximumFractionDigits: 2 }).format(
-      rate || 0,
-    ) + ` ${units[i]}/s`
-  );
-};
+import { displayRate } from "@/utils/format.js";
 
 export default {
   name: "SABnzbd",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => ({
     stats: null,
-    error: false,
+    serverError: null,
     dlSpeed: null,
     ulSpeed: null,
   }),
@@ -78,72 +32,30 @@ export default {
     downRate() {
       return displayRate(this.dlSpeed);
     },
-  },
-  created() {
-    // Set up auto-update method for the scheduler
-    this.autoUpdateMethod = this.fetchStatus;
-
-    // Initial data fetch
-    this.fetchStatus();
+    badges() {
+      return [
+        {
+          key: "downloads",
+          label: "Active downloads",
+          value: this.downloads,
+          tone: "info",
+        },
+        this.connectionBadge(),
+      ];
+    },
   },
   methods: {
-    fetchStatus: async function () {
-      try {
-        const response = await this.fetch(
+    fetchData: function () {
+      return this.load(
+        this.fetch(
           `/api?output=json&apikey=${this.item.apikey}&mode=queue`,
-        );
-        this.error = false;
-        this.stats = response.queue;
-
-        // Fetching download speed from "speed" (convert to KB/s if needed)
-        this.dlSpeed = parseFloat(response.queue.speed) * 1024; // Convert MB to KB
-      } catch (e) {
-        this.error = true;
-        console.error(e);
-      }
+        ).then((response) => {
+          this.stats = response.queue;
+          // `speed` carries a unit suffix ("512 K"); kbpersec is the number.
+          this.dlSpeed = parseFloat(response.queue.kbpersec) * 1000;
+        }),
+      );
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.notifs {
-  position: absolute;
-  color: white;
-  font-family: sans-serif;
-  top: 0.3em;
-  right: 0.5em;
-
-  .notif {
-    display: inline-block;
-    padding: 0.2em 0.35em;
-    border-radius: 0.25em;
-    position: relative;
-    margin-left: 0.3em;
-    font-size: 0.8em;
-
-    &.downloading {
-      background-color: #4fb5d6;
-    }
-
-    &.error {
-      border-radius: 50%;
-      aspect-ratio: 1;
-      background-color: #e51111;
-    }
-  }
-}
-
-.error {
-  color: #e51111 !important;
-}
-
-.down {
-  margin-right: 1em;
-}
-
-.monospace {
-  font-weight: 300;
-  font-family: monospace;
-}
-</style>

--- a/src/components/services/Scrutiny.vue
+++ b/src/components/services/Scrutiny.vue
@@ -1,25 +1,5 @@
 <template>
-  <Generic :item="item">
-    <template #indicator>
-      <div class="notifs">
-        <strong v-if="passed > 0" class="notif passed" title="Passed">
-          {{ passed }}
-        </strong>
-        <strong v-if="failed > 0" class="notif failed" title="Failed">
-          {{ failed }}
-        </strong>
-        <strong v-if="unknown > 0" class="notif unknown" title="Unknown">
-          {{ unknown }}
-        </strong>
-        <strong
-          v-if="serverError"
-          class="notif errors"
-          title="Connection error to Scrutiny API, check your url in config.yml"
-          >?</strong
-        >
-      </div>
-    </template>
-  </Generic>
+  <Generic :item="item" :badges="badges" />
 </template>
 
 <script>
@@ -28,79 +8,58 @@ import service from "@/mixins/service.js";
 export default {
   name: "Scrutiny",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => {
     return {
       passed: null,
       failed: null,
       unknown: null,
-      serverError: false,
+      serverError: null,
     };
   },
-  created: function () {
-    // Set up auto-update method for the scheduler
-    this.autoUpdateMethod = this.fetchSummary;
-
-    // Initial data fetch
-    this.fetchSummary();
+  computed: {
+    badges() {
+      return [
+        {
+          key: "passed",
+          label: "Passed",
+          value: this.passed,
+          tone: "success",
+        },
+        { key: "failed", label: "Failed", value: this.failed, tone: "danger" },
+        {
+          key: "unknown",
+          label: "Unknown",
+          value: this.unknown,
+          tone: "warning",
+        },
+        this.connectionBadge(),
+      ];
+    },
   },
   methods: {
-    fetchSummary: function () {
-      this.fetch(`/api/summary`)
-        .then((scrutinyData) => {
-          const devices = Object.values(scrutinyData.data.summary);       
+    fetchData: function () {
+      return this.load(
+        this.fetch(`/api/summary`).then((scrutinyData) => {
+          const devices = Object.values(scrutinyData.data.summary);
           const availableDevices = devices.filter(
             (device) =>
-              device.device.archived === false &&
-              !device.device.DeletedAt
+              device.device.archived === false && !device.device.DeletedAt,
           );
           this.passed =
             availableDevices.filter(
-              (device) => 
-                device.device.device_status === 0)?.length || 0;
+              (device) => device.device.device_status === 0,
+            )?.length || 0;
           this.failed =
             availableDevices.filter(
               (device) =>
                 device.device.device_status > 0 &&
-                device.device.device_status <= 3)?.length || 0;
-          this.unknown = availableDevices.length - (this.passed + this.failed) || 0;
-        })
-        .catch((e) => {
-          console.error(e);
-          this.serverError = true;
-        });
+                device.device.device_status <= 3,
+            )?.length || 0;
+          this.unknown =
+            availableDevices.length - (this.passed + this.failed) || 0;
+        }),
+      );
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.notifs {
-  position: absolute;
-  color: white;
-  font-family: sans-serif;
-  top: 0.3em;
-  right: 0.5em;
-  .notif {
-    display: inline-block;
-    padding: 0.2em 0.35em;
-    border-radius: 0.25em;
-    position: relative;
-    margin-left: 0.3em;
-    font-size: 0.8em;
-    &.passed {
-      background-color: green;
-    }
-
-    &.failed {
-      background-color: #e51111;
-    }
-
-    &.unknown {
-      background-color: #d08d2e;
-    }
-  }
-}
-</style>

--- a/src/components/services/Seerr.vue
+++ b/src/components/services/Seerr.vue
@@ -1,39 +1,13 @@
 <template>
-  <Generic :item="item">
-    <template #content>
-      <p class="title is-4">{{ item.name }}</p>
-      <p class="subtitle is-6">
-        <template v-if="item.subtitle">{{ item.subtitle }}</template>
-        <template v-else-if="versionstring">
-          Version {{ versionstring }}
-          <i
-            v-for="icon in visibleIcons"
-            :key="icon.key"
-            class="state"
-            :class="icon.class"
-          ></i>
-        </template>
-      </p>
-    </template>
-    <template #indicator>
-      <div class="notifs">
-        <strong
-          v-for="badge in visibleBadges"
-          :key="badge.key"
-          class="notif"
-          :style="{ backgroundColor: badge.color }"
-          :title="badge.label"
-        >
-          {{ badge.text }}
-        </strong>
-        <strong
-          v-if="serverError"
-          class="notif errors"
-          title="Connection error to Seerr API, check url and apikey in config.yml"
-        >
-          ?
-        </strong>
-      </div>
+  <Generic :item="item" :badges="badges">
+    <template v-if="versionstring" #subtitle>
+      {{ versionSubtitle }}
+      <i
+        v-for="icon in visibleIcons"
+        :key="icon.key"
+        class="state"
+        :class="icon.class"
+      ></i>
     </template>
   </Generic>
 </template>
@@ -56,33 +30,33 @@ const icons = [
   { key: "restartRequired", class: "fa-solid fa-recycle" },
 ];
 
-// Indicator badges; count reads the response landed by `from`.
-const badges = [
+// Count reads the response landed by `from`.
+const counters = [
   {
     key: "media",
     label: "Available media",
-    color: "#2ac194",
+    tone: "success",
     from: "media",
     count: (data) => data?.pageInfo?.results,
   },
   {
     key: "pending",
     label: "Pending requests",
-    color: "#0a4bc4",
+    tone: "info",
     from: "requests",
     count: (data) => data?.pending,
   },
   {
     key: "processing",
     label: "Processing requests",
-    color: "#6f11a6",
+    tone: "accent",
     from: "requests",
     count: (data) => data?.processing,
   },
   {
     key: "issues",
     label: "Open issues",
-    color: "#c1942a",
+    tone: "warning",
     from: "issues",
     count: (data) => data?.open,
   },
@@ -91,9 +65,6 @@ const badges = [
 export default {
   name: "Seerr",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => ({
     status: null,
     requests: null,
@@ -105,22 +76,22 @@ export default {
     serverError() {
       return Object.values(this.failed).some(Boolean);
     },
-    visibleBadges() {
-      return badges
-        .map((badge) => {
-          const value = this.isValueShown(badge.key)
-            ? badge.count(this[badge.from]) || 0
-            : 0;
-          return { ...badge, value, text: this.capCount(value) };
-        })
-        .filter((badge) => badge.value > 0);
+    badges() {
+      return [
+        ...counters.map(({ count, from, ...badge }) => ({
+          ...badge,
+          value: count(this[from]),
+        })),
+        this.connectionBadge(),
+      ];
     },
     versionstring() {
       return this.status?.version;
     },
     visibleIcons() {
       return icons.filter(
-        (icon) => this.isValueShown(icon.key) && this.status?.[icon.key] === true,
+        (icon) =>
+          this.isValueShown(icon.key) && this.status?.[icon.key] === true,
       );
     },
   },
@@ -145,7 +116,7 @@ export default {
       if (this.isValueShown("issues")) keys.push("issues");
       return keys;
     },
-    load(key) {
+    loadEndpoint(key) {
       return this.fetch(endpoints[key], this.fetchOptions)
         .then((data) => {
           this[key] = data;
@@ -156,9 +127,10 @@ export default {
           this.failed[key] = true;
         });
     },
-    // Each load catches its own failure, so one bad endpoint can't sink the batch.
     fetchStats() {
-      return Promise.all(this.endpointsToFetch.map((key) => this.load(key)));
+      return Promise.all(
+        this.endpointsToFetch.map((key) => this.loadEndpoint(key)),
+      );
     },
   },
 };
@@ -167,26 +139,5 @@ export default {
 <style scoped lang="scss">
 .state {
   margin-left: 0.2em;
-}
-
-.notifs {
-  position: absolute;
-  color: white;
-  font-family: sans-serif;
-  top: 0.3em;
-  right: 0.5em;
-
-  .notif {
-    display: inline-block;
-    padding: 0.2em 0.35em;
-    border-radius: 0.25em;
-    position: relative;
-    margin-left: 0.3em;
-    font-size: 0.8em;
-
-    &.errors {
-      background-color: #c12a57;
-    }
-  }
 }
 </style>

--- a/src/components/services/Sonarr.vue
+++ b/src/components/services/Sonarr.vue
@@ -1,29 +1,5 @@
 <template>
-  <Generic :item="item">
-    <template #indicator>
-      <div class="notifs">
-        <strong v-if="activity > 0" class="notif activity" title="Activity">
-          {{ activity }}
-        </strong>
-        <strong v-if="missing > 0" class="notif missing" title="Missing">
-          {{ missing }}
-        </strong>
-        <strong v-if="warnings > 0" class="notif warnings" title="Warning">
-          {{ warnings }}
-        </strong>
-        <strong v-if="errors > 0" class="notif errors" title="Error">
-          {{ errors }}
-        </strong>
-        <strong
-          v-if="serverError"
-          class="notif errors"
-          title="Connection error to Sonarr API, check url and apikey in config.yml"
-        >
-          ?
-        </strong>
-      </div>
-    </template>
-  </Generic>
+  <Generic :item="item" :badges="badges" />
 </template>
 
 <script>
@@ -35,97 +11,74 @@ const LEGACY_API = "/api";
 export default {
   name: "Sonarr",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => {
     return {
       activity: null,
       missing: null,
       warnings: null,
       errors: null,
-      serverError: false,
+      serverError: null,
     };
   },
   computed: {
     apiPath() {
       return this.item.legacyApi ? LEGACY_API : V3_API;
     },
-  },
-  created() {
-    // Set up auto-update method for the scheduler
-    this.autoUpdateMethod = this.fetchConfig;
-
-    // Initial data fetch
-    this.fetchConfig();
+    badges() {
+      return [
+        {
+          key: "activity",
+          label: "Activity",
+          value: this.activity,
+          tone: "info",
+        },
+        {
+          key: "missing",
+          label: "Missing",
+          value: this.missing,
+          tone: "accent",
+        },
+        {
+          key: "warnings",
+          label: "Warning",
+          value: this.warnings,
+          tone: "warning",
+        },
+        { key: "errors", label: "Error", value: this.errors, tone: "danger" },
+        this.connectionBadge(),
+      ];
+    },
   },
   methods: {
-    fetchConfig: function () {
-      const handleError = (e) => {
-        console.error(e);
-        this.serverError = true;
-      };
-      this.fetch(`${this.apiPath}/health?apikey=${this.item.apikey}`)
-        .then((health) => {
-          this.warnings = health.filter((h) => h.type === "warning").length;
-          this.errors = health.filter((h) => h.type === "errors").length;
-        })
-        .catch(handleError);
-      this.fetch(`${this.apiPath}/queue?apikey=${this.item.apikey}`)
-        .then((queue) => {
-          this.activity = 0;
-          if (this.item.legacyApi) {
-            for (var i = 0; i < queue.length; i++) {
-              if (queue[i].series) {
-                this.activity++;
+    fetchData: function () {
+      return this.load(
+        this.fetch(`${this.apiPath}/health?apikey=${this.item.apikey}`).then(
+          (health) => {
+            this.warnings = health.filter((h) => h.type === "warning").length;
+            this.errors = health.filter((h) => h.type === "error").length;
+          },
+        ),
+        this.fetch(`${this.apiPath}/queue?apikey=${this.item.apikey}`).then(
+          (queue) => {
+            this.activity = 0;
+            if (this.item.legacyApi) {
+              for (var i = 0; i < queue.length; i++) {
+                if (queue[i].series) {
+                  this.activity++;
+                }
               }
+            } else {
+              this.activity = queue.totalRecords;
             }
-          } else {
-            this.activity = queue.totalRecords;
-          }
-        })
-        .catch(handleError);
-      this.fetch(`${this.apiPath}/wanted/missing?apikey=${this.item.apikey}`)
-        .then((missing) => {
+          },
+        ),
+        this.fetch(
+          `${this.apiPath}/wanted/missing?apikey=${this.item.apikey}`,
+        ).then((missing) => {
           this.missing = missing.totalRecords;
-        })
-        .catch(handleError);
+        }),
+      );
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.notifs {
-  position: absolute;
-  color: white;
-  font-family: sans-serif;
-  top: 0.3em;
-  right: 0.5em;
-
-  .notif {
-    display: inline-block;
-    padding: 0.2em 0.35em;
-    border-radius: 0.25em;
-    position: relative;
-    margin-left: 0.3em;
-    font-size: 0.8em;
-
-    &.activity {
-      background-color: #4fb5d6;
-    }
-
-    &.missing {
-      background-color: #9d00ff;
-    }
-
-    &.warnings {
-      background-color: #d08d2e;
-    }
-
-    &.errors {
-      background-color: #e51111;
-    }
-  }
-}
-</style>

--- a/src/components/services/SpeedtestTracker.vue
+++ b/src/components/services/SpeedtestTracker.vue
@@ -1,14 +1,9 @@
 <template>
-  <Generic :item="item">
-    <template #content>
-      <p class="title is-4">{{ item.name }}</p>
-      <p class="subtitle is-6">
-        <template v-if="speedtest">
-          <i class="fas fa-arrow-down"></i> {{ download }} Mbit/s |
-          <i class="fas fa-arrow-up"></i> {{ upload }} Mbit/s |
-          <i class="fas fa-stopwatch"></i> {{ ping }} ms
-        </template>
-      </p>
+  <Generic :item="item" :badges="badges">
+    <template v-if="speedtest" #subtitle>
+      <i class="fas fa-arrow-down"></i> {{ download }} Mbit/s |
+      <i class="fas fa-arrow-up"></i> {{ upload }} Mbit/s |
+      <i class="fas fa-stopwatch"></i> {{ ping }} ms
     </template>
   </Generic>
 </template>
@@ -19,13 +14,14 @@ import service from "@/mixins/service.js";
 export default {
   name: "SpeedtestTracker",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => ({
     speedtest: null,
+    serverError: null,
   }),
   computed: {
+    badges() {
+      return [this.connectionBadge()];
+    },
     download: function () {
       return this.format(this.speedtest?.download);
     },
@@ -36,16 +32,13 @@ export default {
       return this.format(this.speedtest?.ping);
     },
   },
-  created() {
-    this.fetchStatus();
-  },
   methods: {
-    fetchStatus: async function () {
-      this.fetch("/api/speedtest/latest")
-        .then((response) => {
+    fetchData: function () {
+      return this.load(
+        this.fetch("/api/speedtest/latest").then((response) => {
           this.speedtest = response.data;
-        })
-        .catch((e) => console.log(e));
+        }),
+      );
     },
     format: function (value) {
       return value ? parseFloat(value).toFixed(2) : "n/a";

--- a/src/components/services/Tautulli.vue
+++ b/src/components/services/Tautulli.vue
@@ -1,22 +1,5 @@
 <template>
-  <Generic :item="item">
-    <template #indicator>
-      <div class="notifs">
-        <strong
-          v-if="streams > 0"
-          class="notif playing"
-          :title="`${streams} active stream${streams > 1 ? 's' : ''}`"
-        >
-          {{ streams }}
-        </strong>
-        <i
-          v-if="error"
-          class="notif error fa-solid fa-triangle-exclamation"
-          title="Unable to fetch current status"
-        ></i>
-      </div>
-    </template>
-  </Generic>
+  <Generic :item="item" :badges="badges" />
 </template>
 
 <script>
@@ -25,70 +8,36 @@ import service from "@/mixins/service.js";
 export default {
   name: "Tautulli",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => ({
     stats: null,
-    error: false,
+    serverError: null,
   }),
   computed: {
     streams: function () {
-      if (!this.stats) {
-        return "";
-      }
-      return this.stats.stream_count;
+      return this.stats?.stream_count;
+    },
+    badges() {
+      return [
+        {
+          key: "streams",
+          label: "Active streams",
+          value: this.streams,
+          tone: "success",
+        },
+        this.connectionBadge(),
+      ];
     },
   },
-  created() {
-    // Set up auto-update method for the scheduler
-    this.autoUpdateMethod = this.fetchStatus;
-
-    // Initial data fetch
-    this.fetchStatus();
-  },
   methods: {
-    fetchStatus: async function () {
-      try {
-        const response = await this.fetch(
-          `/api/v2?apikey=${this.item.apikey}&cmd=get_activity`,
-        );
-        this.error = false;
-        this.stats = response.response.data;
-      } catch (e) {
-        this.error = true;
-        console.error(e);
-      }
+    fetchData: function () {
+      return this.load(
+        this.fetch(`/api/v2?apikey=${this.item.apikey}&cmd=get_activity`).then(
+          (response) => {
+            this.stats = response.response.data;
+          },
+        ),
+      );
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.notifs {
-  position: absolute;
-  color: white;
-  font-family: sans-serif;
-  top: 0.3em;
-  right: 0.5em;
-
-  .notif {
-    display: inline-block;
-    padding: 0.2em 0.35em;
-    border-radius: 0.25em;
-    position: relative;
-    margin-left: 0.3em;
-    font-size: 0.8em;
-
-    &.playing {
-      background-color: #28a9a3;
-    }
-
-    &.error {
-      border-radius: 50%;
-      aspect-ratio: 1;
-      background-color: #e51111;
-    }
-  }
-}
-</style>

--- a/src/components/services/Tdarr.vue
+++ b/src/components/services/Tdarr.vue
@@ -1,29 +1,5 @@
 <template>
-  <Generic :item="item">
-    <template #indicator>
-      <div class="notifs">
-        <strong
-          v-if="queue > 0"
-          class="notif queue"
-          :title="`${queue} items queued`"
-        >
-          {{ queue }}
-        </strong>
-        <strong
-          v-if="errored > 0"
-          class="notif errored"
-          :title="`${errored} items`"
-        >
-          {{ errored }}
-        </strong>
-        <i
-          v-if="error"
-          class="notif error fa-solid fa-triangle-exclamation"
-          title="Unable to fetch current status"
-        ></i>
-      </div>
-    </template>
-  </Generic>
+  <Generic :item="item" :badges="badges" />
 </template>
 
 <script>
@@ -32,95 +8,61 @@ import service from "@/mixins/service.js";
 export default {
   name: "Tdarr",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => ({
     stats: null,
-    error: false,
+    serverError: null,
   }),
   computed: {
     queue: function () {
-      if (!this.stats) {
-        return "";
-      }
-      return this.stats.table1Count;
+      return this.stats?.table1Count;
     },
     errored: function () {
-      if (!this.stats) {
-        return "";
-      }
-      return this.stats.table6Count;
+      return this.stats?.table6Count;
+    },
+    badges() {
+      return [
+        {
+          key: "queue",
+          label: "Queued items",
+          value: this.queue,
+          tone: "info",
+        },
+        {
+          key: "errored",
+          label: "Errored items",
+          value: this.errored,
+          tone: "danger",
+        },
+        this.connectionBadge(),
+      ];
     },
   },
-  created() {
-    // Set up auto-update method for the scheduler
-    this.autoUpdateMethod = this.fetchStatus;
-
-    // Initial data fetch
-    this.fetchStatus();
-  },
   methods: {
-    fetchStatus: async function () {
-      try {
-        const options = {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Accept: "application/json",
+    fetchData: function () {
+      const options = {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify({
+          headers: { "content-Type": "application/json" },
+          data: {
+            collection: "StatisticsJSONDB",
+            mode: "getById",
+            docID: "statistics",
+            obj: {},
           },
-          body: JSON.stringify({
-            headers: { "content-Type": "application/json" },
-            data: {
-              collection: "StatisticsJSONDB",
-              mode: "getById",
-              docID: "statistics",
-              obj: {},
-            },
-            timeout: 1000,
-          }),
-        };
-        const response = await this.fetch(`/api/v2/cruddb`, options);
-        this.error = false;
-        this.stats = response;
-      } catch (e) {
-        this.error = true;
-        console.error(e);
-      }
+          timeout: 1000,
+        }),
+      };
+
+      return this.load(
+        this.fetch(`/api/v2/cruddb`, options).then((response) => {
+          this.stats = response;
+        }),
+      );
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.notifs {
-  position: absolute;
-  color: white;
-  font-family: sans-serif;
-  top: 0.3em;
-  right: 0.5em;
-
-  .notif {
-    display: inline-block;
-    padding: 0.2em 0.35em;
-    border-radius: 0.25em;
-    position: relative;
-    margin-left: 0.3em;
-    font-size: 0.8em;
-
-    &.queue {
-      background-color: #28a9a3;
-    }
-
-    &.errored {
-      background-color: #e51111;
-    }
-
-    &.error {
-      border-radius: 50%;
-      aspect-ratio: 1;
-      background-color: #e51111;
-    }
-  }
-}
-</style>

--- a/src/components/services/ThemeChooser.vue
+++ b/src/components/services/ThemeChooser.vue
@@ -1,19 +1,13 @@
 <template>
   <Generic :item="item">
-    <template #content>
-      <p class="title is-4">{{ item.name }}</p>
-      <div class="subtitle is-6">
-        <template v-if="item.subtitle">
-          {{ item.subtitle }}
-        </template>
-        <div class="select is-small">
-          <select v-model="theme" @change="switchTheme">
-            <option value="" disabled selected>Available themes</option>
-            <option value="theme-classic">classic</option>
-            <option value="theme-neon">neon</option>
-            <option value="theme-walkxcode">walkxcode</option>
-          </select>
-        </div>
+    <template #subtitle>
+      <div class="select is-small">
+        <select v-model="theme" @change="switchTheme">
+          <option value="" disabled selected>Available themes</option>
+          <option value="theme-classic">classic</option>
+          <option value="theme-neon">neon</option>
+          <option value="theme-walkxcode">walkxcode</option>
+        </select>
       </div>
     </template>
   </Generic>
@@ -49,9 +43,14 @@ export default {
 </script>
 
 <style scoped lang="scss">
-.select,
+// Bulma sizes its controls at 2.5em, which overflows the card under the title.
+.select {
+  --bulma-control-height: 1.5rem;
+  --bulma-control-padding-vertical: 0;
+  --bulma-control-padding-horizontal: 0.5em;
+}
+
 select {
-  width: 100%;
   background-color: var(--card-background);
 }
 </style>

--- a/src/components/services/Traefik.vue
+++ b/src/components/services/Traefik.vue
@@ -1,22 +1,9 @@
 <template>
-  <Generic :item="item">
-    <template #content>
-      <p class="title is-4">{{ item.name }}</p>
-      <p class="subtitle is-6">
-        <template v-if="item.subtitle">
-          {{ item.subtitle }}
-        </template>
-        <template v-else-if="versionstring">
-          Version {{ versionstring }}
-        </template>
-      </p>
-    </template>
-    <template #indicator>
-      <div v-if="status" class="status" :class="status">
-        {{ status }}
-      </div>
-    </template>
-  </Generic>
+  <Generic
+    :item="item"
+    :subtitle="versionSubtitle"
+    :status="reachabilityStatus()"
+  />
 </template>
 
 <script>
@@ -25,69 +12,23 @@ import service from "@/mixins/service.js";
 export default {
   name: "Traefik",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => ({
-    fetchOk: null,
+    serverError: null,
     versionstring: null,
   }),
-  computed: {
-    status: function () {
-      return this.fetchOk ? "online" : "offline";
-    },
-  },
-  created() {
-    this.fetchStatus();
-  },
   methods: {
-    fetchStatus: async function () {
+    fetchData: function () {
       let headers = {};
       if (this.item.basic_auth) {
         const encodedCredentials = btoa(this.item.basic_auth);
         headers["Authorization"] = `Basic ${encodedCredentials}`;
       }
-      this.fetch("/api/version", { headers })
-        .then((response) => {
-          this.fetchOk = true;
+      return this.load(
+        this.fetch("/api/version", { headers }).then((response) => {
           this.versionstring = response.Version;
-        })
-        .catch((e) => {
-          this.fetchOk = false;
-          console.log(e);
-        });
+        }),
+      );
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.status {
-  font-size: 0.8rem;
-  color: var(--text-title);
-  white-space: nowrap;
-  margin-left: 0.25rem;
-
-  &.online:before {
-    background-color: #94e185;
-    border-color: #78d965;
-    box-shadow: 0 0 5px 1px #94e185;
-  }
-
-  &.offline:before {
-    background-color: #c9404d;
-    border-color: #c42c3b;
-    box-shadow: 0 0 5px 1px #c9404d;
-  }
-
-  &:before {
-    content: " ";
-    display: inline-block;
-    width: 7px;
-    height: 7px;
-    margin-right: 10px;
-    border: 1px solid #000;
-    border-radius: 7px;
-  }
-}
-</style>

--- a/src/components/services/Transmission.vue
+++ b/src/components/services/Transmission.vue
@@ -1,27 +1,13 @@
 <template>
-  <Generic :item="item">
-    <template #content>
-      <p class="title is-4">{{ item.name }}</p>
-      <p v-if="item.subtitle" class="subtitle is-6">{{ item.subtitle }}</p>
-      <p v-else class="subtitle is-6">
-        <span v-if="error" class="error">An error has occurred.</span>
-        <template v-else>
-          <span class="down monospace">
-            <p class="fas fa-download"></p>
-            {{ downRate }}
-          </span>
-          <span class="up monospace">
-            <p class="fas fa-upload"></p>
-            {{ upRate }}
-          </span>
-        </template>
-      </p>
-    </template>
-    <template #indicator>
-      <span v-if="!error" class="count"
-        >{{ count || 0 }}
-        <template v-if="(count || 0) === 1">torrent</template>
-        <template v-else>torrents</template>
+  <Generic :item="item" :badges="badges">
+    <template #subtitle>
+      <span class="is-family-monospace mr-3">
+        <i class="fas fa-download"></i>
+        {{ downRate }}
+      </span>
+      <span class="is-family-monospace">
+        <i class="fas fa-upload"></i>
+        {{ upRate }}
       </span>
     </template>
   </Generic>
@@ -29,36 +15,17 @@
 
 <script>
 import service from "@/mixins/service.js";
-const units = ["B", "KB", "MB", "GB"];
-
-// Take the rate in bytes and keep dividing it by 1k until the lowest
-// value for which we have a unit is determined. Return the value with
-// up to two decimals as a string and unit/s appended.
-const displayRate = (rate) => {
-  let unitIndex = 0;
-
-  while (rate > 1000 && unitIndex < units.length - 1) {
-    rate /= 1000;
-    unitIndex++;
-  }
-  return (
-    Intl.NumberFormat(undefined, { maximumFractionDigits: 2 }).format(
-      rate || 0,
-    ) + ` ${units[unitIndex]}/s`
-  );
-};
+import { displayRate } from "@/utils/format.js";
 
 export default {
   name: "Transmission",
   mixins: [service],
-  props: { item: Object },
   data: () => ({
     dl: null,
     ul: null,
     count: null,
-    error: null,
+    serverError: null,
     sessionId: null,
-    retry: 0,
   }),
   computed: {
     downRate: function () {
@@ -67,21 +34,27 @@ export default {
     upRate: function () {
       return displayRate(this.ul);
     },
-  },
-  created() {
-    // Set up auto-update method for the scheduler
-    this.autoUpdateMethod = this.getStats;
-
-    // Initial fetch
-    this.getStats();
+    badges: function () {
+      return [
+        {
+          key: "torrents",
+          label: "Active torrents",
+          value: this.count,
+          tone: "neutral",
+        },
+        this.connectionBadge(),
+      ];
+    },
   },
   methods: {
     /**
-     * Makes a request to Transmission RPC API with proper session handling
+     * Transmission answers 409 with a fresh session id whenever it rotates
+     * one, so every call gets its own retry.
      * @param {string} method - The RPC method to call
+     * @param {boolean} retried - Internal: guards against a retry loop
      * @returns {Promise<Object>} RPC response
      */
-    transmissionRequest: async function (method) {
+    transmissionRequest: async function (method, retried = false) {
       const options = this.getRequestHeaders(method);
 
       // Add session ID header if we have one
@@ -92,18 +65,25 @@ export default {
       try {
         return await this.fetch("transmission/rpc", options);
       } catch (error) {
-        // Handle Transmission's 409 session requirement
-        if (error.cause.status == 409 && this.retry <= 1) {
-          const sessionId = await this.getSession();
+        if (error.cause?.status === 409 && !retried) {
+          const sessionId = await this.readSessionId(error.cause);
           if (sessionId) {
             this.sessionId = sessionId;
-            this.retry++;
-            return this.transmissionRequest(method);
+            return this.transmissionRequest(method, true);
           }
         }
-        console.error("Transmission RPC error:", error);
         throw error;
       }
+    },
+    // Cross-origin the header needs Access-Control-Expose-Headers, but the id
+    // is also in the body, which is always readable.
+    readSessionId: async function (response) {
+      const header = response.headers.get("X-Transmission-Session-Id");
+      if (header) {
+        return header;
+      }
+      const body = await response.text().catch(() => "");
+      return body.match(/X-Transmission-Session-Id:\s*([^\s<]+)/)?.[1] ?? null;
     },
     getRequestHeaders: function (method) {
       const options = {
@@ -120,58 +100,22 @@ export default {
 
       return options;
     },
-    getSession: async function () {
-      try {
-        await this.fetch(
-          "transmission/rpc",
-          this.getRequestHeaders("session-get"),
-        );
-      } catch (error) {
-        if (error.cause.status == 409) {
-          return error.cause.headers.get("X-Transmission-Session-Id");
-        }
-      }
-    },
-    getStats: async function () {
-      try {
-        // Get session stats for transfer rates and torrent count
-        const statsResponse = await this.transmissionRequest("session-stats");
-        if (statsResponse?.result !== "success") {
-          throw new Error(
-            `Transmission RPC failed: ${statsResponse?.result || "Unknown error"}`,
-          );
-        }
+    fetchData: function () {
+      return this.load(
+        this.transmissionRequest("session-stats").then((statsResponse) => {
+          if (statsResponse?.result !== "success") {
+            throw new Error(
+              `Transmission RPC failed: ${statsResponse?.result || "Unknown error"}`,
+            );
+          }
 
-        const stats = statsResponse.arguments;
-        this.dl = stats.downloadSpeed ?? 0;
-        this.ul = stats.uploadSpeed ?? 0;
-        this.count = stats.activeTorrentCount ?? 0;
-        this.error = false;
-      } catch (e) {
-        this.error = true;
-        console.error("Transmission service error:", e);
-      }
+          const stats = statsResponse.arguments;
+          this.dl = stats.downloadSpeed ?? 0;
+          this.ul = stats.uploadSpeed ?? 0;
+          this.count = stats.activeTorrentCount ?? 0;
+        }),
+      );
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.error {
-  color: #e51111 !important;
-}
-
-.down {
-  margin-right: 1em;
-}
-
-.count {
-  color: var(--text);
-  font-size: 0.8em;
-}
-
-.monospace {
-  font-weight: 300;
-  font-family: monospace;
-}
-</style>

--- a/src/components/services/TruenasScale.vue
+++ b/src/components/services/TruenasScale.vue
@@ -1,23 +1,10 @@
 <template>
-  <Generic :item="item">
-    <template #content>
-      <p class="title is-4">{{ item.name }}</p>
-      <p class="subtitle is-6">
-        <template v-if="item.subtitle">
-          {{ item.subtitle }}
-        </template>
-        <template v-else-if="versionstring">
-          <span class="is-hidden-touch">Version {{ versionstring }}</span>
-          <span class="is-hidden-desktop"
-            >Version {{ versionstring.split("-").pop() }}</span
-          >
-        </template>
-      </p>
-    </template>
-    <template #indicator>
-      <div v-if="status" class="status" :class="status">
-        {{ status }}
-      </div>
+  <Generic :item="item" :status="reachabilityStatus()">
+    <template v-if="versionstring" #subtitle>
+      <span class="is-hidden-touch">Version {{ versionstring }}</span>
+      <span class="is-hidden-desktop"
+        >Version {{ versionstring.split("-").pop() }}</span
+      >
     </template>
   </Generic>
 </template>
@@ -28,68 +15,26 @@ import service from "@/mixins/service.js";
 export default {
   name: "TruenasScale",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => ({
-    fetchOk: null,
+    serverError: null,
     versionstring: null,
   }),
-  computed: {
-    status: function () {
-      return this.fetchOk ? "online" : "offline";
-    },
-  },
-  created() {
-    this.fetchStatus();
-  },
   methods: {
-    fetchStatus: async function () {
+    fetchData: async function () {
       let headers = {};
       if (this.item.api_token) {
         headers["Authorization"] = `Bearer ${this.item.api_token}`;
       }
       this.fetch("/api/v2.0/system/version", { headers })
         .then((response) => {
-          this.fetchOk = true;
+          this.serverError = false;
           this.versionstring = response;
         })
         .catch((e) => {
-          this.fetchOk = false;
-          console.log(e);
+          this.serverError = true;
+          console.error(e);
         });
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.status {
-  font-size: 0.8rem;
-  color: var(--text-title);
-  white-space: nowrap;
-  margin-left: 0.25rem;
-
-  &.online:before {
-    background-color: #94e185;
-    border-color: #78d965;
-    box-shadow: 0 0 5px 1px #94e185;
-  }
-
-  &.offline:before {
-    background-color: #c9404d;
-    border-color: #c42c3b;
-    box-shadow: 0 0 5px 1px #c9404d;
-  }
-
-  &:before {
-    content: " ";
-    display: inline-block;
-    width: 7px;
-    height: 7px;
-    margin-right: 10px;
-    border: 1px solid #000;
-    border-radius: 7px;
-  }
-}
-</style>

--- a/src/components/services/UptimeKuma.vue
+++ b/src/components/services/UptimeKuma.vue
@@ -1,46 +1,44 @@
 <template>
-  <Generic :item="item">
-    <template #content>
-      <p class="title is-4">{{ item.name }}</p>
-      <p class="subtitle is-6">
-        <template v-if="item.subtitle">
-          {{ item.subtitle }}
-        </template>
-        <template v-else-if="status">
-          {{ statusMessage }}
-        </template>
-      </p>
-    </template>
-    <template #indicator>
-      <div v-if="status" class="status" :class="status">
-        {{ uptime }}&percnt;
-      </div>
-    </template>
-  </Generic>
+  <Generic :item="item" :subtitle="statusMessage" :status="status" />
 </template>
 
 <script>
 import service from "@/mixins/service.js";
 
+const PAGE_STATE = {
+  good: "online",
+  warn: "warning",
+  bad: "offline",
+};
+
 export default {
   name: "UptimeKuma",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => ({
     incident: null,
     heartbeat: null,
+    serverError: null,
   }),
   computed: {
     slug: function () {
       return this.item.slug ? this.item.slug : "default";
     },
-    status: function () {
+    state: function () {
       if (!this.incident) {
         return "";
       }
       return this.incident.incident == null ? this.pageStatus : "bad";
+    },
+    status: function () {
+      if (this.serverError) {
+        return this.reachabilityStatus();
+      }
+      return (
+        this.state && {
+          state: PAGE_STATE[this.state],
+          label: `${this.uptime}%`,
+        }
+      );
     },
     lastHeartBeatList: function () {
       let result = {};
@@ -107,59 +105,23 @@ export default {
       return (percent * 100).toFixed(1);
     },
   },
-  created() {
-    // Set up auto-update method for the scheduler
-    this.autoUpdateMethod = this.fetchStatus;
-
-    // Initial data fetch
-    this.fetchStatus();
-  },
   methods: {
-    fetchStatus: function () {
+    fetchData: function () {
       const now = Date.now();
-      this.fetch(`/api/status-page/${this.slug}?cachebust=${now}`)
-        .catch((e) => console.error(e))
-        .then((resp) => (this.incident = resp));
 
-      this.fetch(`/api/status-page/heartbeat/${this.slug}?cachebust=${now}`)
-        .catch((e) => console.error(e))
-        .then((resp) => (this.heartbeat = resp));
+      return this.load(
+        this.fetch(`/api/status-page/${this.slug}?cachebust=${now}`).then(
+          (incident) => {
+            this.incident = incident;
+          },
+        ),
+        this.fetch(
+          `/api/status-page/heartbeat/${this.slug}?cachebust=${now}`,
+        ).then((heartbeat) => {
+          this.heartbeat = heartbeat;
+        }),
+      );
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.status {
-  font-size: 0.8rem;
-  color: var(--text-title);
-
-  &.good:before {
-    background-color: #94e185;
-    border-color: #78d965;
-    box-shadow: 0 0 5px 1px #94e185;
-  }
-
-  &.warn:before {
-    background-color: #f8a306;
-    border-color: #e1b35e;
-    box-shadow: 0 0 5px 1px #f8a306;
-  }
-
-  &.bad:before {
-    background-color: #c9404d;
-    border-color: #c42c3b;
-    box-shadow: 0 0 5px 1px #c9404d;
-  }
-
-  &:before {
-    content: " ";
-    display: inline-block;
-    width: 7px;
-    height: 7px;
-    margin-right: 10px;
-    border: 1px solid #000;
-    border-radius: 7px;
-  }
-}
-</style>

--- a/src/components/services/Vaultwarden.vue
+++ b/src/components/services/Vaultwarden.vue
@@ -1,22 +1,9 @@
 <template>
-  <Generic :item="item">
-    <template #content>
-      <p class="title is-4">{{ item.name }}</p>
-      <p class="subtitle is-6">
-        <template v-if="item.subtitle">
-          {{ item.subtitle }}
-        </template>
-        <template v-else-if="versionstring">
-          Version {{ versionstring }}
-        </template>
-      </p>
-    </template>
-    <template #indicator>
-      <div v-if="status" class="status" :class="status">
-        {{ status }}
-      </div>
-    </template>
-  </Generic>
+  <Generic
+    :item="item"
+    :subtitle="versionSubtitle"
+    :status="reachabilityStatus()"
+  />
 </template>
 
 <script>
@@ -25,64 +12,18 @@ import service from "@/mixins/service.js";
 export default {
   name: "Vaultwarden",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => ({
-    fetchOk: null,
+    serverError: null,
     versionstring: null,
   }),
-  computed: {
-    status: function () {
-      return this.fetchOk ? "online" : "offline";
-    },
-  },
-  created() {
-    this.fetchStatus();
-  },
   methods: {
-    fetchStatus: async function () {
-      this.fetch("api/version")
-        .then((response) => {
-          this.fetchOk = true;
+    fetchData: function () {
+      return this.load(
+        this.fetch("api/version").then((response) => {
           this.versionstring = response;
-        })
-        .catch((e) => {
-          this.fetchOk = false;
-          console.log(e);
-        });
+        }),
+      );
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.status {
-  font-size: 0.8rem;
-  color: var(--text-title);
-  white-space: nowrap;
-  margin-left: 0.25rem;
-
-  &.online:before {
-    background-color: #94e185;
-    border-color: #78d965;
-    box-shadow: 0 0 5px 1px #94e185;
-  }
-
-  &.offline:before {
-    background-color: #c9404d;
-    border-color: #c42c3b;
-    box-shadow: 0 0 5px 1px #c9404d;
-  }
-
-  &:before {
-    content: " ";
-    display: inline-block;
-    width: 7px;
-    height: 7px;
-    margin-right: 10px;
-    border: 1px solid #000;
-    border-radius: 7px;
-  }
-}
-</style>

--- a/src/components/services/WUD.vue
+++ b/src/components/services/WUD.vue
@@ -1,23 +1,5 @@
 <template>
-  <Generic :item="item">
-    <template #indicator>
-      <div class="notifs">
-        <strong v-if="running > 0" class="notif warnings" title="Running">
-          {{ running }}
-        </strong>
-        <strong v-if="update > 0" class="notif errors" title="Update">
-          {{ update }}
-        </strong>
-        <strong
-          v-if="serverError"
-          class="notif errors"
-          title="Connection error to WUD API, check url in config.yml"
-        >
-          ?
-        </strong>
-      </div>
-    </template>
-  </Generic>
+  <Generic :item="item" :badges="badges" />
 </template>
 
 <script>
@@ -26,67 +8,38 @@ import service from "@/mixins/service.js";
 export default {
   name: "WUD",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => {
     return {
       running: null,
       update: null,
-      serverError: false,
+      serverError: null,
     };
   },
-  created: function () {
-    // Set up auto-update method for the scheduler
-    this.autoUpdateMethod = this.fetchConfig;
-
-    // Initial data fetch
-    this.fetchConfig();
+  computed: {
+    badges() {
+      return [
+        {
+          key: "running",
+          label: "Running",
+          value: this.running,
+          tone: "success",
+        },
+        { key: "update", label: "Update", value: this.update, tone: "warning" },
+        this.connectionBadge(),
+      ];
+    },
   },
   methods: {
-    fetchConfig: function () {
-      this.fetch(`/api/containers`)
-        .then((containers) => {
-          this.running = 0;
-          this.update = 0;
-          for (var i = 0; i < containers.length; i++) {
-            this.running++;
-            if (containers[i].updateAvailable) {
-              this.update++;
-            }
-          }
-        })
-        .catch(() => {
-          this.serverError = true;
-        });
+    fetchData: function () {
+      return this.load(
+        this.fetch(`/api/containers`).then((containers) => {
+          this.running = containers.length;
+          this.update = containers.filter(
+            (container) => container.updateAvailable,
+          ).length;
+        }),
+      );
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.notifs {
-  position: absolute;
-  color: white;
-  font-family: sans-serif;
-  top: 0.3em;
-  right: 0.5em;
-
-  .notif {
-    display: inline-block;
-    padding: 0.2em 0.35em;
-    border-radius: 0.25em;
-    position: relative;
-    margin-left: 0.3em;
-    font-size: 0.8em;
-
-    &.warnings {
-      background-color: #d08d2e;
-    }
-
-    &.errors {
-      background-color: #e51111;
-    }
-  }
-}
-</style>

--- a/src/components/services/Wallabag.vue
+++ b/src/components/services/Wallabag.vue
@@ -1,22 +1,9 @@
 <template>
-  <Generic :item="item">
-    <template #content>
-      <p class="title is-4">{{ item.name }}</p>
-      <p class="subtitle is-6">
-        <template v-if="item.subtitle">
-          {{ item.subtitle }}
-        </template>
-        <template v-else-if="versionstring">
-          Version {{ versionstring }}
-        </template>
-      </p>
-    </template>
-    <template #indicator>
-      <div v-if="status" class="status" :class="status">
-        {{ status }}
-      </div>
-    </template>
-  </Generic>
+  <Generic
+    :item="item"
+    :subtitle="versionSubtitle"
+    :status="reachabilityStatus()"
+  />
 </template>
 
 <script>
@@ -25,59 +12,18 @@ import service from "@/mixins/service.js";
 export default {
   name: "Wallabag",
   mixins: [service],
-  props: {
-    item: Object,
-  },
   data: () => ({
-    status: null,
+    serverError: null,
     versionstring: null,
   }),
-  created() {
-    this.fetchStatus();
-  },
   methods: {
-    fetchStatus: async function () {
-      this.fetch("/api/version")
-        .then((response) => {
-          this.status = "online";
+    fetchData: function () {
+      return this.load(
+        this.fetch("/api/version").then((response) => {
           this.versionstring = response;
-        })
-        .catch((e) => {
-          this.status = "offline";
-          console.log(e);
-        });
+        }),
+      );
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.status {
-  font-size: 0.8rem;
-  color: var(--text-title);
-  white-space: nowrap;
-  margin-left: 0.25rem;
-
-  &.online:before {
-    background-color: #94e185;
-    border-color: #78d965;
-    box-shadow: 0 0 5px 1px #94e185;
-  }
-
-  &.offline:before {
-    background-color: #c9404d;
-    border-color: #c42c3b;
-    box-shadow: 0 0 5px 1px #c9404d;
-  }
-
-  &:before {
-    content: " ";
-    display: inline-block;
-    width: 7px;
-    height: 7px;
-    margin-right: 10px;
-    border: 1px solid #000;
-    border-radius: 7px;
-  }
-}
-</style>

--- a/src/components/services/_error.vue
+++ b/src/components/services/_error.vue
@@ -1,10 +1,11 @@
 <template>
-  <Generic :item="item" :title="error.message" class="component-error">
-    <template #content>
-      <p class="title is-4">{{ item.name }}</p>
-      <p class="subtitle is-6">Failed to load component</p>
-    </template>
-    <template #indicator>⚠️</template>
+  <Generic
+    :item="item"
+    :title="error.message"
+    subtitle="Failed to load component"
+    class="component-error"
+  >
+    <template #aside>⚠️</template>
   </Generic>
 </template>
 
@@ -15,7 +16,6 @@ export default {
   name: "Error",
   mixins: [service],
   props: {
-    item: Object,
     error: Object,
   },
 };

--- a/src/components/services/qBittorrent.vue
+++ b/src/components/services/qBittorrent.vue
@@ -1,26 +1,13 @@
 <template>
-  <Generic :item="item">
-    <template #content>
-      <p class="title is-4">{{ item.name }}</p>
-      <p class="subtitle is-6">
-        <span v-if="error" class="error">An error has occurred.</span>
-        <template v-else>
-          <span class="down monospace">
-            <p class="fas fa-download"></p>
-            {{ downRate }}
-          </span>
-          <span class="up monospace">
-            <p class="fas fa-upload"></p>
-            {{ upRate }}
-          </span>
-        </template>
-      </p>
-    </template>
-    <template #indicator>
-      <span v-if="!error" class="count"
-        >{{ count }}
-        <template v-if="count === 1">torrent</template>
-        <template v-else>torrents</template>
+  <Generic :item="item" :badges="badges">
+    <template #subtitle>
+      <span class="is-family-monospace mr-3">
+        <i class="fas fa-download"></i>
+        {{ downRate }}
+      </span>
+      <span class="is-family-monospace">
+        <i class="fas fa-upload"></i>
+        {{ upRate }}
       </span>
     </template>
   </Generic>
@@ -28,30 +15,12 @@
 
 <script>
 import service from "@/mixins/service.js";
-const units = ["B", "KB", "MB", "GB"];
-
-// Take the rate in bytes and keep dividing it by 1k until the lowest
-// value for which we have a unit is determined. Return the value with
-// up to two decimals as a string and unit/s appended.
-const displayRate = (rate) => {
-  let i = 0;
-
-  while (rate > 1000 && i < units.length) {
-    rate /= 1000;
-    i++;
-  }
-  return (
-    Intl.NumberFormat(undefined, { maximumFractionDigits: 2 }).format(
-      rate || 0,
-    ) + ` ${units[i]}/s`
-  );
-};
+import { displayRate } from "@/utils/format.js";
 
 export default {
   name: "QBittorrent",
   mixins: [service],
-  props: { item: Object },
-  data: () => ({ dl: null, ul: null, count: null, error: null }),
+  data: () => ({ dl: null, ul: null, count: null, serverError: null }),
   computed: {
     downRate: function () {
       return displayRate(this.dl);
@@ -59,61 +28,30 @@ export default {
     upRate: function () {
       return displayRate(this.ul);
     },
-  },
-  created() {
-    // Set up auto-update method for the scheduler
-    this.autoUpdateMethod = this.fetchAllData;
-
-    // Fetch initial values
-    this.fetchAllData();
+    badges: function () {
+      return [
+        {
+          key: "torrents",
+          label: "Torrents",
+          value: this.count,
+          tone: "neutral",
+        },
+        this.connectionBadge(),
+      ];
+    },
   },
   methods: {
-    // Combined method for scheduler - fetches both rates and count
-    fetchAllData: async function () {
-      this.getRate();
-      this.fetchCount();
-    },
-    fetchCount: async function () {
-      try {
-        const body = await this.fetch("/api/v2/torrents/info");
-        this.error = false;
-        this.count = body.length;
-      } catch (e) {
-        this.error = true;
-        console.error(e);
-      }
-    },
-    getRate: async function () {
-      try {
-        const body = await this.fetch("/api/v2/transfer/info");
-        this.error = false;
-        this.dl = body.dl_info_speed;
-        this.ul = body.up_info_speed;
-      } catch (e) {
-        this.error = true;
-        console.error(e);
-      }
+    fetchData: function () {
+      return this.load(
+        this.fetch("/api/v2/torrents/info").then((body) => {
+          this.count = body.length;
+        }),
+        this.fetch("/api/v2/transfer/info").then((body) => {
+          this.dl = body.dl_info_speed;
+          this.ul = body.up_info_speed;
+        }),
+      );
     },
   },
 };
 </script>
-
-<style scoped lang="scss">
-.error {
-  color: #e51111 !important;
-}
-
-.down {
-  margin-right: 1em;
-}
-
-.count {
-  color: var(--text);
-  font-size: 0.8em;
-}
-
-.monospace {
-  font-weight: 300;
-  font-family: monospace;
-}
-</style>

--- a/src/mixins/service.js
+++ b/src/mixins/service.js
@@ -1,5 +1,4 @@
 import updateScheduler from "@/utils/updateScheduler.js";
-import { capCount } from "@/utils/format.js";
 
 // Header names are case-insensitive, so they are lowercased before merging and
 // each source overrides the previous one whatever its casing. Unset values are
@@ -18,6 +17,7 @@ function mergeHeaders(...sources) {
 
 export default {
   props: {
+    item: Object,
     proxy: Object,
   },
   inject: {
@@ -30,6 +30,9 @@ export default {
     globalConfig() {
       return this.config() || {};
     },
+    versionSubtitle() {
+      return this.versionstring ? `Version ${this.versionstring}` : null;
+    },
   },
   created: function () {
     // Custom service often consume info from an API using the item link (url) as a base url,
@@ -38,6 +41,13 @@ export default {
 
     if (this.endpoint && this.endpoint.endsWith("/")) {
       this.endpoint = this.endpoint.slice(0, -1);
+    }
+
+    // A card's own created() runs after this one, so it can still override
+    // autoUpdateMethod to pick a method at runtime.
+    if (typeof this.fetchData === "function") {
+      this.autoUpdateMethod = this.fetchData;
+      this.fetchData();
     }
   },
   beforeMount: function () {
@@ -52,7 +62,45 @@ export default {
     isValueShown(key) {
       return !(this.item.hide || []).includes(key);
     },
-    capCount,
+    reachabilityStatus() {
+      if (this.serverError === null || this.serverError === undefined) {
+        return null;
+      }
+      return this.serverError
+        ? { state: "offline", label: "offline" }
+        : { state: "online", label: "online" };
+    },
+    async load(...requests) {
+      let failed = false;
+      await Promise.all(
+        requests.map((request) =>
+          request.catch((e) => {
+            console.error(e);
+            failed = true;
+          }),
+        ),
+      );
+      this.serverError = failed;
+    },
+    requireConfig(...keys) {
+      const missing = keys.filter((key) => !this.item[key]);
+      if (!missing.length) {
+        return true;
+      }
+      console.error(
+        `Missing ${missing.join(", ")} in config.yml for the "${this.item.name || this.item.type}" entry.`,
+      );
+      this.serverError = true;
+      return false;
+    },
+    connectionBadge() {
+      return {
+        key: "serverError",
+        label: `Connection error to the ${this.item.type} API, check the url and credentials in config.yml`,
+        value: this.serverError ? "?" : null,
+        tone: "danger",
+      };
+    },
     fetch: function (path, init, json = true) {
       let options = {};
 
@@ -94,7 +142,7 @@ export default {
 
         if (!success) {
           throw new Error(
-            `Fail to fetch ressource: (${response.status} error)`,
+            `Failed to fetch resource: (${response.status} error)`,
             { cause: response },
           );
         }

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -1,5 +1,59 @@
-// TODO(cards-migrate-to-api): the follow-up moves the rest of the card
-// formatters here, off the cards and the service mixin.
+const RATE_UNITS = ["B", "KB", "MB", "GB", "TB"];
+const SIZE_UNITS = ["KiB", "MiB", "GiB", "TiB"];
+
 export function capCount(value, max = 99) {
   return typeof value === "number" && value > max ? `${max}+` : value;
+}
+
+export function displayRate(bytesPerSecond) {
+  let rate = bytesPerSecond || 0;
+  let unit = 0;
+
+  while (rate > 1000 && unit < RATE_UNITS.length - 1) {
+    rate /= 1000;
+    unit++;
+  }
+
+  return `${Intl.NumberFormat(undefined, { maximumFractionDigits: 2 }).format(
+    rate,
+  )} ${RATE_UNITS[unit]}/s`;
+}
+
+export function displaySize(bytes) {
+  if (Math.abs(bytes) < 1024) return `${bytes} B`;
+
+  let size = bytes;
+  let unit = -1;
+  do {
+    size /= 1024;
+    ++unit;
+  } while (
+    Math.round(Math.abs(size) * 100) / 100 >= 1024 &&
+    unit < SIZE_UNITS.length - 1
+  );
+
+  return `${size.toFixed(2)} ${SIZE_UNITS[unit]}`;
+}
+
+export function displayDuration(seconds) {
+  const days = Math.floor(seconds / 86400);
+  let remainingSeconds = seconds % 86400;
+  const hours = Math.floor(remainingSeconds / 3600);
+  remainingSeconds %= 3600;
+  const minutes = Math.floor(remainingSeconds / 60);
+  const secs = remainingSeconds % 60;
+
+  const formattedHrs = hours.toString().padStart(2, "0");
+  const formattedMins = minutes.toString().padStart(2, "0");
+  const formattedSecs = secs.toString().padStart(2, "0");
+
+  if (days > 0) {
+    return `${days}d ${formattedHrs}h ${formattedMins}m`;
+  } else if (hours > 0) {
+    return `${formattedHrs}h ${formattedMins}m ${formattedSecs}s`;
+  } else if (minutes > 0) {
+    return `${formattedMins}m ${formattedSecs}s`;
+  } else {
+    return `${secs} seconds`;
+  }
 }

--- a/src/utils/updateScheduler.js
+++ b/src/utils/updateScheduler.js
@@ -64,7 +64,7 @@ class UpdateScheduler {
 
   generateComponentId(component) {
     // Use component's unique identifier or Vue instance uid
-    return component._uid || component.$.uid
+    return component._uid || component.$.uid;
   }
 
   startGlobalTimer() {


### PR DESCRIPTION
Second of two stacked PRs. The first gave [`Generic.vue`](https://github.com/bastienwirtz/homer/blob/daa017d/src/components/services/Generic.vue) the card layout and kept the old slots open so nothing had to change at once. This one migrates every card onto the new props, moves the shared loading and error handling into the [`service` mixin](https://github.com/bastienwirtz/homer/blob/daa017d/src/mixins/service.js), and removes the compatibility the first PR held open.

It deletes about 2000 lines more than it adds.

## What changes

- **Cards feed props instead of positioning markup.** `<Generic :item="item" :subtitle="subtitle" :status="status" :badges="badges" />` replaces the `#content` and `#indicator` slots. Richer content still goes through the `icon` / `subtitle` / `aside` / `badges` slots.
- **One vocabulary for "is it up".** `status` is `{ state, label }` with `state` one of `online`, `offline`, `warning`, `busy` or `unknown`, replacing the six sets of words cards invented for themselves, and every colour now comes from a theme token.
- **Counters become badges.** `badges` is a list of `{ key, label, value, tone }` with `tone` one of `info`, `success`, `warning`, `danger`, `accent` or `neutral`. Empty values, zeros without `showZero` and any `key` listed in the item's `hide` are dropped centrally, and counts cap at `99+`.
- **The mixin owns fetching and failure.** It auto-wires `fetchData()` on create and on the `updateIntervalMs` schedule, and adds `load()`, `serverError`, `reachabilityStatus()`, `connectionBadge()`, `requireConfig()` and `versionSubtitle`. A card that cannot reach its API now says so once, the same way everywhere.
- **Formatting leaves the mixin and the cards.** `src/utils/format.js`, introduced in the first PR for `capCount`, gains `displayRate`, `displaySize` and `displayDuration`, the last two lifted out of `Immich` and `OctoPrint`. They are pure functions with no `this`, so the mixin keeps only what needs component state and `Generic` imports what it needs without the mixin. [`Gotify`](https://github.com/bastienwirtz/homer/blob/daa017d/src/components/services/Gotify.vue)'s message count caps at `99+` with everything else, rather than at its own `100`.
- **An ESLint rule enforces the contract**, so the next card starts on it rather than inventing a seventh vocabulary: a single `<Generic>` root, known slots, known `tone` and `state` values, no redeclared `item` prop, a declared `serverError`, and no card restyling the shared chrome.
- [`docs/development.md`](https://github.com/bastienwirtz/homer/blob/daa017d/docs/development.md), [`docs/customservices.md`](https://github.com/bastienwirtz/homer/blob/daa017d/docs/customservices.md) and `AGENTS.md` document the props, the slots and the rule.

Fixes #953.

## What it removes

Everything the first PR held open, all of it marked `TODO(cards-migrate-to-api)` there:

- the `#content` and `#indicator` slots
- the pre-migration status names `ready`, `error`, `pending` and `in-progress`, and `--status-color: transparent`
- the dot spacing as a `margin-inline-end`, back to a `gap` on `.status` now that no card ships a margin of its own
- `z-index` on `.card-aside`, so **the status chip is clickable again**. It was held above the card link so unmigrated indicators kept the `title` tooltips that were the only labels on their counts. Badges carry their own tooltips without blocking the click.
- the placeholder in `src/utils/format.js`, now that the remaining formatters have joined `capCount` there

Along with the per-card styling that duplicated the shared chrome: 21 scoped `.status` blocks, 25 scoped `.notifs` blocks, and all but two of the hardcoded hex colours. The two that stay are [`OpenWeather`](https://github.com/bastienwirtz/homer/blob/daa017d/src/components/services/OpenWeather.vue)'s icon backdrop, which is a backdrop rather than a theme colour.

## Unreachable APIs now report themselves

Running each card against a real instance rather than fixtures showed that a handful could look healthy, or say nothing at all, while their API was unreachable. That is what happens when every card decides for itself what a failed fetch means.

Routing them through `load()`, which records the failure, and `reachabilityStatus()` or `connectionBadge()`, which surface it, fixes those cases without patching any of them individually, and covers the next card by default.

## Compatibility

- **A configured [`subtitle`](https://github.com/bastienwirtz/homer/blob/daa017d/docs/customservices.md) is now honoured everywhere.** Six cards rendered their own subtitle without checking `item.subtitle` first, and [`Gatus`](https://github.com/bastienwirtz/homer/blob/daa017d/src/components/services/Gatus.vue) rendered both at once. On those seven a `subtitle:` that used to do nothing, or to appear alongside the card's own line, now replaces it, which is [the documented behaviour](https://github.com/bastienwirtz/homer/blob/daa017d/docs/customservices.md#L90).
- **Status and badge colours come from the theme.** A card that shipped its own green now uses `--status-online`, so a custom stylesheet targeting a card's scoped `.status` or `.notif` rules no longer matches. The tokens are listed in [theming](https://github.com/bastienwirtz/homer/blob/daa017d/docs/theming.md).
- **No card styles the shared chrome any more.** Anyone maintaining an out-of-tree card that copied a scoped `.status` or `.notifs` block loses their reference implementation; the props and the skeleton in `docs/development.md` replace it.

## Please merge both PRs in the same release

The first one alone looks half-migrated: the new chrome with cards still using their own status words, colours and pill placement. The split exists so the layout can be reviewed on its own, not so the two can ship separately.

## Testing

- `pnpm lint` and `pnpm build` clean, with the new rule active.
- Every card exercised against a real service in a container, with authentication configured wherever it could be, rather than against fixtures alone. That is what surfaced the unreachable-API cases above.
- Rendered against a config covering every card plus the chrome cases, side by side with `main` and with the first PR alone, in light and dark, in both layouts, across the classic, walkxcode and neon themes.
- Confirmed no card renders its own subtitle markup, none overrides `#content`, no scoped `.status` or `.notifs` block remains, and the status dot colours resolve to the same values `main` used, so no card's dot changes.

