### PR TITLE
Update index.html to include dark light color-scheme meta tag to prev…

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <link rel="apple-touch-icon" href="assets/icons/apple-touch-icon.png" sizes="180x180">
     <link rel="mask-icon" href="assets/icons/logo.svg">
     <meta name="viewport" content="width=device-width,initial-scale=1.0,viewport-fit=cover">
+    <meta name="color-scheme" content="dark light"/>
     <title>Homer</title>
   </head>
   <body>


### PR DESCRIPTION
…ent flash of white before javascript loads

This allows the browser to use its default stylesheets for either dark or light mode depending on how the user has configured their browser. This prevents flash of white for dark mode users as the browsers display a dark background before javascript has a chance to load in the actual homer configured color theme

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] I have made corresponding changes to the documentation (`README.md`).
- [ ] I've checked my modifications for any breaking changes, especially in the `config.yml` file
