### PR TITLE
fix(header): align the header and navbar with the content grid

### DIFF
--- a/src/assets/components/base.scss
+++ b/src/assets/components/base.scss
@@ -123,7 +123,7 @@
 
         .container {
           min-height: 80px;
-          padding: 10px 0;
+          padding: 10px 0.75rem;
         }
 
         .logo {
@@ -131,11 +131,13 @@
           i {
             vertical-align: top;
             padding: 8px 15px;
+            margin-inline-start: -15px;
             font-size: 50px;
           }
 
           img {
             padding: 10px;
+            margin-inline-start: -10px;
             max-height: 70px;
             max-width: 70px;
           }
@@ -146,15 +148,19 @@
 
         a {
           color: var(--text-header);
-          padding: 8px 12px;
+          padding: 0.5rem 0.75rem;
           &:hover,
           &:focus {
             color: var(--text-header);
             background-color: var(--highlight-hover);
           }
         }
+        .navbar-brand {
+          margin-inline-start: 0;
+        }
         .navbar-menu {
           background-color: inherit;
+          margin-inline-end: 0;
         }
       }
       .navbar-end {


### PR DESCRIPTION
## Description

The navbar and the header sit `0.75rem` to the left of everything below them, as reported in #886.

Bulma pulls the navbar out of its container by `0.75rem` on desktop, so that navbar links line up with content sitting flush against the container edge. Homer's content is not flush: the cards start a `0.75rem` gutter in and it misaligns the navbar. The header had the mirror problem, starting on the container edge rather than on the gutter.

## What changes

All of it is in `#bighead`, in `src/assets/components/base.scss`.

- The header container picks up the same `0.75rem` gutter the content grid already uses, so the title starts where the cards do.
- The logo and the icon get a negative inline-start margin cancelling their own padding, which had been acting as an indent while the container had no gutter. Without it they land 10px and 15px past the cards. Negative margins rather than removing the padding, because `max-width` bounds the border box and dropping the padding would resize non-square logos.
- The navbar zeroes Bulma's two negative margins, so the links line up with the cards and the search box's right edge lines up with theirs.
- Navbar link padding moves from `8px 12px` to the identical `0.5rem 0.75rem`, so it tracks the gutter when the browser font size is raised, and matches the search box, which was already in rem.


## Before / after

The red rule marks the left edge of the card column.

<details open>
<summary>title + subtitle</summary>

<img width="1020" height="779" alt="image" src="https://github.com/user-attachments/assets/0f58157f-2f2d-41b7-98d1-03efd9e7e9b9" />


<img width="1020" height="779" alt="image" src="https://github.com/user-attachments/assets/e275005b-04b5-43d2-884e-658f457a2c28" />


</details>

<details>
<summary><code>logo:</code> set</summary>

<img width="1020" height="779" alt="image" src="https://github.com/user-attachments/assets/fc5fbedf-3a41-4549-b77f-861ede3627f6" />


<img width="1020" height="779" alt="image" src="https://github.com/user-attachments/assets/85946fbf-33a8-440c-8702-5524771e86af" />


</details>

<details>
<summary><code>icon:</code> set</summary>

<img width="1020" height="779" alt="image" src="https://github.com/user-attachments/assets/635314b5-e846-4799-a206-f00a4e1a8604" />


<img width="1020" height="779" alt="image" src="https://github.com/user-attachments/assets/6fdf6303-7348-4f77-8cb8-d93cbca37a0e" />


</details>

## Compatibility

- Nothing changes on mobile for the navbar. Bulma applies no pull below 1024px, so the two zeroes are inert there. The header gutter does apply, and lines the header up with the cards on mobile too, which it did not do before.

## Note

Merges cleanly with #1080 and #1081 in any order. This touches only `#bighead`, those touch only `#main-section`, and neither moves the card edges this aligns to.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] I have made corresponding changes to the documentation (`README.md`) — not applicable, no documented behaviour changes
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file

Fixes #886
